### PR TITLE
Proof Of Concept: Add MPP protocol adapter for x402v2 primitives

### DIFF
--- a/packages/fetch/src/fetch.ts
+++ b/packages/fetch/src/fetch.ts
@@ -63,9 +63,13 @@ export function wrap(phase2Fetch: typeof fetch, options: WrapOpts) {
         await processPaymentRequiredResponse(ctx, response, options);
 
       const headers = new Headers(init.headers);
-      const headerName =
-        detectedVersion === 2 ? V2_PAYMENT_HEADER : X_PAYMENT_HEADER;
-      headers.set(headerName, paymentHeader);
+      if (detectedVersion === "mpp") {
+        headers.set("Authorization", paymentHeader);
+      } else {
+        const headerName =
+          detectedVersion === 2 ? V2_PAYMENT_HEADER : X_PAYMENT_HEADER;
+        headers.set(headerName, paymentHeader);
+      }
 
       const newInit: RequestInit = {
         ...init,

--- a/packages/fetch/src/internal.ts
+++ b/packages/fetch/src/internal.ts
@@ -23,10 +23,16 @@ import { isValidationError, throwValidationError } from "@faremeter/types";
 
 import { adaptRequirementsV1ToV2 } from "@faremeter/types/x402-adapters";
 import { normalizeNetworkId, translateNetworkToLegacy } from "@faremeter/info";
+import {
+  parseMPPChallenge,
+  mppChallengeToX402Requirements,
+  formatMPPCredential,
+} from "@faremeter/types/mpp-x402v2";
+import { mppCredential, type mppChallengeParams } from "@faremeter/types/mpp";
 
 export { X_PAYMENT_HEADER, V2_PAYMENT_HEADER, V2_PAYMENT_REQUIRED_HEADER };
 
-export type DetectedVersion = 1 | 2;
+export type DetectedVersion = 1 | 2 | "mpp";
 
 /**
  * Default payer chooser that selects the first available payment execer.
@@ -63,18 +69,31 @@ export type ProcessPaymentRequiredResponseOpts = {
 /**
  * Result of processing a 402 Payment Required response.
  */
-export type ProcessPaymentRequiredResponseResult = {
-  /** The selected payment execer. */
-  payer: PaymentExecer;
-  /** The result from executing the payment. */
-  payerResult: { payload: object };
-  /** The payment payload in the detected protocol version format. */
-  paymentPayload: x402PaymentPayload | x402PaymentPayloadV1;
-  /** Base64-encoded payment header ready to attach to the retry request. */
-  paymentHeader: string;
-  /** The detected protocol version (1 or 2). */
-  detectedVersion: DetectedVersion;
-};
+export type ProcessPaymentRequiredResponseResult =
+  | {
+      /** The selected payment execer. */
+      payer: PaymentExecer;
+      /** The result from executing the payment. */
+      payerResult: { payload: object };
+      /** Base64-encoded payment header ready to attach to the retry request. */
+      paymentHeader: string;
+      /** The detected protocol version. */
+      detectedVersion: 1 | 2;
+      /** The payment payload. */
+      paymentPayload: x402PaymentPayload | x402PaymentPayloadV1;
+    }
+  | {
+      /** The selected payment execer. */
+      payer: PaymentExecer;
+      /** The result from executing the payment. */
+      payerResult: { payload: object };
+      /** Base64-encoded payment header ready to attach to the retry request. */
+      paymentHeader: string;
+      /** The detected protocol version. */
+      detectedVersion: "mpp";
+      /** Original MPP challenge. */
+      mppChallenge: mppChallengeParams;
+    };
 
 /**
  * Process a 402 Payment Required response, auto-detecting v1 or v2 protocol.
@@ -91,12 +110,20 @@ export async function processPaymentRequiredResponse(
 ): Promise<ProcessPaymentRequiredResponseResult> {
   const payerChooser = options.payerChooser ?? chooseFirstAvailable;
 
+  // Check for MPP (402 + WWW-Authenticate: Payment)
+  if (response.status === 402) {
+    const wwwAuth = response.headers.get("WWW-Authenticate");
+    if (wwwAuth?.toLowerCase().startsWith("payment ")) {
+      return handleMPPChallenge(ctx, wwwAuth, payerChooser, options.handlers);
+    }
+  }
+
   // Detect version from response structure
   const paymentRequiredHeader = response.headers.get(
     V2_PAYMENT_REQUIRED_HEADER,
   );
 
-  let detectedVersion: DetectedVersion;
+  let detectedVersion: 1 | 2;
   let v2Accepts: x402PaymentRequirements[];
   let v2ResourceInfo: x402ResourceInfo | null = null;
 
@@ -181,5 +208,52 @@ export async function processPaymentRequiredResponse(
     paymentPayload,
     paymentHeader,
     detectedVersion,
+  };
+}
+
+async function handleMPPChallenge(
+  ctx: RequestContext,
+  wwwAuthHeader: string,
+  payerChooser: (
+    execers: PaymentExecer[],
+  ) => PaymentExecer | Promise<PaymentExecer>,
+  handlers: PaymentHandler[],
+): Promise<ProcessPaymentRequiredResponseResult> {
+  const mppChallenge = parseMPPChallenge(wwwAuthHeader);
+
+  // Converts to x402v2 and validates expiry via calculateTimeout,
+  // which throws if the challenge has already expired.
+  const x402Req = mppChallengeToX402Requirements(mppChallenge);
+
+  const possiblePayers: PaymentExecer[] = [];
+  for (const handler of handlers) {
+    const execers = await handler(ctx, [x402Req]);
+    possiblePayers.push(...execers);
+  }
+
+  if (possiblePayers.length === 0) {
+    throw new Error("No payment handler matched MPP challenge");
+  }
+
+  const payer = await payerChooser(possiblePayers);
+  const payerResult = await payer.exec();
+
+  const credential = mppCredential({
+    challenge: mppChallenge,
+    payload: payerResult.payload,
+  });
+
+  if (isValidationError(credential)) {
+    throw new Error(`Invalid MPP credential: ${credential.summary}`);
+  }
+
+  const paymentHeader = `Payment ${formatMPPCredential(credential)}`;
+
+  return {
+    payer,
+    payerResult,
+    paymentHeader,
+    detectedVersion: "mpp",
+    mppChallenge,
   };
 }

--- a/packages/middleware/src/common.ts
+++ b/packages/middleware/src/common.ts
@@ -1,4 +1,13 @@
-import { isValidationError } from "@faremeter/types";
+import { isValidationError, base64url } from "@faremeter/types";
+import {
+  mppCredentialToX402Payload,
+  x402SettleToMPPReceipt,
+} from "@faremeter/types/mpp-x402v2";
+import {
+  mppCredential,
+  MPP_PAYMENT_RECEIPT,
+  type mppCredential as mppCredentialType,
+} from "@faremeter/types/mpp";
 import {
   type x402PaymentRequirements as x402PaymentRequirementsV1,
   type x402PaymentPayload as x402PaymentPayloadV1,
@@ -39,6 +48,8 @@ import { normalizeNetworkId } from "@faremeter/info";
 import { type AgedLRUCacheOpts, AgedLRUCache } from "./cache";
 
 import { logger } from "./logger";
+
+const { decodeBase64url, encodeBase64url } = base64url;
 
 /**
  * Build the X-PAYMENT-RESPONSE header value from a settle response.
@@ -179,7 +190,8 @@ function relaxedRequirementsToV2(
  */
 type ParsedPaymentHeader =
   | { version: 1; payload: x402PaymentPayloadV1; rawHeader: string }
-  | { version: 2; payload: x402PaymentPayload; rawHeader: string };
+  | { version: 2; payload: x402PaymentPayload; rawHeader: string }
+  | { version: "mpp"; credential: mppCredentialType; rawHeader: string };
 
 /**
  * Parse a payment header from either v1 (X-PAYMENT) or v2 (PAYMENT-SIGNATURE).
@@ -188,6 +200,24 @@ type ParsedPaymentHeader =
 function parsePaymentHeader(
   getHeader: (key: string) => string | undefined,
 ): ParsedPaymentHeader | undefined {
+  // Check for MPP (Authorization: Payment)
+  const authHeader = getHeader("Authorization");
+  if (authHeader?.toLowerCase().startsWith("payment ")) {
+    const credentialB64 = authHeader.substring("payment ".length);
+    try {
+      const credentialJSON = decodeBase64url(credentialB64);
+      const credentialData = JSON.parse(credentialJSON) as unknown;
+      const credential = mppCredential(credentialData);
+
+      if (!isValidationError(credential)) {
+        return { version: "mpp", credential, rawHeader: authHeader };
+      }
+      logger.debug(`couldn't validate MPP credential: ${credential.summary}`);
+    } catch (error) {
+      logger.debug(`couldn't parse MPP credential: ${error}`);
+    }
+  }
+
   // Try v2 header first
   const v2Header = getHeader(V2_PAYMENT_HEADER);
   if (v2Header) {
@@ -314,6 +344,8 @@ export type SupportedVersionsConfig = {
   x402v1?: boolean;
   /** Support x402 v2 protocol (PAYMENT-REQUIRED header, PAYMENT-SIGNATURE header). Default: false */
   x402v2?: boolean;
+  /** Support MPP protocol (Authorization: Payment header). Default: false */
+  mpp?: boolean;
 };
 
 /**
@@ -327,12 +359,19 @@ export function resolveSupportedVersions(
   const resolved = {
     x402v1: config?.x402v1 ?? true,
     x402v2: config?.x402v2 ?? false,
+    mpp: config?.mpp ?? false,
   };
 
-  if (!resolved.x402v1 && !resolved.x402v2) {
+  if (!resolved.x402v1 && !resolved.x402v2 && !resolved.mpp) {
     throw new Error(
       "Invalid supportedVersions configuration: at least one protocol version must be enabled",
     );
+  }
+
+  // MPP converts credentials to x402v2 format for the facilitator,
+  // so it needs the v2 payment-required response to match against.
+  if (resolved.mpp) {
+    resolved.x402v2 = true;
   }
 
   return resolved;
@@ -401,12 +440,20 @@ export type MiddlewareBodyContextV2<MiddlewareResponse> = {
 };
 
 /**
- * Context provided to the middleware body handler.
- * Use protocolVersion to discriminate between v1 and v2 request types.
+ * Context provided to the middleware body handler for MPP protocol requests.
+ * The verify function is absent because MPP has no separate verify step.
  */
+export type MiddlewareBodyContextMPP<MiddlewareResponse> = {
+  protocolVersion: "mpp";
+  paymentRequirements: x402PaymentRequirements;
+  paymentPayload: x402PaymentPayload;
+  settle: () => Promise<SettleResultV2<MiddlewareResponse>>;
+};
+
 export type MiddlewareBodyContext<MiddlewareResponse> =
   | MiddlewareBodyContextV1<MiddlewareResponse>
-  | MiddlewareBodyContextV2<MiddlewareResponse>;
+  | MiddlewareBodyContextV2<MiddlewareResponse>
+  | MiddlewareBodyContextMPP<MiddlewareResponse>;
 
 /**
  * Arguments for the core middleware request handler.
@@ -525,6 +572,24 @@ export async function handleMiddlewareRequest<MiddlewareResponse>(
 
   if (!parsedHeader) {
     return sendPaymentRequired();
+  }
+
+  if (parsedHeader.version === "mpp") {
+    if (!supportedVersions.mpp) {
+      return args.sendJSONResponse(400, {
+        error: "This server does not support MPP protocol",
+      });
+    }
+    if (!v2Response) {
+      throw new Error("v2 response unavailable for MPP request");
+    }
+    return handleMPPRequest(
+      args,
+      parsedHeader.credential,
+      v2Response,
+      sendPaymentRequired,
+      fetchFn,
+    );
   }
 
   if (parsedHeader.version === 2 && !supportedVersions.x402v2) {
@@ -854,4 +919,126 @@ export function createPaymentRequiredResponseCache(
       return response;
     },
   };
+}
+
+/**
+ * Handle MPP payment request.
+ *
+ * Keeps the original MPP credential in scope throughout. Uses MPP fields
+ * directly for validation/logging. Converts to x402v2 only for calling
+ * the facilitator.
+ *
+ * Known limitation: when this function needs to re-challenge (expired
+ * credential, no matching requirements), it calls sendPaymentRequired()
+ * which returns x402 format headers, not an MPP WWW-Authenticate: Payment
+ * challenge. MPP clients will not recognize this as a re-challenge.
+ * Proper MPP challenge generation is deferred.
+ */
+async function handleMPPRequest<MiddlewareResponse>(
+  args: HandleMiddlewareRequestArgs<MiddlewareResponse>,
+  credential: mppCredentialType,
+  paymentRequiredResponse: x402PaymentRequiredResponse,
+  sendPaymentRequired: () => MiddlewareResponse,
+  fetchFn: typeof fetch,
+): Promise<MiddlewareResponse | undefined> {
+  // TODO (deferred): Verify request body digest if present
+  // Per MPP Spec Section 5.1.3: MUST verify digest matches request body
+  // Requires RFC 9530 digest computation implementation.
+
+  // TODO (deferred): Check challenge ID for replay protection
+  // Per MPP Spec Section 11.3: Payment proof MUST be single-use
+  // Requires persistent storage (Redis, database, etc.)
+
+  const challengeId = credential.challenge.id;
+  const method = credential.challenge.method;
+
+  // mppCredentialToX402Payload validates expiry via calculateTimeout,
+  // which throws if the challenge has expired (including sub-second remaining).
+  let x402Payload;
+  try {
+    x402Payload = mppCredentialToX402Payload(credential);
+  } catch (error) {
+    logger.warning("MPP credential conversion failed", {
+      id: challengeId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return sendPaymentRequired();
+  }
+
+  const paymentRequirements = findMatchingPaymentRequirementsV2(
+    paymentRequiredResponse.accepts,
+    x402Payload,
+  );
+
+  if (!paymentRequirements) {
+    logger.warning("couldn't find matching payment requirements for MPP", {
+      id: challengeId,
+      method,
+    });
+    return sendPaymentRequired();
+  }
+
+  const settle = async (): Promise<SettleResultV2<MiddlewareResponse>> => {
+    const settleRequest: x402SettleRequest = {
+      paymentPayload: x402Payload,
+      paymentRequirements,
+    };
+
+    const response = await fetchFn(`${args.facilitatorURL}/settle`, {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(settleRequest),
+    });
+
+    const settlementResponse = x402SettleResponse(await response.json());
+
+    if (isValidationError(settlementResponse)) {
+      const msg = `error from facilitator: ${settlementResponse.summary}`;
+      logger.error(msg);
+      throw new Error(msg);
+    }
+
+    if (settlementResponse.success) {
+      const receipt = x402SettleToMPPReceipt(settlementResponse, method);
+
+      if (args.setResponseHeader) {
+        args.setResponseHeader(
+          MPP_PAYMENT_RECEIPT,
+          encodeBase64url(JSON.stringify(receipt)),
+        );
+        args.setResponseHeader("Cache-Control", "private");
+      }
+
+      // TODO (deferred): Mark challenge as used (replay protection)
+
+      logger.info("MPP payment settled", {
+        challengeId,
+        source: credential.source,
+        method,
+        transaction: settlementResponse.transaction,
+        network: settlementResponse.network,
+        opaque: credential.challenge.opaque,
+      });
+    } else {
+      logger.warning("MPP payment failed", {
+        challengeId,
+        errorReason: settlementResponse.errorReason,
+      });
+      return { success: false, errorResponse: sendPaymentRequired() };
+    }
+
+    return { success: true, facilitatorResponse: settlementResponse };
+  };
+
+  const bodyContext: MiddlewareBodyContextMPP<MiddlewareResponse> = {
+    protocolVersion: "mpp",
+    paymentRequirements,
+    paymentPayload: x402Payload,
+    settle,
+  };
+
+  return args.body(bodyContext);
 }

--- a/packages/middleware/src/hono.ts
+++ b/packages/middleware/src/hono.ts
@@ -54,18 +54,17 @@ export async function createMiddleware(
         }
         return c.body(null);
       },
-      body: async ({ verify, settle }) => {
-        if (args.verifyBeforeSettle) {
-          // If configured, try to verify the transaction before running
-          // the next operation.
-          const verifyResult = await verify();
+      body: async (ctx) => {
+        if (
+          args.verifyBeforeSettle &&
+          ctx.protocolVersion !== "mpp" // MPP has no separate verify step
+        ) {
+          const verifyResult = await ctx.verify();
           if (!verifyResult.success) {
             return verifyResult.errorResponse;
           }
         } else {
-          // Otherwise just settle the payment beforehand, like we've
-          // done historically.
-          const settleResult = await settle();
+          const settleResult = await ctx.settle();
           if (!settleResult.success) {
             return settleResult.errorResponse;
           }
@@ -73,10 +72,8 @@ export async function createMiddleware(
 
         await next();
 
-        if (args.verifyBeforeSettle) {
-          // Close out the verification, by actually settling the
-          // payment.
-          const settleResult = await settle();
+        if (args.verifyBeforeSettle && ctx.protocolVersion !== "mpp") {
+          const settleResult = await ctx.settle();
           if (!settleResult.success) {
             // If the settlement fails, we need to explicitly
             // overwrite the downstream result.  See:

--- a/packages/test-harness/src/harness/harness.ts
+++ b/packages/test-harness/src/harness/harness.ts
@@ -324,7 +324,10 @@ export class TestHarness {
       };
     } else {
       let verifyResponse: ResourceContextV2["verifyResponse"];
-      if (this.settleMode === "verify-then-settle") {
+      if (
+        this.settleMode === "verify-then-settle" &&
+        context.protocolVersion !== "mpp"
+      ) {
         const verifyResult = await context.verify();
         if (!verifyResult.success) return verifyResult.errorResponse;
         verifyResponse = verifyResult.facilitatorResponse;

--- a/packages/test-harness/src/index.ts
+++ b/packages/test-harness/src/index.ts
@@ -82,6 +82,7 @@ export {
 } from "./interceptors/delay";
 
 export { createV2ResponseInterceptor } from "./interceptors/v2";
+export { createMPPResponseInterceptor } from "./interceptors/mpp";
 
 export {
   createRequestHook,

--- a/packages/test-harness/src/interceptors/mpp.ts
+++ b/packages/test-harness/src/interceptors/mpp.ts
@@ -1,0 +1,91 @@
+import type { Interceptor } from "./types";
+import { x402PaymentRequiredResponse } from "@faremeter/types/x402";
+import { isValidationError, base64url } from "@faremeter/types";
+import { adaptPaymentRequiredResponseV1ToV2 } from "@faremeter/types/x402-adapters";
+import { normalizeNetworkId } from "@faremeter/info";
+
+const { encodeBase64url } = base64url;
+
+/**
+ * Creates an interceptor that transforms v1 402 responses to MPP challenge
+ * format (WWW-Authenticate: Payment header).
+ *
+ * This allows testing the full MPP client flow by making the middleware
+ * appear to respond with an MPP challenge even though it generates x402
+ * payment-required responses internally.
+ *
+ * The transformation:
+ * - Parses the JSON body as v1 PaymentRequiredResponse
+ * - Converts to v2 PaymentRequiredResponse to get normalized fields
+ * - Builds an MPP challenge from the first accepted requirement
+ * - Returns 402 with WWW-Authenticate: Payment header
+ */
+export function createMPPResponseInterceptor(): Interceptor {
+  return (baseFetch) => async (input, init) => {
+    const response = await baseFetch(input, init);
+
+    if (response.status !== 402) {
+      return response;
+    }
+
+    const cloned = response.clone();
+    let body: unknown;
+    try {
+      body = await cloned.json();
+    } catch {
+      return response;
+    }
+
+    const v1Response = x402PaymentRequiredResponse(body);
+    if (isValidationError(v1Response)) {
+      return response;
+    }
+
+    const resourceURL = v1Response.accepts[0]?.resource ?? "";
+    const v2Response = adaptPaymentRequiredResponseV1ToV2(
+      v1Response,
+      resourceURL,
+      normalizeNetworkId,
+    );
+
+    const firstAccept = v2Response.accepts[0];
+    if (!firstAccept) {
+      return response;
+    }
+
+    const chargeRequest = {
+      amount: firstAccept.amount,
+      currency: firstAccept.asset,
+      recipient: firstAccept.payTo,
+      methodDetails: {
+        network: firstAccept.network,
+        ...(firstAccept.extra ?? {}),
+      },
+    };
+
+    const requestParam = encodeBase64url(JSON.stringify(chargeRequest));
+
+    const challengeId = `mpp-test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const expires = new Date(
+      Date.now() + (firstAccept.maxTimeoutSeconds ?? 300) * 1000,
+    ).toISOString();
+
+    const wwwAuth =
+      `Payment ` +
+      `id="${challengeId}", ` +
+      `realm="test-harness", ` +
+      `method="${firstAccept.scheme}", ` +
+      `intent="charge", ` +
+      `request="${requestParam}", ` +
+      `expires="${expires}"`;
+
+    const newHeaders = new Headers();
+    newHeaders.set("WWW-Authenticate", wwwAuth);
+
+    return new Response(null, {
+      status: 402,
+      statusText: "Payment Required",
+      headers: newHeaders,
+    });
+  };
+}

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -54,6 +54,16 @@
       "require": "./dist/src/evm.js",
       "import": "./dist/src/evm.js",
       "types": "./dist/src/evm.d.ts"
+    },
+    "./mpp": {
+      "require": "./dist/src/mpp.js",
+      "import": "./dist/src/mpp.js",
+      "types": "./dist/src/mpp.d.ts"
+    },
+    "./mpp-x402v2": {
+      "require": "./dist/src/mpp-x402v2.js",
+      "import": "./dist/src/mpp-x402v2.js",
+      "types": "./dist/src/mpp-x402v2.d.ts"
     }
   },
   "files": [

--- a/packages/types/src/base64url.ts
+++ b/packages/types/src/base64url.ts
@@ -1,0 +1,37 @@
+/**
+ * Base64url encoding/decoding per RFC 4648 Section 5.
+ *
+ * Base64url is URL-safe: uses '-' and '_' instead of '+' and '/',
+ * and omits padding '=' characters.
+ *
+ * Uses TextEncoder/TextDecoder for proper UTF-8 support. The naive
+ * btoa/atob approach only handles Latin1 (code points 0-255) and
+ * throws on any non-Latin1 character.
+ */
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+export function encodeBase64url(input: string): string {
+  const bytes = encoder.encode(input);
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  const base64 = btoa(binary);
+  return base64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
+}
+
+export function decodeBase64url(input: string): string {
+  let base64 = input.replace(/-/g, "+").replace(/_/g, "/");
+  const padding = base64.length % 4;
+  if (padding > 0) {
+    base64 += "=".repeat(4 - padding);
+  }
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return decoder.decode(bytes);
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -34,6 +34,24 @@ export * as client from "./client";
  * @description Type definitions for facilitator handlers and requirements
  */
 export * as facilitator from "./facilitator";
+/**
+ * @title MPP Protocol Types
+ * @sidebarTitle Types / MPP
+ * @description Type definitions for MPP (Machine Payments Protocol)
+ */
+export * as mpp from "./mpp";
+/**
+ * @title MPP Converters
+ * @sidebarTitle Types / MPP Converters
+ * @description Conversion utilities between MPP and x402v2 formats
+ */
+export * as mppX402v2 from "./mpp-x402v2";
+/**
+ * @title Base64url Utilities
+ * @sidebarTitle Types / Base64url
+ * @description RFC 4648 base64url encoding/decoding
+ */
+export * as base64url from "./base64url";
 export * from "./validation";
 export * from "./literal";
 /**

--- a/packages/types/src/mpp-x402v2.test.ts
+++ b/packages/types/src/mpp-x402v2.test.ts
@@ -1,0 +1,135 @@
+#!/usr/bin/env pnpm tsx
+
+import t from "tap";
+import {
+  parseMPPChallenge,
+  mppChallengeToX402Requirements,
+  formatMPPCredential,
+} from "./mpp-x402v2";
+import { encodeBase64url } from "./base64url";
+
+await t.test("parseMPPChallenge", async (t) => {
+  await t.test("parses valid challenge", (t) => {
+    const challenge = parseMPPChallenge(
+      'Payment id="abc", realm="api.example.com", method="exact", intent="charge", request="eyJhbW91bnQiOiIxMDAwIiwiY3VycmVuY3kiOiJ1c2QifQ"',
+    );
+
+    t.equal(challenge.id, "abc");
+    t.equal(challenge.realm, "api.example.com");
+    t.equal(challenge.method, "exact");
+    t.equal(challenge.intent, "charge");
+    t.end();
+  });
+
+  await t.test("throws on missing Payment prefix", (t) => {
+    t.throws(() => parseMPPChallenge('id="abc"'));
+    t.end();
+  });
+});
+
+await t.test("mppChallengeToX402Requirements", async (t) => {
+  await t.test("converts MPP to x402v2", (t) => {
+    const challenge = {
+      id: "abc",
+      realm: "api.example.com",
+      method: "exact",
+      intent: "charge",
+      request: encodeBase64url(
+        JSON.stringify({
+          amount: "1000",
+          currency: "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+          recipient: "0x1234567890123456789012345678901234567890",
+          methodDetails: { network: "eip155:84532" },
+        }),
+      ),
+    };
+
+    const req = mppChallengeToX402Requirements(challenge);
+
+    t.equal(req.scheme, "exact");
+    t.equal(req.network, "eip155:84532");
+    t.equal(req.amount, "1000");
+    t.equal(req.asset, "0x036CbD53842c5426634e7929541eC2318f3dCF7e");
+    t.end();
+  });
+
+  await t.test("throws on expired challenge", (t) => {
+    const challenge = {
+      id: "abc",
+      realm: "api.example.com",
+      method: "exact",
+      intent: "charge",
+      expires: new Date(Date.now() - 60000).toISOString(),
+      request: encodeBase64url(
+        JSON.stringify({
+          amount: "1000",
+          currency: "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+          methodDetails: { network: "eip155:84532" },
+        }),
+      ),
+    };
+
+    t.throws(() => mppChallengeToX402Requirements(challenge));
+    t.end();
+  });
+
+  await t.test("throws on missing network in methodDetails", (t) => {
+    const challenge = {
+      id: "abc",
+      realm: "api.example.com",
+      method: "exact",
+      intent: "charge",
+      request: encodeBase64url(
+        JSON.stringify({
+          amount: "1000",
+          currency: "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+          methodDetails: {},
+        }),
+      ),
+    };
+
+    t.throws(() => mppChallengeToX402Requirements(challenge));
+    t.end();
+  });
+
+  await t.test("throws on unsupported intent", (t) => {
+    const challenge = {
+      id: "abc",
+      realm: "api.example.com",
+      method: "exact",
+      intent: "subscription",
+      request: encodeBase64url(
+        JSON.stringify({
+          amount: "1000",
+          currency: "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+          methodDetails: { network: "eip155:84532" },
+        }),
+      ),
+    };
+
+    t.throws(() => mppChallengeToX402Requirements(challenge));
+    t.end();
+  });
+});
+
+await t.test("formatMPPCredential", async (t) => {
+  await t.test("produces base64url output without padding", (t) => {
+    const credential = {
+      challenge: {
+        id: "test",
+        realm: "example.com",
+        method: "exact",
+        intent: "charge",
+        request: "dGVzdA",
+      },
+      payload: { key: "value" },
+    };
+
+    const result = formatMPPCredential(credential);
+
+    t.ok(!result.includes("="), "should not contain padding");
+    t.ok(!result.includes("+"), "should not contain +");
+    t.ok(!result.includes("/"), "should not contain /");
+    t.end();
+  });
+});

--- a/packages/types/src/mpp-x402v2.ts
+++ b/packages/types/src/mpp-x402v2.ts
@@ -1,0 +1,251 @@
+import type { mppChallengeParams, mppCredential, mppReceipt } from "./mpp";
+import {
+  mppChargeRequest as mppChargeRequestValidator,
+  mppReceipt as mppReceiptValidator,
+  mppChallengeParams as mppChallengeParamsValidator,
+  isSupportedIntent,
+} from "./mpp";
+import type {
+  x402PaymentRequirements,
+  x402PaymentPayload,
+  x402SettleResponse,
+} from "./x402v2";
+import {
+  x402PaymentRequirements as x402PaymentRequirementsValidator,
+  x402PaymentPayload as x402PaymentPayloadValidator,
+} from "./x402v2";
+import { isValidationError } from "./validation";
+import { decodeBase64url, encodeBase64url } from "./base64url";
+
+/**
+ * Convert MPP challenge to x402v2 requirements (EPHEMERAL).
+ *
+ * This creates a temporary x402v2 object for calling payment handlers.
+ * The caller MUST keep the original mppChallengeParams in scope for:
+ * - Building the MPP credential (requires full challenge object)
+ * - Checking expiry (challenge.expires)
+ * - Other validation as needed
+ *
+ * Only payment-relevant fields are converted. MPP protocol metadata
+ * (id, realm, intent, opaque, digest, description) is NOT included
+ * in the x402v2 object - it stays in the original MPP challenge.
+ *
+ * @param challenge - Validated MPP challenge parameters
+ * @returns x402v2 payment requirements (ephemeral, for handler input only)
+ */
+export function mppChallengeToX402Requirements(
+  challenge: mppChallengeParams,
+): x402PaymentRequirements {
+  const requestJSON = decodeBase64url(challenge.request);
+  const requestData = JSON.parse(requestJSON) as unknown;
+  const request = mppChargeRequestValidator(requestData);
+
+  if (isValidationError(request)) {
+    throw new Error(`Invalid MPP charge request: ${request.summary}`);
+  }
+
+  if (!isSupportedIntent(challenge.intent)) {
+    throw new Error(`Unsupported MPP intent: ${challenge.intent}`);
+  }
+
+  if (!request.recipient) {
+    throw new Error("MPP challenge request missing required recipient");
+  }
+
+  const network = extractNetworkFromMethodDetails(
+    challenge.method,
+    request.methodDetails,
+  );
+
+  const result = x402PaymentRequirementsValidator({
+    scheme: challenge.method,
+    network,
+    amount: request.amount,
+    asset: request.currency,
+    payTo: request.recipient,
+    maxTimeoutSeconds: calculateTimeout(challenge.expires),
+    extra: request.methodDetails,
+  });
+
+  if (isValidationError(result)) {
+    throw new Error(`Invalid x402 requirements: ${result.summary}`);
+  }
+
+  return result;
+}
+
+/**
+ * Convert MPP credential to x402v2 payload (EPHEMERAL).
+ *
+ * This creates a temporary x402v2 object for calling the facilitator.
+ * The caller MUST keep the original mppCredential in scope for:
+ * - Validating challenge expiry (credential.challenge.expires)
+ * - Verifying request digest (credential.challenge.digest)
+ * - Replay protection (credential.challenge.id)
+ * - Correlation (credential.challenge.opaque)
+ * - Logging/audit (credential.source)
+ * - Building the MPP receipt (credential.challenge.method)
+ *
+ * MPP protocol metadata is NOT sent to the facilitator - middleware
+ * uses it directly from the original credential.
+ *
+ * @param credential - Validated MPP credential
+ * @returns x402v2 payment payload (ephemeral, for facilitator input only)
+ */
+export function mppCredentialToX402Payload(
+  credential: mppCredential,
+): x402PaymentPayload {
+  const requirements = mppChallengeToX402Requirements(credential.challenge);
+
+  const result = x402PaymentPayloadValidator({
+    x402Version: 2,
+    accepted: requirements,
+    payload: credential.payload,
+  });
+
+  if (isValidationError(result)) {
+    throw new Error(`Invalid x402 payload: ${result.summary}`);
+  }
+
+  return result;
+}
+
+/**
+ * Convert x402v2 settle response to MPP receipt.
+ *
+ * Used by middleware to build the Payment-Receipt header.
+ * The method parameter comes from the original MPP credential
+ * (not from the x402 settlement response).
+ *
+ * @param response - Validated x402v2 settle response
+ * @param method - Payment method (from original credential.challenge.method)
+ * @returns MPP receipt
+ */
+export function x402SettleToMPPReceipt(
+  response: x402SettleResponse,
+  method: string,
+): mppReceipt {
+  if (!response.success) {
+    throw new Error(
+      `Settlement failed: ${response.errorReason ?? "unknown error"}`,
+    );
+  }
+
+  const result = mppReceiptValidator({
+    status: "success",
+    method,
+    timestamp: new Date().toISOString(),
+    reference: response.transaction,
+  });
+
+  if (isValidationError(result)) {
+    throw new Error(`Invalid MPP receipt: ${result.summary}`);
+  }
+
+  return result;
+}
+
+/**
+ * Parse WWW-Authenticate: Payment header into MPP challenge params.
+ *
+ * Format: Payment realm="...", method="...", intent="...", request="..."
+ *
+ * @param headerValue - The full WWW-Authenticate header value
+ * @returns Validated MPP challenge parameters
+ */
+export function parseMPPChallenge(headerValue: string): mppChallengeParams {
+  if (!headerValue.toLowerCase().startsWith("payment ")) {
+    throw new Error("Invalid MPP challenge: must start with 'Payment '");
+  }
+
+  const paramsStr = headerValue.substring("payment ".length);
+
+  // Limitations:
+  // 1. Does not handle RFC 9110 quoted-string escaping (e.g., \" within
+  //    values). Acceptable because description/opaque are optional and
+  //    critical fields (id, realm, method, intent, request) are simple
+  //    tokens or base64url strings that never contain quotes.
+  // 2. Does not handle unquoted token values (e.g., key=value without
+  //    quotes). Per RFC 9110, auth-param values can be either tokens or
+  //    quoted-strings. A non-spec-compliant server sending unquoted
+  //    values would produce empty params and a validation error.
+  // If either becomes a problem, replace with a proper RFC 9110 parser.
+  const params: Record<string, string> = {};
+  const regex = /(\w+)="([^"]*)"/g;
+  let match;
+
+  while ((match = regex.exec(paramsStr)) !== null) {
+    const key = match[1];
+    const value = match[2];
+    if (key && value !== undefined) {
+      params[key] = value;
+    }
+  }
+
+  const result = mppChallengeParamsValidator(params);
+
+  if (isValidationError(result)) {
+    throw new Error(`Invalid MPP challenge params: ${result.summary}`);
+  }
+
+  return result;
+}
+
+/**
+ * Format MPP credential for Authorization header.
+ *
+ * Per MPP Spec Section 5.2: base64url-encoded JSON without padding.
+ *
+ * @param credential - Validated MPP credential
+ * @returns Base64url-encoded JSON for Authorization: Payment header value
+ */
+export function formatMPPCredential(credential: mppCredential): string {
+  return encodeBase64url(JSON.stringify(credential));
+}
+
+/**
+ * Calculate timeout in seconds from ISO 8601 expires timestamp.
+ *
+ * Throws if the challenge has already expired. Producing a zero or
+ * negative timeout would result in undefined behavior downstream.
+ *
+ * @param expires - Optional ISO 8601 timestamp
+ * @returns Timeout in seconds (default 300 if no expires)
+ */
+function calculateTimeout(expires?: string): number {
+  if (!expires) return 300;
+  const expiryTime = new Date(expires).getTime();
+  const now = Date.now();
+  const timeout = Math.floor((expiryTime - now) / 1000);
+  if (timeout <= 0) {
+    throw new Error("MPP challenge has expired");
+  }
+  return timeout;
+}
+
+/**
+ * Extract network from method-specific methodDetails.
+ *
+ * Per FAREMETER_MPP_METHOD_SPEC.md, the `network` field is required
+ * and must be in CAIP-2 format. No legacy fallbacks.
+ *
+ * @param method - Payment method identifier
+ * @param methodDetails - Method-specific details object
+ * @returns CAIP-2 network identifier
+ */
+function extractNetworkFromMethodDetails(
+  method: string,
+  methodDetails: unknown,
+): string {
+  if (!methodDetails || typeof methodDetails !== "object") {
+    throw new Error(`MPP method ${method} missing methodDetails`);
+  }
+
+  if ("network" in methodDetails && typeof methodDetails.network === "string") {
+    return methodDetails.network;
+  }
+
+  throw new Error(
+    `MPP method ${method} methodDetails missing required network field`,
+  );
+}

--- a/packages/types/src/mpp.ts
+++ b/packages/types/src/mpp.ts
@@ -1,0 +1,54 @@
+import { type } from "arktype";
+
+export const MPP_PAYMENT_RECEIPT = "Payment-Receipt";
+
+export const SUPPORTED_MPP_INTENTS = ["charge"] as const;
+export type SupportedMPPIntent = (typeof SUPPORTED_MPP_INTENTS)[number];
+
+export const mppChallengeParams = type({
+  id: "string",
+  realm: "string",
+  method: "string",
+  intent: "string",
+  request: "string",
+  "expires?": "string",
+  "digest?": "string",
+  "description?": "string",
+  "opaque?": "string",
+});
+
+export type mppChallengeParams = typeof mppChallengeParams.infer;
+
+export const mppChargeRequest = type({
+  amount: "string.numeric",
+  currency: "string",
+  "recipient?": "string",
+  "description?": "string",
+  "externalId?": "string",
+  "methodDetails?": "object",
+});
+
+export type mppChargeRequest = typeof mppChargeRequest.infer;
+
+export const mppCredential = type({
+  challenge: mppChallengeParams,
+  "source?": "string",
+  payload: "object",
+});
+
+export type mppCredential = typeof mppCredential.infer;
+
+export const mppReceipt = type({
+  status: '"success"',
+  method: "string",
+  timestamp: "string",
+  reference: "string",
+});
+
+export type mppReceipt = typeof mppReceipt.infer;
+
+export function isSupportedIntent(
+  intent: string,
+): intent is SupportedMPPIntent {
+  return SUPPORTED_MPP_INTENTS.includes(intent as SupportedMPPIntent);
+}

--- a/tests/mpp/failures.test.ts
+++ b/tests/mpp/failures.test.ts
@@ -1,0 +1,413 @@
+#!/usr/bin/env pnpm tsx
+
+import t from "tap";
+import {
+  TestHarness,
+  createTestFacilitatorHandler,
+  createTestPaymentHandler,
+  accepts,
+  createMPPResponseInterceptor,
+  createFailureInterceptor,
+  createNonMatchingHandler,
+  matchFacilitatorSettle,
+  matchFacilitatorAccepts,
+  settleFailedResponseV2,
+  networkError,
+  httpError,
+  suppressConsoleErrors,
+  TEST_NETWORK,
+} from "@faremeter/test-harness";
+import type { Interceptor } from "@faremeter/test-harness";
+
+await t.test("MPP failure paths", async (t) => {
+  t.teardown(suppressConsoleErrors());
+
+  await t.test("settlement rejected by facilitator", async (t) => {
+    const harness = new TestHarness({
+      supportedVersions: { mpp: true },
+      settleMode: "settle-only",
+      accepts: [accepts()],
+      facilitatorHandlers: [
+        createTestFacilitatorHandler({ payTo: "test-receiver" }),
+      ],
+      clientHandlers: [createTestPaymentHandler()],
+      clientInterceptors: [createMPPResponseInterceptor()],
+      middlewareInterceptors: [
+        createFailureInterceptor(matchFacilitatorSettle, () =>
+          settleFailedResponseV2("settlement_rejected", TEST_NETWORK),
+        ),
+      ],
+    });
+
+    const fetch = harness.createFetch();
+
+    try {
+      await fetch("/test-resource");
+      t.fail("should throw an error");
+    } catch (error) {
+      t.ok(error instanceof Error, "should throw an error");
+      if (error instanceof Error) {
+        t.match(
+          error.message,
+          /failed to complete payment after retries/,
+          "should exhaust retry loop on persistent settlement rejection",
+        );
+      }
+    }
+
+    t.end();
+  });
+
+  await t.test("settlement endpoint network error", async (t) => {
+    let interceptorCalled = false;
+
+    const harness = new TestHarness({
+      supportedVersions: { mpp: true },
+      settleMode: "settle-only",
+      accepts: [accepts()],
+      facilitatorHandlers: [
+        createTestFacilitatorHandler({ payTo: "test-receiver" }),
+      ],
+      clientHandlers: [createTestPaymentHandler()],
+      clientInterceptors: [createMPPResponseInterceptor()],
+      middlewareInterceptors: [
+        createFailureInterceptor(matchFacilitatorSettle, () => {
+          interceptorCalled = true;
+          return networkError();
+        }),
+      ],
+    });
+
+    const fetch = harness.createFetch();
+    const response = await fetch("/test-resource");
+
+    t.ok(interceptorCalled, "failure interceptor should have been called");
+    t.equal(
+      response.status,
+      500,
+      "should return 500 when settlement endpoint is unreachable",
+    );
+
+    t.end();
+  });
+
+  await t.test("settlement endpoint HTTP 500", async (t) => {
+    let interceptorCalled = false;
+
+    const harness = new TestHarness({
+      supportedVersions: { mpp: true },
+      settleMode: "settle-only",
+      accepts: [accepts()],
+      facilitatorHandlers: [
+        createTestFacilitatorHandler({ payTo: "test-receiver" }),
+      ],
+      clientHandlers: [createTestPaymentHandler()],
+      clientInterceptors: [createMPPResponseInterceptor()],
+      middlewareInterceptors: [
+        createFailureInterceptor(matchFacilitatorSettle, () => {
+          interceptorCalled = true;
+          return httpError(500, "Internal Server Error");
+        }),
+      ],
+    });
+
+    const fetch = harness.createFetch();
+    const response = await fetch("/test-resource");
+
+    t.ok(interceptorCalled, "failure interceptor should have been called");
+    t.equal(
+      response.status,
+      500,
+      "should return 500 when settlement returns HTTP 500",
+    );
+
+    t.end();
+  });
+
+  await t.test(
+    "handler returning success:false exhausts retries",
+    async (t) => {
+      const base = createTestFacilitatorHandler({ payTo: "test-receiver" });
+      const failingHandler = {
+        ...base,
+        handleSettle: async () => ({
+          success: false,
+          errorReason: "Insufficient funds for transfer",
+          transaction: "",
+          network: TEST_NETWORK,
+          payer: "",
+        }),
+      };
+
+      const harness = new TestHarness({
+        supportedVersions: { mpp: true },
+        settleMode: "settle-only",
+        accepts: [accepts()],
+        facilitatorHandlers: [failingHandler],
+        clientHandlers: [createTestPaymentHandler()],
+        clientInterceptors: [createMPPResponseInterceptor()],
+      });
+
+      const fetch = harness.createFetch();
+
+      try {
+        await fetch("/test-resource");
+        t.fail("should throw an error");
+      } catch (error) {
+        t.ok(error instanceof Error, "should throw an error");
+        if (error instanceof Error) {
+          t.match(
+            error.message,
+            /failed to complete payment after retries/,
+            "should exhaust retries when handler returns success:false",
+          );
+        }
+      }
+
+      t.end();
+    },
+  );
+
+  await t.test("handler throwing exception exhausts retries", async (t) => {
+    const harness = new TestHarness({
+      supportedVersions: { mpp: true },
+      settleMode: "settle-only",
+      accepts: [accepts()],
+      facilitatorHandlers: [
+        createTestFacilitatorHandler({
+          payTo: "test-receiver",
+          onSettle: () => {
+            throw new Error("Transaction simulation failed");
+          },
+        }),
+      ],
+      clientHandlers: [createTestPaymentHandler()],
+      clientInterceptors: [createMPPResponseInterceptor()],
+    });
+
+    const fetch = harness.createFetch();
+
+    try {
+      await fetch("/test-resource");
+      t.fail("should throw an error");
+    } catch (error) {
+      t.ok(error instanceof Error, "should throw an error");
+      if (error instanceof Error) {
+        t.match(
+          error.message,
+          /failed to complete payment after retries/,
+          "should exhaust retries when handler throws",
+        );
+      }
+    }
+
+    t.end();
+  });
+
+  await t.test("no matching client handler for MPP challenge", async (t) => {
+    const harness = new TestHarness({
+      supportedVersions: { mpp: true },
+      settleMode: "settle-only",
+      accepts: [accepts()],
+      facilitatorHandlers: [
+        createTestFacilitatorHandler({ payTo: "test-receiver" }),
+      ],
+      clientHandlers: [createNonMatchingHandler()],
+      clientInterceptors: [createMPPResponseInterceptor()],
+    });
+
+    const fetch = harness.createFetch();
+
+    try {
+      await fetch("/test-resource");
+      t.fail("should throw when no client handler matches");
+    } catch (error) {
+      t.ok(error instanceof Error, "should throw an error");
+      if (error instanceof Error) {
+        t.match(
+          error.message,
+          /No payment handler matched MPP challenge/,
+          "should indicate no handler matched the MPP challenge",
+        );
+      }
+    }
+
+    t.end();
+  });
+
+  await t.test(
+    "malformed MPP credential degrades to 402 re-challenge",
+    async (t) => {
+      let corruptedCount = 0;
+
+      const corruptAuthorization: Interceptor =
+        (fetch) => async (input, init) => {
+          const headers = new Headers(init?.headers);
+          if (headers.has("Authorization")) {
+            corruptedCount++;
+            headers.set("Authorization", "Payment not-valid-base64!!!");
+            return fetch(input, { ...init, headers });
+          }
+          return fetch(input, init);
+        };
+
+      const harness = new TestHarness({
+        supportedVersions: { mpp: true },
+        settleMode: "settle-only",
+        accepts: [accepts()],
+        facilitatorHandlers: [
+          createTestFacilitatorHandler({ payTo: "test-receiver" }),
+        ],
+        clientHandlers: [createTestPaymentHandler()],
+        clientInterceptors: [
+          createMPPResponseInterceptor(),
+          corruptAuthorization,
+        ],
+      });
+
+      const fetch = harness.createFetch();
+
+      try {
+        await fetch("/test-resource");
+        t.fail("should throw an error");
+      } catch (error) {
+        t.ok(error instanceof Error, "should throw an error");
+        if (error instanceof Error) {
+          t.match(
+            error.message,
+            /failed to complete payment after retries/,
+            "should exhaust retries when credential is malformed",
+          );
+        }
+      }
+
+      t.ok(corruptedCount > 0, "should have corrupted at least one credential");
+
+      t.end();
+    },
+  );
+
+  await t.test(
+    "MPP credential rejected when server does not support MPP",
+    async (t) => {
+      const harness = new TestHarness({
+        supportedVersions: { x402v2: true },
+        settleMode: "settle-only",
+        accepts: [accepts()],
+        facilitatorHandlers: [
+          createTestFacilitatorHandler({ payTo: "test-receiver" }),
+        ],
+        clientHandlers: [createTestPaymentHandler()],
+        clientInterceptors: [createMPPResponseInterceptor()],
+      });
+
+      const fetch = harness.createFetch();
+      const response = await fetch("/test-resource");
+
+      t.equal(
+        response.status,
+        400,
+        "should return 400 when server does not support MPP",
+      );
+
+      const body = (await response.json()) as { error: string };
+      t.match(
+        body.error,
+        /does not support MPP/,
+        "should indicate MPP is not supported",
+      );
+
+      t.end();
+    },
+  );
+
+  await t.test("expired MPP challenge triggers re-challenge", async (t) => {
+    const expiredChallengeInterceptor: Interceptor =
+      (baseFetch) => async (input, init) => {
+        const response = await baseFetch(input, init);
+
+        if (response.status !== 402) {
+          return response;
+        }
+
+        const wwwAuth = response.headers.get("WWW-Authenticate");
+        if (!wwwAuth) {
+          return response;
+        }
+
+        // Replace the expires value with an already-expired timestamp
+        const expired = new Date(Date.now() - 60_000).toISOString();
+        const modified = wwwAuth.replace(
+          /expires="[^"]*"/,
+          `expires="${expired}"`,
+        );
+
+        const newHeaders = new Headers();
+        newHeaders.set("WWW-Authenticate", modified);
+
+        return new Response(null, {
+          status: 402,
+          statusText: "Payment Required",
+          headers: newHeaders,
+        });
+      };
+
+    const harness = new TestHarness({
+      supportedVersions: { mpp: true },
+      settleMode: "settle-only",
+      accepts: [accepts()],
+      facilitatorHandlers: [
+        createTestFacilitatorHandler({ payTo: "test-receiver" }),
+      ],
+      clientHandlers: [createTestPaymentHandler()],
+      clientInterceptors: [
+        expiredChallengeInterceptor,
+        createMPPResponseInterceptor(),
+      ],
+    });
+
+    const fetch = harness.createFetch();
+
+    try {
+      await fetch("/test-resource");
+      t.fail("should throw an error");
+    } catch (error) {
+      t.ok(error instanceof Error, "should throw an error");
+    }
+
+    t.end();
+  });
+
+  await t.test("accepts endpoint network error", async (t) => {
+    let interceptorCalled = false;
+
+    const harness = new TestHarness({
+      supportedVersions: { mpp: true },
+      settleMode: "settle-only",
+      accepts: [accepts()],
+      facilitatorHandlers: [
+        createTestFacilitatorHandler({ payTo: "test-receiver" }),
+      ],
+      clientHandlers: [createTestPaymentHandler()],
+      clientInterceptors: [createMPPResponseInterceptor()],
+      middlewareInterceptors: [
+        createFailureInterceptor(matchFacilitatorAccepts, () => {
+          interceptorCalled = true;
+          return networkError("connection refused");
+        }),
+      ],
+    });
+
+    const fetch = harness.createFetch();
+    const response = await fetch("/test-resource");
+
+    t.ok(interceptorCalled, "failure interceptor should have been called");
+    t.equal(
+      response.status,
+      500,
+      "should return 500 when accepts endpoint is unreachable",
+    );
+
+    t.end();
+  });
+});

--- a/tests/mpp/success.test.ts
+++ b/tests/mpp/success.test.ts
@@ -1,0 +1,263 @@
+#!/usr/bin/env pnpm tsx
+
+import t from "tap";
+import {
+  TestHarness,
+  createTestFacilitatorHandler,
+  createTestPaymentHandler,
+  accepts,
+  createMPPResponseInterceptor,
+  isResourceContextV2,
+  createCaptureInterceptor,
+  matchResource,
+} from "@faremeter/test-harness";
+import { base64url } from "@faremeter/types";
+
+await t.test("MPP protocol flow", async (t) => {
+  await t.test("end-to-end MPP successful flow (settle-only)", async (t) => {
+    let facilitatorSettleCalled = false;
+
+    const harness = new TestHarness({
+      supportedVersions: { mpp: true },
+      settleMode: "settle-only",
+      accepts: [accepts()],
+      facilitatorHandlers: [
+        createTestFacilitatorHandler({
+          payTo: "test-receiver",
+          onSettle: () => {
+            facilitatorSettleCalled = true;
+          },
+        }),
+      ],
+      clientHandlers: [createTestPaymentHandler()],
+      clientInterceptors: [createMPPResponseInterceptor()],
+    });
+
+    let resourceHandlerCalled = false;
+    harness.setResourceHandler(() => {
+      resourceHandlerCalled = true;
+      return { status: 200, body: { success: true } };
+    });
+
+    const fetch = harness.createFetch();
+    const response = await fetch("/test-resource");
+
+    t.equal(response.status, 200, "should complete successfully");
+    t.ok(resourceHandlerCalled, "resource handler should have been called");
+    t.ok(facilitatorSettleCalled, "facilitator settle should have been called");
+    const body = await response.json();
+    t.same(
+      body,
+      { success: true },
+      "response body should match resource handler output",
+    );
+
+    t.end();
+  });
+
+  await t.test("MPP settle-only skips verify step", async (t) => {
+    let verifyAttempted = false;
+
+    const harness = new TestHarness({
+      supportedVersions: { mpp: true },
+      settleMode: "verify-then-settle",
+      accepts: [accepts()],
+      facilitatorHandlers: [
+        createTestFacilitatorHandler({
+          payTo: "test-receiver",
+          onVerify: () => {
+            verifyAttempted = true;
+          },
+        }),
+      ],
+      clientHandlers: [createTestPaymentHandler()],
+      clientInterceptors: [createMPPResponseInterceptor()],
+    });
+
+    harness.setResourceHandler(() => {
+      return { status: 200, body: { success: true } };
+    });
+
+    const fetch = harness.createFetch();
+    const response = await fetch("/test-resource");
+
+    t.equal(response.status, 200, "should complete successfully");
+    t.notOk(
+      verifyAttempted,
+      "verify should not be called for MPP even in verify-then-settle mode",
+    );
+
+    t.end();
+  });
+
+  await t.test("MPP response includes Payment-Receipt header", async (t) => {
+    const { interceptor: captureInterceptor, captured } =
+      createCaptureInterceptor(matchResource);
+
+    const harness = new TestHarness({
+      supportedVersions: { mpp: true },
+      settleMode: "settle-only",
+      accepts: [accepts()],
+      facilitatorHandlers: [
+        createTestFacilitatorHandler({ payTo: "test-receiver" }),
+      ],
+      clientHandlers: [createTestPaymentHandler()],
+      clientInterceptors: [captureInterceptor, createMPPResponseInterceptor()],
+    });
+
+    harness.setResourceHandler(() => {
+      return { status: 200, body: { success: true } };
+    });
+
+    const fetch = harness.createFetch();
+    await fetch("/test-resource");
+
+    // The second captured request is the paid retry (first is the initial 402)
+    const paidRequest = captured[1];
+    t.ok(paidRequest, "should have a paid request");
+
+    const paidResponse = paidRequest?.response;
+    t.ok(paidResponse, "should have a paid response");
+
+    const receiptHeader = paidResponse?.headers.get("Payment-Receipt");
+    t.ok(receiptHeader, "response should include Payment-Receipt header");
+
+    if (receiptHeader) {
+      const receiptJSON = base64url.decodeBase64url(receiptHeader);
+      const receipt = JSON.parse(receiptJSON) as {
+        status: string;
+        method: string;
+        timestamp: string;
+        reference: string;
+      };
+
+      t.equal(receipt.status, "success", "receipt status should be success");
+      t.ok(receipt.method, "receipt should include method");
+      t.ok(receipt.timestamp, "receipt should include timestamp");
+      t.ok(receipt.reference, "receipt should include reference");
+    }
+
+    t.end();
+  });
+
+  await t.test("MPP client sends Authorization: Payment header", async (t) => {
+    const { interceptor: captureInterceptor, captured } =
+      createCaptureInterceptor(matchResource);
+
+    const harness = new TestHarness({
+      supportedVersions: { mpp: true },
+      settleMode: "settle-only",
+      accepts: [accepts()],
+      facilitatorHandlers: [
+        createTestFacilitatorHandler({ payTo: "test-receiver" }),
+      ],
+      clientHandlers: [createTestPaymentHandler()],
+      clientInterceptors: [captureInterceptor, createMPPResponseInterceptor()],
+    });
+
+    harness.setResourceHandler(() => {
+      return { status: 200, body: { success: true } };
+    });
+
+    const fetch = harness.createFetch();
+    await fetch("/test-resource");
+
+    // First capture is the initial request (gets 402)
+    // Second capture is the retry with payment
+    const paidCapture = captured[1];
+    t.ok(paidCapture, "should have a paid request capture");
+
+    const authHeader = paidCapture?.init?.headers;
+    t.ok(authHeader, "paid request should have headers");
+
+    // The headers are set by the wrap function as a Headers object
+    if (authHeader instanceof Headers) {
+      const authValue = authHeader.get("Authorization");
+      t.ok(authValue, "should have Authorization header");
+      t.ok(
+        authValue?.startsWith("Payment "),
+        "Authorization header should start with 'Payment '",
+      );
+    }
+
+    t.end();
+  });
+
+  await t.test("MPP resource handler receives v2 context", async (t) => {
+    const harness = new TestHarness({
+      supportedVersions: { mpp: true },
+      settleMode: "settle-only",
+      accepts: [accepts()],
+      facilitatorHandlers: [
+        createTestFacilitatorHandler({ payTo: "test-receiver" }),
+      ],
+      clientHandlers: [createTestPaymentHandler()],
+      clientInterceptors: [createMPPResponseInterceptor()],
+    });
+
+    let wasV2Context = false;
+
+    harness.setResourceHandler((ctx) => {
+      // MPP uses v2 context types since it converts to x402v2 internally
+      wasV2Context = isResourceContextV2(ctx);
+
+      if (isResourceContextV2(ctx)) {
+        t.ok(ctx.paymentRequirements, "should have payment requirements");
+        t.ok(ctx.paymentPayload, "should have payment payload");
+        t.ok(ctx.settleResponse, "should have settle response");
+        t.ok(ctx.settleResponse?.transaction, "should have transaction field");
+      }
+
+      return { status: 200, body: { success: true } };
+    });
+
+    const fetch = harness.createFetch();
+    const response = await fetch("/test-resource");
+
+    t.equal(response.status, 200, "should return 200");
+    t.ok(wasV2Context, "context should be v2 (MPP uses v2 internally)");
+
+    t.end();
+  });
+
+  await t.test(
+    "MPP response includes Cache-Control: private header",
+    async (t) => {
+      const { interceptor: captureInterceptor, captured } =
+        createCaptureInterceptor(matchResource);
+
+      const harness = new TestHarness({
+        supportedVersions: { mpp: true },
+        settleMode: "settle-only",
+        accepts: [accepts()],
+        facilitatorHandlers: [
+          createTestFacilitatorHandler({ payTo: "test-receiver" }),
+        ],
+        clientHandlers: [createTestPaymentHandler()],
+        clientInterceptors: [
+          captureInterceptor,
+          createMPPResponseInterceptor(),
+        ],
+      });
+
+      harness.setResourceHandler(() => {
+        return { status: 200, body: { success: true } };
+      });
+
+      const fetch = harness.createFetch();
+      await fetch("/test-resource");
+
+      const paidResponse = captured[1]?.response;
+      t.ok(paidResponse, "should have a paid response");
+
+      const cacheControl = paidResponse?.headers.get("Cache-Control");
+      t.equal(
+        cacheControl,
+        "private",
+        "should set Cache-Control: private per MPP spec",
+      );
+
+      t.end();
+    },
+  );
+});

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -3,5 +3,11 @@
   "compilerOptions": {
     "noEmit": true
   },
-  "include": ["x402v1/*.ts", "x402v2/*.ts", "x402-interop/*.ts", "rides/*.ts"]
+  "include": [
+    "x402v1/*.ts",
+    "x402v2/*.ts",
+    "x402-interop/*.ts",
+    "rides/*.ts",
+    "mpp/*.ts"
+  ]
 }


### PR DESCRIPTION
## Summary

Implements MPP (Machine Payments Protocol) support as an adapter layer on top of the existing x402v2 infrastructure. Rather than building a separate facilitator path, MPP challenges and credentials are translated to x402v2 format, allowing full reuse of existing payment handlers and settlement logic.

### What was implemented

**Types (`packages/types`)**

- `mpp.ts` -- Pure MPP protocol types: challenge parameters, charge request, credential, and receipt (all arktype-validated)
- `mpp-x402v2.ts` -- Conversion layer between MPP and x402v2 formats: challenge-to-requirements, credential-to-payload, settle-response-to-receipt, plus challenge parsing and credential formatting
- `base64url.ts` -- RFC 4648 Section 5 base64url encoding/decoding with proper UTF-8 support
- New package exports: `@faremeter/types/mpp`, `@faremeter/types/mpp-x402v2`

**Client (`packages/fetch`)**

- Detects MPP challenges via `WWW-Authenticate: Payment` header on 402 responses
- Converts MPP challenge to x402v2 requirements for payment handler selection
- Formats credential as `Authorization: Payment <base64url>` on retry request
- `DetectedVersion` type extended with `"mpp"` variant

**Middleware (`packages/middleware`)**

- Parses `Authorization: Payment` credential from incoming requests
- Converts to x402v2 payload for facilitator settlement
- Returns `Payment-Receipt` header (base64url-encoded) and `Cache-Control: private` on success
- New `MiddlewareBodyContextMPP` type (no verify step -- MPP is settle-only)
- `supportedVersions` config extended with `mpp` flag (auto-enables x402v2)

**Test harness (`packages/test-harness`)**

- `createMPPResponseInterceptor` -- Transforms x402 402 responses to MPP challenge format for end-to-end testing

**Integration tests (`tests/mpp`)**

- Success paths: end-to-end flow, verify-skip behavior, Payment-Receipt header, Authorization header format, Cache-Control header, resource handler context
- Failure paths: settlement rejection, network errors, HTTP 500, handler exceptions, no matching handler, malformed credentials, unsupported server, expired challenges, accepts endpoint failures

### Known limitations (deferred)

- Re-challenge on credential failure sends x402 format headers, not MPP `WWW-Authenticate: Payment`
- Request body digest verification (MPP Spec Section 5.1.3) not implemented
- Challenge replay protection (MPP Spec Section 11.3) not implemented -- requires persistent storage