### PR TITLE
Settle promises with timeout when getting requirements

### DIFF
--- a/packages/facilitator/src/promise.test.ts
+++ b/packages/facilitator/src/promise.test.ts
@@ -1,0 +1,120 @@
+#!/usr/bin/env pnpm tsx
+
+import t from "tap";
+import { sleep, allSettledWithTimeout } from "./promise";
+
+async function checkDuration<T>(min: number, max: number, f: () => Promise<T>) {
+  if (max <= min) {
+    throw new Error("max duration must be greater than min");
+  }
+
+  const start = Date.now();
+
+  const res = await f();
+
+  const delta = Date.now() - start;
+
+  t.ok(delta >= min, `duration took ${delta} ms, which isn't >= ${min} ms`);
+  t.ok(delta <= max, `duration took ${delta} ms, which isn't <= ${max} ms`);
+
+  return res;
+}
+
+await t.test("checkAllSettledNoTimeout", async (t) => {
+  const results = await checkDuration(25, 50, () =>
+    allSettledWithTimeout(
+      [sleep(10, "good"), sleep(30, "to"), sleep(1, "go")],
+      100,
+    ),
+  );
+
+  t.equal(results.length, 3);
+
+  results.forEach((x) => {
+    if (x === undefined) {
+      t.bailout();
+    }
+    t.matchOnly(x.status, "fulfilled");
+  });
+
+  t.matchOnly(
+    results.map((x) => (x as PromiseFulfilledResult<string>).value),
+    ["good", "to", "go"],
+  );
+
+  t.pass();
+  t.end();
+});
+
+await t.test("checkAllSettledWithTimeout", async (t) => {
+  const results = await checkDuration(20, 125, () =>
+    allSettledWithTimeout([sleep(10), sleep(500)], 100),
+  );
+
+  t.equal(results.length, 2);
+
+  const [result0, result1] = results;
+
+  if (result0 == undefined) {
+    return t.bailout();
+  }
+
+  if (result1 == undefined) {
+    return t.bailout();
+  }
+
+  t.matchOnly(result0.status, "fulfilled");
+  t.matchOnly(result1.status, "rejected");
+
+  t.pass();
+  t.end();
+});
+
+await t.test("checkAllSettleException", async (t) => {
+  const results = await checkDuration(10, 45, async () =>
+    allSettledWithTimeout(
+      [
+        sleep(10, 42),
+        (async () => {
+          throw new Error("an error happened");
+        })(),
+        sleep(15, 1337),
+      ],
+      50,
+    ),
+  );
+
+  t.equal(results.length, 3);
+
+  const [result0, result1, result2] = results;
+
+  if (result0 === undefined) {
+    return t.bailout();
+  }
+
+  if (result1 === undefined) {
+    return t.bailout();
+  }
+
+  if (result2 === undefined) {
+    return t.bailout();
+  }
+
+  if (result0.status !== "fulfilled") {
+    return t.fail();
+  }
+
+  t.matchOnly(result0.value, 42);
+
+  if (result1.status !== "rejected") {
+    return t.fail();
+  }
+
+  t.matchOnly(result1.reason, new Error("an error happened"));
+
+  if (result2.status !== "fulfilled") {
+    return t.fail();
+  }
+
+  t.matchOnly(result2.value, 1337);
+});

--- a/packages/facilitator/src/promise.ts
+++ b/packages/facilitator/src/promise.ts
@@ -1,0 +1,20 @@
+export function sleep<T>(sleepMs: number, value?: T): Promise<T | undefined> {
+  return new Promise((resolve) => setTimeout(() => resolve(value), sleepMs));
+}
+
+export function timeout<T>(timeoutMs: number, msg?: string) {
+  return new Promise<T>((_, reject) =>
+    setTimeout(() => reject(new Error(msg ?? "timed out")), timeoutMs),
+  );
+}
+
+export function allSettledWithTimeout<T>(
+  promises: readonly Promise<T>[],
+  timeoutMs: number,
+) {
+  const timedPromises = promises.map((p) =>
+    Promise.race([p, timeout<T>(timeoutMs, "request timed out")]),
+  );
+
+  return Promise.allSettled(timedPromises);
+}


### PR DESCRIPTION
This provides a better experience than just failing outright when we can't fetch requirements for one
specific handler (e.g. when an RPC call fails).

The duration tests are intentionally pretty loose on timing, to avoid erroring out too easily.
