### PR TITLE
CL-484 Migrate exact payment client to v2 and fix bn.js vulnerability

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -176,6 +176,26 @@ NOTE: To pay using Crossmint, you must have your `CROSSMINT_WALLET` address and 
 
 NOTE: Your payer keypair must be funded with SPL Token-based `USDC` for this demo to work.
 
+#### Exact SPL Token Payment (USDC)
+
+```
+(cd scripts && pnpm tsx solana-example/solana-exact-payment.ts)
+```
+
+#### Exact Token-2022 Payment (PYUSD)
+
+```
+(cd scripts && pnpm tsx solana-example/token2022-exact-payment.ts)
+```
+
+NOTE: Your payer keypair must be funded with PYUSD on devnet.
+
+#### Exact Payment via Open Wallet Standard
+
+```
+(cd scripts && pnpm tsx solana-example/ows-exact-payment.ts)
+```
+
 ### EVM Payments
 
 #### USDC Payment on Base Sepolia

--- a/package.json
+++ b/package.json
@@ -23,5 +23,10 @@
       "!@tapjs/typescript",
       "@tapjs/tsx"
     ]
+  },
+  "pnpm": {
+    "overrides": {
+      "bn.js": "^5.2.3"
+    }
   }
 }

--- a/packages/payment-solana/src/exact/client.test.ts
+++ b/packages/payment-solana/src/exact/client.test.ts
@@ -1,0 +1,184 @@
+#!/usr/bin/env pnpm tsx
+
+import t from "tap";
+import { AccountRole, address } from "@solana/kit";
+import { Keypair, VersionedTransaction } from "@solana/web3.js";
+import { toTransactionInstruction, createPaymentHandler } from "./client";
+import type { x402PaymentRequirements } from "@faremeter/types/x402v2";
+
+await t.test("toTransactionInstruction", async (t) => {
+  const programAddr = address("11111111111111111111111111111111");
+  const accountAddr = address("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
+
+  await t.test("maps all AccountRole values correctly", async (t) => {
+    const roles = [
+      {
+        role: AccountRole.READONLY,
+        expectedSigner: false,
+        expectedWritable: false,
+      },
+      {
+        role: AccountRole.WRITABLE,
+        expectedSigner: false,
+        expectedWritable: true,
+      },
+      {
+        role: AccountRole.READONLY_SIGNER,
+        expectedSigner: true,
+        expectedWritable: false,
+      },
+      {
+        role: AccountRole.WRITABLE_SIGNER,
+        expectedSigner: true,
+        expectedWritable: true,
+      },
+    ] as const;
+
+    for (const { role, expectedSigner, expectedWritable } of roles) {
+      const result = toTransactionInstruction({
+        programAddress: programAddr,
+        accounts: [{ address: accountAddr, role }],
+        data: new Uint8Array([1, 2, 3]),
+      });
+
+      t.equal(result.programId.toBase58(), programAddr);
+      t.equal(result.keys.length, 1);
+      t.equal(
+        result.keys[0]?.isSigner,
+        expectedSigner,
+        `role ${role}: isSigner should be ${expectedSigner}`,
+      );
+      t.equal(
+        result.keys[0]?.isWritable,
+        expectedWritable,
+        `role ${role}: isWritable should be ${expectedWritable}`,
+      );
+    }
+
+    t.pass();
+    t.end();
+  });
+
+  await t.test("handles instruction with data", async (t) => {
+    const result = toTransactionInstruction({
+      programAddress: programAddr,
+      accounts: [],
+      data: new Uint8Array([0xde, 0xad, 0xbe, 0xef]),
+    });
+
+    t.equal(result.data.length, 4);
+    t.same([...result.data], [0xde, 0xad, 0xbe, 0xef]);
+
+    t.pass();
+    t.end();
+  });
+
+  await t.test("handles instruction without data", async (t) => {
+    const result = toTransactionInstruction({
+      programAddress: programAddr,
+      accounts: [],
+    });
+
+    t.equal(result.data.length, 0);
+
+    t.pass();
+    t.end();
+  });
+
+  await t.test("handles instruction without accounts", async (t) => {
+    const result = toTransactionInstruction({
+      programAddress: programAddr,
+      data: new Uint8Array([1]),
+    });
+
+    t.equal(result.keys.length, 0);
+
+    t.pass();
+    t.end();
+  });
+});
+
+await t.test("createPaymentHandler", async (t) => {
+  const keypair = Keypair.generate();
+  const mint = Keypair.generate().publicKey;
+  const receiver = Keypair.generate().publicKey;
+  const feePayer = Keypair.generate().publicKey;
+
+  const wallet = {
+    network: "devnet",
+    publicKey: keypair.publicKey,
+    partiallySignTransaction: async (tx: VersionedTransaction) => tx,
+  };
+
+  const requirements: x402PaymentRequirements = {
+    scheme: "exact",
+    network: "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1",
+    amount: "1000000",
+    asset: mint.toBase58(),
+    payTo: receiver.toBase58(),
+    maxTimeoutSeconds: 30,
+    extra: {
+      feePayer: feePayer.toBase58(),
+      decimals: 6,
+      recentBlockhash: "EETubP46DHLkT9hAFKy4x2BoFUqUFvKjiiNVY3CaYRi3",
+    },
+  };
+
+  await t.test("returns a function", async (t) => {
+    const handler = createPaymentHandler(wallet, mint);
+    t.equal(typeof handler, "function");
+    t.end();
+  });
+
+  await t.test("returns PaymentExecer for matching requirements", async (t) => {
+    const handler = createPaymentHandler(wallet, mint);
+    const context = { request: new Request("https://example.com") };
+    const execers = await handler(context, [requirements]);
+
+    t.equal(execers.length, 1);
+    t.ok(execers[0]?.exec);
+    t.equal(typeof execers[0]?.exec, "function");
+    t.same(execers[0]?.requirements, requirements);
+    t.end();
+  });
+
+  await t.test("exec produces a payload with a transaction", async (t) => {
+    const handler = createPaymentHandler(wallet, mint);
+    const context = { request: new Request("https://example.com") };
+    const execers = await handler(context, [requirements]);
+    const execer = execers[0];
+    if (!execer) throw new Error("expected an execer");
+    const result = await execer.exec();
+
+    t.ok(result.payload);
+    t.ok(
+      "transaction" in result.payload,
+      "payload should contain a transaction",
+    );
+    t.equal(
+      typeof (result.payload as { transaction: string }).transaction,
+      "string",
+    );
+    t.end();
+  });
+
+  await t.test("skips non-matching requirements", async (t) => {
+    const handler = createPaymentHandler(wallet, mint);
+    const context = { request: new Request("https://example.com") };
+    const wrongNetwork = {
+      ...requirements,
+      network: "solana:SomeOtherNetwork",
+    };
+    const execers = await handler(context, [wrongNetwork]);
+
+    t.equal(execers.length, 0);
+    t.end();
+  });
+
+  await t.test("deprecated Connection overload works", async (t) => {
+    const fakeConnection = { rpcEndpoint: "https://api.devnet.solana.com" };
+    const handler = createPaymentHandler(wallet, mint, fakeConnection);
+    t.equal(typeof handler, "function");
+    t.end();
+  });
+});

--- a/packages/payment-solana/src/exact/client.ts
+++ b/packages/payment-solana/src/exact/client.ts
@@ -7,20 +7,33 @@ import type {
 } from "@faremeter/types/client";
 import type { SolanaCAIP2Network } from "@faremeter/info/solana";
 import {
-  createAssociatedTokenAccountIdempotentInstruction,
-  createTransferCheckedInstruction,
-  getAssociatedTokenAddressSync,
-  getMint,
-  TOKEN_PROGRAM_ID,
-} from "@solana/spl-token";
+  fetchMint,
+  findAssociatedTokenPda,
+  getCreateAssociatedTokenIdempotentInstruction,
+  getTransferCheckedInstruction,
+  TOKEN_PROGRAM_ADDRESS,
+} from "@solana-program/token";
+import {
+  getSetComputeUnitLimitInstruction,
+  getSetComputeUnitPriceInstruction,
+} from "@solana-program/compute-budget";
+import {
+  address,
+  AccountRole,
+  createNoopSigner,
+  createSolanaRpc,
+  type Address,
+  type Instruction,
+  type AccountMeta,
+  type Rpc,
+  type SolanaRpcApi,
+} from "@solana/kit";
 import {
   getBase64EncodedWireTransaction,
   type SignaturesMap,
   type TransactionMessageBytes,
 } from "@solana/transactions";
 import {
-  ComputeBudgetProgram,
-  Connection,
   PublicKey,
   TransactionInstruction,
   TransactionMessage,
@@ -48,24 +61,22 @@ export type Wallet = {
   sendTransaction?: (tx: VersionedTransaction) => Promise<string>;
 };
 
-interface GetAssociatedTokenAddressSyncOptions {
-  allowOwnerOffCurve?: boolean;
-  programId?: PublicKey;
-  associatedTokenProgramId?: PublicKey;
-}
-
-function generateGetAssociatedTokenAddressSyncRest(
-  tokenConfig: GetAssociatedTokenAddressSyncOptions,
+export function toTransactionInstruction(
+  ix: Instruction & { accounts?: readonly AccountMeta[] },
 ) {
-  const { allowOwnerOffCurve, programId, associatedTokenProgramId } =
-    tokenConfig;
-
-  // NOTE: These map to the trailing default args of
-  // getAssociatedTokenAddressSync, so order matters. If things are
-  // refactored, they should be updated to match the reality of the
-  // implementation.
-
-  return [allowOwnerOffCurve, programId, associatedTokenProgramId] as const;
+  return new TransactionInstruction({
+    programId: new PublicKey(ix.programAddress),
+    keys: (ix.accounts ?? []).map((a) => ({
+      pubkey: new PublicKey(a.address),
+      isSigner:
+        a.role === AccountRole.READONLY_SIGNER ||
+        a.role === AccountRole.WRITABLE_SIGNER,
+      isWritable:
+        a.role === AccountRole.WRITABLE ||
+        a.role === AccountRole.WRITABLE_SIGNER,
+    })),
+    data: ix.data ? Buffer.from(ix.data) : Buffer.alloc(0),
+  });
 }
 
 const PaymentMode = {
@@ -76,13 +87,13 @@ const PaymentMode = {
 type PaymentMode = (typeof PaymentMode)[keyof typeof PaymentMode];
 
 async function extractMetadata(args: {
-  connection: Connection | undefined;
-  mint: PublicKey;
+  rpc: Rpc<SolanaRpcApi> | undefined;
+  mintAddress: Address;
   requirements: x402PaymentRequirements;
   options: CreatePaymentHandlerOptions | undefined;
   wallet: Wallet;
 }) {
-  const { connection, mint, requirements, wallet, options } = args;
+  const { rpc, mintAddress, requirements, wallet, options } = args;
 
   const extra = PaymentRequirementsExtra(requirements.extra);
 
@@ -93,19 +104,18 @@ async function extractMetadata(args: {
   let recentBlockhash: string;
   if (extra.recentBlockhash !== undefined) {
     recentBlockhash = extra.recentBlockhash;
-  } else if (connection !== undefined) {
-    recentBlockhash = (await connection.getLatestBlockhash()).blockhash;
+  } else if (rpc !== undefined) {
+    recentBlockhash = (await rpc.getLatestBlockhash().send()).value.blockhash;
   } else {
     throw new Error("couldn't get the latest Solana network block hash");
   }
 
   let decimals: number;
-
   if (extra.decimals !== undefined) {
     decimals = extra.decimals;
-  } else if (connection !== undefined) {
-    const mintInfo = await getMint(connection, mint);
-    decimals = mintInfo.decimals;
+  } else if (rpc !== undefined) {
+    const mintInfo = await fetchMint(rpc, mintAddress);
+    decimals = mintInfo.data.decimals;
   } else {
     throw new Error("couldn't get the decimal information for the mint");
   }
@@ -123,9 +133,9 @@ async function extractMetadata(args: {
     paymentMode = PaymentMode.SettlementAccount;
   }
 
-  const tokenProgramId = extra.tokenProgram
-    ? new PublicKey(extra.tokenProgram)
-    : (options?.token?.programId ?? TOKEN_PROGRAM_ID);
+  const tokenProgram = extra.tokenProgram
+    ? address(extra.tokenProgram)
+    : TOKEN_PROGRAM_ADDRESS;
 
   const memo = extra.memo;
 
@@ -136,17 +146,26 @@ async function extractMetadata(args: {
     amount,
     payerKey,
     paymentMode,
-    tokenProgramId,
+    tokenProgram,
     memo,
   };
 }
 
 interface CreatePaymentHandlerOptions {
-  token?: GetAssociatedTokenAddressSyncOptions;
+  rpc?: Rpc<SolanaRpcApi>;
   settlementRentDestination?: string;
   features?: {
     enableSettlementAccounts?: boolean;
   };
+}
+
+function isConnection(value: unknown): value is { rpcEndpoint: string } {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "rpcEndpoint" in value &&
+    typeof (value as { rpcEndpoint: unknown }).rpcEndpoint === "string"
+  );
 }
 
 /**
@@ -157,18 +176,41 @@ interface CreatePaymentHandlerOptions {
  *
  * @param wallet - Wallet providing signing capabilities
  * @param mint - SPL token mint public key
- * @param connection - Optional Solana connection for fetching blockhash and mint info
- * @param options - Optional configuration for token address and features
+ * @param options - Optional configuration including RPC fallback and features
  * @returns A PaymentHandler function for use with the x402 client
  */
+/** @deprecated Pass `{ rpc }` in options instead of a Connection */
 export function createPaymentHandler(
   wallet: Wallet,
   mint: PublicKey,
-  connection?: Connection,
+  connection: { rpcEndpoint: string },
   options?: CreatePaymentHandlerOptions,
+): PaymentHandler;
+export function createPaymentHandler(
+  wallet: Wallet,
+  mint: PublicKey,
+  options?: CreatePaymentHandlerOptions,
+): PaymentHandler;
+export function createPaymentHandler(
+  wallet: Wallet,
+  mint: PublicKey,
+  connectionOrOptions?: { rpcEndpoint: string } | CreatePaymentHandlerOptions,
+  legacyOptions?: CreatePaymentHandlerOptions,
 ): PaymentHandler {
-  const tokenConfig = options?.token ?? {};
+  let options: CreatePaymentHandlerOptions | undefined;
 
+  if (isConnection(connectionOrOptions)) {
+    logger.warning(
+      "createPaymentHandler: passing a Connection as the third argument is deprecated. " +
+        "Pass { rpc: createSolanaRpc(url) } in options instead.",
+    );
+    options = {
+      ...legacyOptions,
+      rpc: createSolanaRpc(connectionOrOptions.rpcEndpoint),
+    };
+  } else {
+    options = connectionOrOptions;
+  }
   let hasWarnedAboutDeprecation = false;
 
   const signTransaction = async (tx: VersionedTransaction) => {
@@ -192,6 +234,8 @@ export function createPaymentHandler(
     mint ? mint.toBase58() : "sol",
   );
 
+  const mintAddress = address(mint.toBase58());
+
   return async (
     _context: RequestContext,
     accepts: x402PaymentRequirements[],
@@ -206,55 +250,56 @@ export function createPaymentHandler(
           amount,
           payerKey,
           paymentMode,
-          tokenProgramId,
+          tokenProgram,
           memo,
         } = await extractMetadata({
-          connection,
-          mint,
+          rpc: options?.rpc,
+          mintAddress,
           requirements,
           wallet,
           options,
         });
 
-        const getAssociatedTokenAddressSyncRest =
-          generateGetAssociatedTokenAddressSyncRest({
-            ...tokenConfig,
-            programId: tokenProgramId,
-          });
+        const walletSigner = createNoopSigner(
+          address(wallet.publicKey.toBase58()),
+        );
 
         const instructions = [
-          ComputeBudgetProgram.setComputeUnitLimit({
-            units: 50_000,
-          }),
-          ComputeBudgetProgram.setComputeUnitPrice({
-            microLamports: 1,
-          }),
+          toTransactionInstruction(
+            getSetComputeUnitLimitInstruction({ units: 50_000 }),
+          ),
+          toTransactionInstruction(
+            getSetComputeUnitPriceInstruction({ microLamports: 1n }),
+          ),
         ];
 
-        const sourceAccount = getAssociatedTokenAddressSync(
-          mint,
-          wallet.publicKey,
-          ...getAssociatedTokenAddressSyncRest,
-        );
+        const [sourceAccount] = await findAssociatedTokenPda({
+          mint: mintAddress,
+          owner: address(wallet.publicKey.toBase58()),
+          tokenProgram,
+        });
 
         switch (paymentMode) {
           case PaymentMode.ToSpec: {
-            const receiverAccount = getAssociatedTokenAddressSync(
-              mint,
-              payTo,
-              ...getAssociatedTokenAddressSyncRest,
-            );
+            const [receiverAccount] = await findAssociatedTokenPda({
+              mint: mintAddress,
+              owner: address(payTo.toBase58()),
+              tokenProgram,
+            });
 
             instructions.push(
-              createTransferCheckedInstruction(
-                sourceAccount,
-                mint,
-                receiverAccount,
-                wallet.publicKey,
-                amount,
-                decimals,
-                undefined,
-                tokenProgramId,
+              toTransactionInstruction(
+                getTransferCheckedInstruction(
+                  {
+                    source: sourceAccount,
+                    mint: mintAddress,
+                    destination: receiverAccount,
+                    authority: walletSigner,
+                    amount: BigInt(amount),
+                    decimals,
+                  },
+                  { programAddress: tokenProgram },
+                ),
               ),
               createMemoInstruction(memo ?? generateMemoNonce()),
             );
@@ -291,29 +336,34 @@ export function createPaymentHandler(
 
           case PaymentMode.SettlementAccount: {
             const settleKeypair = Keypair.generate();
-            const settleATA = getAssociatedTokenAddressSync(
-              mint,
-              settleKeypair.publicKey,
-              ...getAssociatedTokenAddressSyncRest,
-            );
+            const [settleATA] = await findAssociatedTokenPda({
+              mint: mintAddress,
+              owner: address(settleKeypair.publicKey.toBase58()),
+              tokenProgram,
+            });
+
             instructions.push(
-              createAssociatedTokenAccountIdempotentInstruction(
-                wallet.publicKey,
-                settleATA,
-                settleKeypair.publicKey,
-                mint,
-                tokenProgramId,
-                tokenConfig.associatedTokenProgramId,
+              toTransactionInstruction(
+                getCreateAssociatedTokenIdempotentInstruction({
+                  payer: walletSigner,
+                  ata: settleATA,
+                  owner: address(settleKeypair.publicKey.toBase58()),
+                  mint: mintAddress,
+                  tokenProgram,
+                }),
               ),
-              createTransferCheckedInstruction(
-                sourceAccount,
-                mint,
-                settleATA,
-                wallet.publicKey,
-                amount,
-                decimals,
-                undefined,
-                tokenProgramId,
+              toTransactionInstruction(
+                getTransferCheckedInstruction(
+                  {
+                    source: sourceAccount,
+                    mint: mintAddress,
+                    destination: settleATA,
+                    authority: walletSigner,
+                    amount: BigInt(amount),
+                    decimals,
+                  },
+                  { programAddress: tokenProgram },
+                ),
               ),
             );
 

--- a/packages/rides/src/solana.ts
+++ b/packages/rides/src/solana.ts
@@ -11,7 +11,7 @@ import { exact } from "@faremeter/payment-solana";
 import { type WalletAdapter } from "./types";
 import { getTokenBalance } from "@faremeter/payment-solana/splToken";
 import { isValidationError } from "@faremeter/types";
-import { PublicKey, Keypair, clusterApiUrl, Connection } from "@solana/web3.js";
+import { PublicKey, Keypair, clusterApiUrl } from "@solana/web3.js";
 import { createSolanaRpc } from "@solana/kit";
 import { readLocalFile } from "./common";
 
@@ -105,11 +105,6 @@ export function createAdapter(opts: CreateAdapterOptions) {
         const rpcClient = createSolanaRpc(rpcURL);
 
         for (const mint of mints) {
-          const connection = new Connection(
-            clusterApiUrl(cluster),
-            "confirmed",
-          );
-
           const wallet = await createLocalWallet(cluster, privateKey);
           res.push({
             x402Id: [
@@ -122,7 +117,7 @@ export function createAdapter(opts: CreateAdapterOptions) {
             paymentHandler: exact.createPaymentHandler(
               wallet,
               new PublicKey(mint.address),
-              connection,
+              { rpc: rpcClient },
             ),
             getBalance: async () => {
               let balance = await getTokenBalance({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,9 +24,6 @@ catalogs:
     '@solana-program/memo':
       specifier: 0.10.0
       version: 0.10.0
-    '@solana-program/system':
-      specifier: 0.7.0
-      version: 0.7.0
     '@solana-program/token':
       specifier: 0.5.1
       version: 0.5.1
@@ -120,6 +117,9 @@ catalogs:
     typedoc-plugin-markdown:
       specifier: 4.9.0
       version: 4.9.0
+    typescript:
+      specifier: 5.9.3
+      version: 5.9.3
     typescript-eslint:
       specifier: 8.42.0
       version: 8.42.0
@@ -134,8 +134,7 @@ catalogs:
       version: 8.8.1
 
 overrides:
-  abitype: 1.1.0
-  typescript: 5.9.3
+  bn.js: ^5.2.3
 
 importers:
 
@@ -172,7 +171,7 @@ importers:
         specifier: 'catalog:'
         version: 4.9.0(typedoc@0.28.3(typescript@5.9.3))
       typescript:
-        specifier: 5.9.3
+        specifier: 'catalog:'
         version: 5.9.3
       typescript-eslint:
         specifier: 'catalog:'
@@ -288,7 +287,7 @@ importers:
         specifier: 'catalog:'
         version: 3.1.2
       typescript:
-        specifier: 5.9.3
+        specifier: 'catalog:'
         version: 5.9.3
       typescript-eslint:
         specifier: 'catalog:'
@@ -337,7 +336,7 @@ importers:
         specifier: 'catalog:'
         version: 3.1.2
       typescript:
-        specifier: 5.9.3
+        specifier: 'catalog:'
         version: 5.9.3
       typescript-eslint:
         specifier: 'catalog:'
@@ -383,7 +382,7 @@ importers:
         specifier: 'catalog:'
         version: 3.1.2
       typescript:
-        specifier: 5.9.3
+        specifier: 'catalog:'
         version: 5.9.3
       typescript-eslint:
         specifier: 'catalog:'
@@ -425,7 +424,7 @@ importers:
         specifier: 'catalog:'
         version: 3.1.2
       typescript:
-        specifier: 5.9.3
+        specifier: 'catalog:'
         version: 5.9.3
       typescript-eslint:
         specifier: 'catalog:'
@@ -480,7 +479,7 @@ importers:
         specifier: 'catalog:'
         version: 3.1.2
       typescript:
-        specifier: 5.9.3
+        specifier: 'catalog:'
         version: 5.9.3
       typescript-eslint:
         specifier: 'catalog:'
@@ -526,7 +525,7 @@ importers:
         specifier: 'catalog:'
         version: 3.1.2
       typescript:
-        specifier: 5.9.3
+        specifier: 'catalog:'
         version: 5.9.3
       typescript-eslint:
         specifier: 'catalog:'
@@ -552,9 +551,6 @@ importers:
       '@solana-program/memo':
         specifier: 'catalog:'
         version: 0.10.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
-      '@solana-program/system':
-        specifier: 'catalog:'
-        version: 0.7.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
       '@solana-program/token':
         specifier: 'catalog:'
         version: 0.5.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
@@ -573,9 +569,6 @@ importers:
       '@solana/rpc-types':
         specifier: 'catalog:'
         version: 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/spl-token':
-        specifier: 'catalog:'
-        version: 0.4.13(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@solana/transactions':
         specifier: 'catalog:'
         version: 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
@@ -608,7 +601,7 @@ importers:
         specifier: 'catalog:'
         version: 3.1.2
       typescript:
-        specifier: 5.9.3
+        specifier: 'catalog:'
         version: 5.9.3
       typescript-eslint:
         specifier: 'catalog:'
@@ -687,7 +680,7 @@ importers:
         specifier: 'catalog:'
         version: 3.1.2
       typescript:
-        specifier: 5.9.3
+        specifier: 'catalog:'
         version: 5.9.3
       typescript-eslint:
         specifier: 'catalog:'
@@ -745,7 +738,7 @@ importers:
         specifier: 'catalog:'
         version: 3.1.2
       typescript:
-        specifier: 5.9.3
+        specifier: 'catalog:'
         version: 5.9.3
       typescript-eslint:
         specifier: 'catalog:'
@@ -788,7 +781,7 @@ importers:
         specifier: 'catalog:'
         version: 3.1.2
       typescript:
-        specifier: 5.9.3
+        specifier: 'catalog:'
         version: 5.9.3
       typescript-eslint:
         specifier: 'catalog:'
@@ -828,7 +821,7 @@ importers:
         specifier: 'catalog:'
         version: 3.1.2
       typescript:
-        specifier: 5.9.3
+        specifier: 'catalog:'
         version: 5.9.3
       typescript-eslint:
         specifier: 'catalog:'
@@ -865,7 +858,7 @@ importers:
         specifier: 'catalog:'
         version: 3.1.2
       typescript:
-        specifier: 5.9.3
+        specifier: 'catalog:'
         version: 5.9.3
       typescript-eslint:
         specifier: 'catalog:'
@@ -911,7 +904,7 @@ importers:
         specifier: 'catalog:'
         version: 3.1.2
       typescript:
-        specifier: 5.9.3
+        specifier: 'catalog:'
         version: 5.9.3
 
   packages/wallet-ows:
@@ -954,7 +947,7 @@ importers:
         specifier: 'catalog:'
         version: 3.1.2
       typescript:
-        specifier: 5.9.3
+        specifier: 'catalog:'
         version: 5.9.3
       typescript-eslint:
         specifier: 'catalog:'
@@ -988,7 +981,7 @@ importers:
         specifier: 'catalog:'
         version: 3.1.2
       typescript:
-        specifier: 5.9.3
+        specifier: 'catalog:'
         version: 5.9.3
       typescript-eslint:
         specifier: 'catalog:'
@@ -1040,7 +1033,7 @@ importers:
         specifier: 'catalog:'
         version: 3.1.2
       typescript:
-        specifier: 5.9.3
+        specifier: 'catalog:'
         version: 5.9.3
       typescript-eslint:
         specifier: 'catalog:'
@@ -1189,7 +1182,7 @@ importers:
         specifier: 'catalog:'
         version: 21.1.0(@types/node@24.3.0)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.3)(utf-8-validate@5.0.10)
       typescript:
-        specifier: 5.9.3
+        specifier: 'catalog:'
         version: 5.9.3
 
 packages:
@@ -1557,7 +1550,7 @@ packages:
       '@swc/core': '>=1.2.50'
       '@swc/wasm': '>=1.2.50'
       '@types/node': '*'
-      typescript: 5.9.3
+      typescript: '>=4.2'
     peerDependenciesMeta:
       '@swc/core':
         optional: true
@@ -1841,11 +1834,6 @@ packages:
     peerDependencies:
       '@solana/kit': ^5.0
 
-  '@solana-program/system@0.7.0':
-    resolution: {integrity: sha512-FKTBsKHpvHHNc1ATRm7SlC5nF/VdJtOSjldhcyfMN9R7xo712Mo2jHIzvBgn8zQO5Kg0DcWuKB7268Kv1ocicw==}
-    peerDependencies:
-      '@solana/kit': ^2.1.0
-
   '@solana-program/token@0.5.1':
     resolution: {integrity: sha512-bJvynW5q9SFuVOZ5vqGVkmaPGA0MCC+m9jgJj1nk5m20I389/ms69ASnhWGoOPNcie7S9OwBX0gTj2fiyWpfag==}
     peerDependencies:
@@ -1855,43 +1843,43 @@ packages:
     resolution: {integrity: sha512-QgQTj404Z6PXNOyzaOpSzjgMOuGwG8vC66jSDB+3zHaRcEPRVRd2sVSrd1U6sHtnV3aiaS6YyDuPQMheg4K2jw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=5.3.3'
 
   '@solana/addresses@2.3.0':
     resolution: {integrity: sha512-ypTNkY2ZaRFpHLnHAgaW8a83N0/WoqdFvCqf4CQmnMdFsZSdC7qOwcbd7YzdaQn9dy+P2hybewzB+KP7LutxGA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=5.3.3'
 
   '@solana/addresses@3.0.3':
     resolution: {integrity: sha512-AuMwKhJI89ANqiuJ/fawcwxNKkSeHH9CApZd2xelQQLS7X8uxAOovpcmEgiObQuiVP944s9ScGUT62Bdul9qYg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=5.3.3'
 
   '@solana/addresses@5.0.0':
     resolution: {integrity: sha512-bVk+khc1ZZQHMri25csosM/ikuyPcB/CZidDM/ZMBX0CoJErpHJnmcID5mYOmv4/UHbqo2OANuEaGcFO0Q37sw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=5.3.3'
 
   '@solana/assertions@2.3.0':
     resolution: {integrity: sha512-Ekoet3khNg3XFLN7MIz8W31wPQISpKUGDGTylLptI+JjCDWx3PIa88xjEMqFo02WJ8sBj2NLV64Xg1sBcsHjZQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=5.3.3'
 
   '@solana/assertions@3.0.3':
     resolution: {integrity: sha512-2qspxdbWp2y62dfCIlqeWQr4g+hE8FYSSwcaP6itwMwGRb8393yDGCJfI/znuzJh6m/XVWhMHIgFgsBwnevCmg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=5.3.3'
 
   '@solana/assertions@5.0.0':
     resolution: {integrity: sha512-2kIykk90kYciQW6bp+KaE6jRd1Y2CgHPeJxxlc5chQnjhoG6eiD8VXvocs6AvqPTht0p/SoEj9jH5tT4oG/bcg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=5.3.3'
 
   '@solana/buffer-layout-utils@0.2.0':
     resolution: {integrity: sha512-szG4sxgJGktbuZYDg2FfNmkMi0DYQoVjN2h7ta1W1hPrwzarcFLBq9UpX1UjNXsNpT9dn+chgprtWGioUAr4/g==}
@@ -1904,358 +1892,358 @@ packages:
   '@solana/codecs-core@2.0.0-rc.1':
     resolution: {integrity: sha512-bauxqMfSs8EHD0JKESaNmNuNvkvHSuN3bbWAF5RjOfDu2PugxHrvRebmYauvSumZ3cTfQ4HJJX6PG5rN852qyQ==}
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=5'
 
   '@solana/codecs-core@2.3.0':
     resolution: {integrity: sha512-oG+VZzN6YhBHIoSKgS5ESM9VIGzhWjEHEGNPSibiDTxFhsFWxNaz8LbMDPjBUE69r9wmdGLkrQ+wVPbnJcZPvw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=5.3.3'
 
   '@solana/codecs-core@3.0.3':
     resolution: {integrity: sha512-emKykJ3h1DmnDOY29Uv9eJXP8E/FHzvlUBJ6te+5EbKdFjj7vdlKYPfDxOI6iGdXTY+YC/ELtbNBh6QwF2uEDQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=5.3.3'
 
   '@solana/codecs-core@5.0.0':
     resolution: {integrity: sha512-rCG2d8OaamVF2/J//YyCgDqNJpUytVVltw9C8mJtEz5c6Se/LR6BFuG8g4xeJswq/ab4RFk5/HFdgbvNjKgQjA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=5.3.3'
 
   '@solana/codecs-data-structures@2.0.0-rc.1':
     resolution: {integrity: sha512-rinCv0RrAVJ9rE/rmaibWJQxMwC5lSaORSZuwjopSUE6T0nb/MVg6Z1siNCXhh/HFTOg0l8bNvZHgBcN/yvXog==}
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=5'
 
   '@solana/codecs-data-structures@2.3.0':
     resolution: {integrity: sha512-qvU5LE5DqEdYMYgELRHv+HMOx73sSoV1ZZkwIrclwUmwTbTaH8QAJURBj0RhQ/zCne7VuLLOZFFGv6jGigWhSw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=5.3.3'
 
   '@solana/codecs-data-structures@5.0.0':
     resolution: {integrity: sha512-y503Pqmv0LHcfcf0vQJGaxDvydQJbyCo8nK3nxn56EhFj5lBQ1NWb3WvTd83epigwuZurW2MhJARrpikfhQglQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=5.3.3'
 
   '@solana/codecs-numbers@2.0.0-rc.1':
     resolution: {integrity: sha512-J5i5mOkvukXn8E3Z7sGIPxsThRCgSdgTWJDQeZvucQ9PT6Y3HiVXJ0pcWiOWAoQ3RX8e/f4I3IC+wE6pZiJzDQ==}
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=5'
 
   '@solana/codecs-numbers@2.3.0':
     resolution: {integrity: sha512-jFvvwKJKffvG7Iz9dmN51OGB7JBcy2CJ6Xf3NqD/VP90xak66m/Lg48T01u5IQ/hc15mChVHiBm+HHuOFDUrQg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=5.3.3'
 
   '@solana/codecs-numbers@3.0.3':
     resolution: {integrity: sha512-pfXkH9J0glrM8qj6389GAn30+cJOxzXLR2FsPOHCUMXrqLhGjMMZAWhsQkpOQ37SGc/7EiQsT/gmyGC7gxHqJQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=5.3.3'
 
   '@solana/codecs-numbers@5.0.0':
     resolution: {integrity: sha512-a2+skRLuUK02f/XFe4L0e1+wHCyfK25PkyseFps1v1l4pvevukFwth/EhSyrs6w5CsTJRVoR7MuE3E00PM4egw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=5.3.3'
 
   '@solana/codecs-strings@2.0.0-rc.1':
     resolution: {integrity: sha512-9/wPhw8TbGRTt6mHC4Zz1RqOnuPTqq1Nb4EyuvpZ39GW6O2t2Q7Q0XxiB3+BdoEjwA2XgPw6e2iRfvYgqty44g==}
     peerDependencies:
       fastestsmallesttextencoderdecoder: ^1.0.22
-      typescript: 5.9.3
+      typescript: '>=5'
 
   '@solana/codecs-strings@2.3.0':
     resolution: {integrity: sha512-y5pSBYwzVziXu521hh+VxqUtp0hYGTl1eWGoc1W+8mdvBdC1kTqm/X7aYQw33J42hw03JjryvYOvmGgk3Qz/Ug==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       fastestsmallesttextencoderdecoder: ^1.0.22
-      typescript: 5.9.3
+      typescript: '>=5.3.3'
 
   '@solana/codecs-strings@3.0.3':
     resolution: {integrity: sha512-VHBXnnTVtcQ1j+7Vrz+qSYo38no+jiHRdGnhFspRXEHNJbllzwKqgBE7YN3qoIXH+MKxgJUcwO5KHmdzf8Wn2A==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       fastestsmallesttextencoderdecoder: ^1.0.22
-      typescript: 5.9.3
+      typescript: '>=5.3.3'
 
   '@solana/codecs-strings@5.0.0':
     resolution: {integrity: sha512-ALkRwpV8bGR6qjAYw0YXZwp2YI4wzvKOJGmx04Ut8gMdbaUx7qOcJkhEQKI6ZVC3lAWSIS1N1wGccUZDwvfKxw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       fastestsmallesttextencoderdecoder: ^1.0.22
-      typescript: 5.9.3
+      typescript: '>=5.3.3'
 
   '@solana/codecs@2.0.0-rc.1':
     resolution: {integrity: sha512-qxoR7VybNJixV51L0G1RD2boZTcxmwUWnKCaJJExQ5qNKwbpSyDdWfFJfM5JhGyKe9DnPVOZB+JHWXnpbZBqrQ==}
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=5'
 
   '@solana/codecs@2.3.0':
     resolution: {integrity: sha512-JVqGPkzoeyU262hJGdH64kNLH0M+Oew2CIPOa/9tR3++q2pEd4jU2Rxdfye9sd0Ce3XJrR5AIa8ZfbyQXzjh+g==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=5.3.3'
 
   '@solana/errors@2.0.0-rc.1':
     resolution: {integrity: sha512-ejNvQ2oJ7+bcFAYWj225lyRkHnixuAeb7RQCixm+5mH4n1IA4Qya/9Bmfy5RAAHQzxK43clu3kZmL5eF9VGtYQ==}
     hasBin: true
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=5'
 
   '@solana/errors@2.3.0':
     resolution: {integrity: sha512-66RI9MAbwYV0UtP7kGcTBVLxJgUxoZGm8Fbc0ah+lGiAw17Gugco6+9GrJCV83VyF2mDWyYnYM9qdI3yjgpnaQ==}
     engines: {node: '>=20.18.0'}
     hasBin: true
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=5.3.3'
 
   '@solana/errors@3.0.3':
     resolution: {integrity: sha512-1l84xJlHNva6io62PcYfUamwWlc0eM95nHgCrKX0g0cLoC6D6QHYPCEbEVkR+C5UtP9JDgyQM8MFiv+Ei5tO9Q==}
     engines: {node: '>=20.18.0'}
     hasBin: true
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=5.3.3'
 
   '@solana/errors@5.0.0':
     resolution: {integrity: sha512-gTuhzO6E+ydfAAzqmqdPcvFyJwAzFKKIrqtnZPpgAuomcPYu+HSo0tuwSM/cTX0djmHt+GoOsf/julph+nvs2w==}
     engines: {node: '>=20.18.0'}
     hasBin: true
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=5.3.3'
 
   '@solana/fast-stable-stringify@2.3.0':
     resolution: {integrity: sha512-KfJPrMEieUg6D3hfQACoPy0ukrAV8Kio883llt/8chPEG3FVTX9z/Zuf4O01a15xZmBbmQ7toil2Dp0sxMJSxw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=5.3.3'
 
   '@solana/fast-stable-stringify@5.0.0':
     resolution: {integrity: sha512-sGTbu7a4/olL+8EIOOJ7IZjzqOOpCJcK1UaVJ6015sRgo9vwGf4jg9KtXEYv5LVhLCTYmAb50L4BaIUcBph/Ig==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=5.3.3'
 
   '@solana/functional@2.3.0':
     resolution: {integrity: sha512-AgsPh3W3tE+nK3eEw/W9qiSfTGwLYEvl0rWaxHht/lRcuDVwfKRzeSa5G79eioWFFqr+pTtoCr3D3OLkwKz02Q==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=5.3.3'
 
   '@solana/functional@5.0.0':
     resolution: {integrity: sha512-UNBrpfzBL4dKD2iucjNnrkFbnjz5ZYDu2OvrIBAcCSQsxxgHMamUj1n3EDe6kl1us49YG1r05Ho8QLqNrbkVbw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=5.3.3'
 
   '@solana/instructions@2.3.0':
     resolution: {integrity: sha512-PLMsmaIKu7hEAzyElrk2T7JJx4D+9eRwebhFZpy2PXziNSmFF929eRHKUsKqBFM3cYR1Yy3m6roBZfA+bGE/oQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=5.3.3'
 
   '@solana/instructions@5.0.0':
     resolution: {integrity: sha512-12dbrmwERT1o6NTr/Uvrjj/ZsiteSXoT5Gi+dnjIeRNHWg9H+gEFuFzJvTDVKlNg34CZ71xdvbVdbV0V8gKGvg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=5.3.3'
 
   '@solana/keys@2.3.0':
     resolution: {integrity: sha512-ZVVdga79pNH+2pVcm6fr2sWz9HTwfopDVhYb0Lh3dh+WBmJjwkabXEIHey2rUES7NjFa/G7sV8lrUn/v8LDCCQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=5.3.3'
 
   '@solana/keys@5.0.0':
     resolution: {integrity: sha512-kWkR7NslpTttk5i1BhBNCDtVQDkEtgkdsM3Jp9TGPk0GFjBjBwrQStw3vvwLe8itEIvRFGFZU6JHEk8HLS0WLQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=5.3.3'
 
   '@solana/kit@2.3.0':
     resolution: {integrity: sha512-sb6PgwoW2LjE5oTFu4lhlS/cGt/NB3YrShEyx7JgWFWysfgLdJnhwWThgwy/4HjNsmtMrQGWVls0yVBHcMvlMQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=5.3.3'
 
   '@solana/nominal-types@2.3.0':
     resolution: {integrity: sha512-uKlMnlP4PWW5UTXlhKM8lcgIaNj8dvd8xO4Y9l+FVvh9RvW2TO0GwUO6JCo7JBzCB0PSqRJdWWaQ8pu1Ti/OkA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=5.3.3'
 
   '@solana/nominal-types@3.0.3':
     resolution: {integrity: sha512-aZavCiexeUAoMHRQg4s1AHkH3wscbOb70diyfjhwZVgFz1uUsFez7csPp9tNFkNolnadVb2gky7yBk3IImQJ6A==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=5.3.3'
 
   '@solana/nominal-types@5.0.0':
     resolution: {integrity: sha512-Qn7xH4UG2rDAv+wAyheP4jWvX3oQmbZ/woxFZwug7PaRLvyjUswGr38Hil+SjiQyFDo+un1UqWM9N9yusUeeZQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=5.3.3'
 
   '@solana/options@2.0.0-rc.1':
     resolution: {integrity: sha512-mLUcR9mZ3qfHlmMnREdIFPf9dpMc/Bl66tLSOOWxw4ml5xMT2ohFn7WGqoKcu/UHkT9CrC6+amEdqCNvUqI7AA==}
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=5'
 
   '@solana/options@2.3.0':
     resolution: {integrity: sha512-PPnnZBRCWWoZQ11exPxf//DRzN2C6AoFsDI/u2AsQfYih434/7Kp4XLpfOMT/XESi+gdBMFNNfbES5zg3wAIkw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=5.3.3'
 
   '@solana/programs@2.3.0':
     resolution: {integrity: sha512-UXKujV71VCI5uPs+cFdwxybtHZAIZyQkqDiDnmK+DawtOO9mBn4Nimdb/6RjR2CXT78mzO9ZCZ3qfyX+ydcB7w==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=5.3.3'
 
   '@solana/promises@2.3.0':
     resolution: {integrity: sha512-GjVgutZKXVuojd9rWy1PuLnfcRfqsaCm7InCiZc8bqmJpoghlyluweNc7ml9Y5yQn1P2IOyzh9+p/77vIyNybQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=5.3.3'
 
   '@solana/rpc-api@2.3.0':
     resolution: {integrity: sha512-UUdiRfWoyYhJL9PPvFeJr4aJ554ob2jXcpn4vKmRVn9ire0sCbpQKYx6K8eEKHZWXKrDW8IDspgTl0gT/aJWVg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=5.3.3'
 
   '@solana/rpc-api@5.0.0':
     resolution: {integrity: sha512-IJbZZnX2B1ldXPok1NhneXTYq9ZvdJbE5Pryr03pZTlPJaWGqDcZuQ14nwR4s6PoUUgdT+p87QlLZqLb8MusoQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=5.3.3'
 
   '@solana/rpc-parsed-types@2.3.0':
     resolution: {integrity: sha512-B5pHzyEIbBJf9KHej+zdr5ZNAdSvu7WLU2lOUPh81KHdHQs6dEb310LGxcpCc7HVE8IEdO20AbckewDiAN6OCg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=5.3.3'
 
   '@solana/rpc-parsed-types@5.0.0':
     resolution: {integrity: sha512-fU9uqlOYAaBqgk2qCl+ntenBm7wuSFBRbIO/rVjeBPd/qPCvNZU+qFET+ERLK6wbCTSz0MmdHqPn1V8KCMOvZQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=5.3.3'
 
   '@solana/rpc-spec-types@2.3.0':
     resolution: {integrity: sha512-xQsb65lahjr8Wc9dMtP7xa0ZmDS8dOE2ncYjlvfyw/h4mpdXTUdrSMi6RtFwX33/rGuztQ7Hwaid5xLNSLvsFQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=5.3.3'
 
   '@solana/rpc-spec-types@5.0.0':
     resolution: {integrity: sha512-B0P/ylXVaCG5oSIV+kB88s2qoW996D8iKhc7RyF0C/AyYvklF6kCwv0N9ZVrWp0ibjlQ8St290WbBHJyo7QZkA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=5.3.3'
 
   '@solana/rpc-spec@2.3.0':
     resolution: {integrity: sha512-fA2LMX4BMixCrNB2n6T83AvjZ3oUQTu7qyPLyt8gHQaoEAXs8k6GZmu6iYcr+FboQCjUmRPgMaABbcr9j2J9Sw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=5.3.3'
 
   '@solana/rpc-spec@5.0.0':
     resolution: {integrity: sha512-1LD2SYEQ5bYhiBumznAPzymtxSX4nYLZd6u+FA0bAxNBVzHDvUUQzVSXHAoWROhlGrCyvtALTs9u0DIDlgZHCA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=5.3.3'
 
   '@solana/rpc-subscriptions-api@2.3.0':
     resolution: {integrity: sha512-9mCjVbum2Hg9KGX3LKsrI5Xs0KX390lS+Z8qB80bxhar6MJPugqIPH8uRgLhCW9GN3JprAfjRNl7our8CPvsPQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=5.3.3'
 
   '@solana/rpc-subscriptions-channel-websocket@2.3.0':
     resolution: {integrity: sha512-2oL6ceFwejIgeWzbNiUHI2tZZnaOxNTSerszcin7wYQwijxtpVgUHiuItM/Y70DQmH9sKhmikQp+dqeGalaJxw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=5.3.3'
       ws: ^8.18.0
 
   '@solana/rpc-subscriptions-spec@2.3.0':
     resolution: {integrity: sha512-rdmVcl4PvNKQeA2l8DorIeALCgJEMSu7U8AXJS1PICeb2lQuMeaR+6cs/iowjvIB0lMVjYN2sFf6Q3dJPu6wWg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=5.3.3'
 
   '@solana/rpc-subscriptions@2.3.0':
     resolution: {integrity: sha512-Uyr10nZKGVzvCOqwCZgwYrzuoDyUdwtgQRefh13pXIrdo4wYjVmoLykH49Omt6abwStB0a4UL5gX9V4mFdDJZg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=5.3.3'
 
   '@solana/rpc-transformers@2.3.0':
     resolution: {integrity: sha512-UuHYK3XEpo9nMXdjyGKkPCOr7WsZsxs7zLYDO1A5ELH3P3JoehvrDegYRAGzBS2VKsfApZ86ZpJToP0K3PhmMA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=5.3.3'
 
   '@solana/rpc-transformers@5.0.0':
     resolution: {integrity: sha512-EMHhSgfF6/T4FfHbLaBP08SIj1ZAjxJr6WPNZMHLV7Cup8UfiB9TNV+bPQkum7JbVQNhUKzkKEEmyYqPfQoV9w==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=5.3.3'
 
   '@solana/rpc-transport-http@2.3.0':
     resolution: {integrity: sha512-HFKydmxGw8nAF5N+S0NLnPBDCe5oMDtI2RAmW8DMqP4U3Zxt2XWhvV1SNkAldT5tF0U1vP+is6fHxyhk4xqEvg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=5.3.3'
 
   '@solana/rpc-transport-http@5.0.0':
     resolution: {integrity: sha512-RoIEvWp7yc7rIRzNkOyjLs2UQF0odIEMWj87dbD4Ir4hwTCGo/TSTfQF/8KDV2etdke3Fa1K+W1NkpG2POqWFg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=5.3.3'
 
   '@solana/rpc-types@2.3.0':
     resolution: {integrity: sha512-O09YX2hED2QUyGxrMOxQ9GzH1LlEwwZWu69QbL4oYmIf6P5dzEEHcqRY6L1LsDVqc/dzAdEs/E1FaPrcIaIIPw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=5.3.3'
 
   '@solana/rpc-types@3.0.3':
     resolution: {integrity: sha512-petWQ5xSny9UfmC3Qp2owyhNU0w9SyBww4+v7tSVyXMcCC9v6j/XsqTeimH1S0qQUllnv0/FY83ohFaxofmZ6Q==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=5.3.3'
 
   '@solana/rpc-types@5.0.0':
     resolution: {integrity: sha512-JMbhwnV6nX4ezJv/KmaElOR0r/MZTKzKpaz6cv7FopLNuPrYCBrRCZKuM2XQh6gUbt9Mey08/KBOmOGmzTbL/g==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=5.3.3'
 
   '@solana/rpc@2.3.0':
     resolution: {integrity: sha512-ZWN76iNQAOCpYC7yKfb3UNLIMZf603JckLKOOLTHuy9MZnTN8XV6uwvDFhf42XvhglgUjGCEnbUqWtxQ9pa/pQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=5.3.3'
 
   '@solana/rpc@5.0.0':
     resolution: {integrity: sha512-Myx/ZBmMHkgh9Di3tLzc+vd30f+6YC1JXr9+YmIHKEeqN/+iTHkDJU2E/hGRLy8vTOBOU7+2466A+dLnSVuGkg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=5.3.3'
 
   '@solana/signers@2.3.0':
     resolution: {integrity: sha512-OSv6fGr/MFRx6J+ZChQMRqKNPGGmdjkqarKkRzkwmv7v8quWsIRnJT5EV8tBy3LI4DLO/A8vKiNSPzvm1TdaiQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=5.3.3'
 
   '@solana/spl-token-group@0.0.7':
     resolution: {integrity: sha512-V1N/iX7Cr7H0uazWUT2uk27TMqlqedpXHRqqAbVO2gvmJyT0E0ummMEAVQeXZ05ZhQ/xF39DLSdBp90XebWEug==}
@@ -2285,43 +2273,43 @@ packages:
     resolution: {integrity: sha512-DkgohEDbMkdTWiKAoatY02Njr56WXx9e/dKKfmne8/Ad6/2llUIrax78nCdlvZW9quXMaXPTxZvdQqo9N669Og==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=5.3.3'
 
   '@solana/sysvars@2.3.0':
     resolution: {integrity: sha512-LvjADZrpZ+CnhlHqfI5cmsRzX9Rpyb1Ox2dMHnbsRNzeKAMhu9w4ZBIaeTdO322zsTr509G1B+k2ABD3whvUBA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=5.3.3'
 
   '@solana/transaction-confirmation@2.3.0':
     resolution: {integrity: sha512-UiEuiHCfAAZEKdfne/XljFNJbsKAe701UQHKXEInYzIgBjRbvaeYZlBmkkqtxwcasgBTOmEaEKT44J14N9VZDw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=5.3.3'
 
   '@solana/transaction-messages@2.3.0':
     resolution: {integrity: sha512-bgqvWuy3MqKS5JdNLH649q+ngiyOu5rGS3DizSnWwYUd76RxZl1kN6CoqHSrrMzFMvis6sck/yPGG3wqrMlAww==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=5.3.3'
 
   '@solana/transaction-messages@5.0.0':
     resolution: {integrity: sha512-rJLe1wUGW5DovQFV0gjXHXnriPxTBgZ3TvGWnjCu2OIBU8mcQkQVJ7zzVZY2IAYlmJ6OSF9nvzhSt/ncPbkJPg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=5.3.3'
 
   '@solana/transactions@2.3.0':
     resolution: {integrity: sha512-LnTvdi8QnrQtuEZor5Msje61sDpPstTVwKg4y81tNxDhiyomjuvnSNLAq6QsB9gIxUqbNzPZgOG9IU4I4/Uaug==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=5.3.3'
 
   '@solana/transactions@5.0.0':
     resolution: {integrity: sha512-4TcsqH7JtgRKGGBIRRGz0n+tXu4h5TPPC49kkV0ygIndQaHW7FOZUYTwQ0epq0A5h9KYi+ClNbzF9xiuDbAD5Q==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=5.3.3'
 
   '@solana/web3.js@1.98.4':
     resolution: {integrity: sha512-vv9lfnvjUsRiq//+j5pBdXig0IQdtzA0BRZ3bXEP4KaIyF1CcaydWqgyzQgfZMNIsWNWmG+AUHwPy4AHOD6gpw==}
@@ -2601,20 +2589,20 @@ packages:
     peerDependencies:
       '@typescript-eslint/parser': ^8.42.0
       eslint: ^8.57.0 || ^9.0.0
-      typescript: 5.9.3
+      typescript: '>=4.8.4 <6.0.0'
 
   '@typescript-eslint/parser@8.42.0':
     resolution: {integrity: sha512-r1XG74QgShUgXph1BYseJ+KZd17bKQib/yF3SR+demvytiRXrwd12Blnz5eYGm8tXaeRdd4x88MlfwldHoudGg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
-      typescript: 5.9.3
+      typescript: '>=4.8.4 <6.0.0'
 
   '@typescript-eslint/project-service@8.42.0':
     resolution: {integrity: sha512-vfVpLHAhbPjilrabtOSNcUDmBboQNrJUiNAGoImkZKnMjs2TIcWG33s4Ds0wY3/50aZmTMqJa6PiwkwezaAklg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=4.8.4 <6.0.0'
 
   '@typescript-eslint/scope-manager@8.42.0':
     resolution: {integrity: sha512-51+x9o78NBAVgQzOPd17DkNTnIzJ8T/O2dmMBLoK9qbY0Gm52XJcdJcCl18ExBMiHo6jPMErUQWUv5RLE51zJw==}
@@ -2624,14 +2612,14 @@ packages:
     resolution: {integrity: sha512-kHeFUOdwAJfUmYKjR3CLgZSglGHjbNTi1H8sTYRYV2xX6eNz4RyJ2LIgsDLKf8Yi0/GL1WZAC/DgZBeBft8QAQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=4.8.4 <6.0.0'
 
   '@typescript-eslint/type-utils@8.42.0':
     resolution: {integrity: sha512-9KChw92sbPTYVFw3JLRH1ockhyR3zqqn9lQXol3/YbI6jVxzWoGcT3AsAW0mu1MY0gYtsXnUGV/AKpkAj5tVlQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
-      typescript: 5.9.3
+      typescript: '>=4.8.4 <6.0.0'
 
   '@typescript-eslint/types@8.42.0':
     resolution: {integrity: sha512-LdtAWMiFmbRLNP7JNeY0SqEtJvGMYSzfiWBSmx+VSZ1CH+1zyl8Mmw1TT39OrtsRvIYShjJWzTDMPWZJCpwBlw==}
@@ -2641,14 +2629,14 @@ packages:
     resolution: {integrity: sha512-ku/uYtT4QXY8sl9EDJETD27o3Ewdi72hcXg1ah/kkUgBvAYHLwj2ofswFFNXS+FL5G+AGkxBtvGt8pFBHKlHsQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=4.8.4 <6.0.0'
 
   '@typescript-eslint/utils@8.42.0':
     resolution: {integrity: sha512-JnIzu7H3RH5BrKC4NoZqRfmjqCIS1u3hGZltDYJgkVdqAezl4L9d1ZLw+36huCujtSBSAirGINF/S4UxOcR+/g==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
-      typescript: 5.9.3
+      typescript: '>=4.8.4 <6.0.0'
 
   '@typescript-eslint/visitor-keys@8.42.0':
     resolution: {integrity: sha512-3WbiuzoEowaEn8RSnhJBrxSwX8ULYE9CXaPepS2C2W3NSA5NNIvBaslpBSBElPq0UGr0xVJlXFWOAKIkyylydQ==}
@@ -2658,10 +2646,21 @@ packages:
     resolution: {integrity: sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
+  abitype@1.0.8:
+    resolution: {integrity: sha512-ZeiI6h3GnW06uYDLx0etQtX/p8E24UaHHBj57RSjK7YBFe7iuVn07EDpOeP451D06sF27VOz9JJPlIKJmXgkEg==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+      zod: ^3 >=3.22.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+      zod:
+        optional: true
+
   abitype@1.1.0:
     resolution: {integrity: sha512-6Vh4HcRxNMLA0puzPjM5GBgT4aAcFGKZzSgAXvuZ27shJP6NEpielTuqbBmZILR5/xd0PizkBGy5hReKz9jl5A==}
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=5.0.4'
       zod: ^3.22.0 || ^4.0.0
     peerDependenciesMeta:
       typescript:
@@ -2811,11 +2810,8 @@ packages:
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
-  bn.js@4.12.2:
-    resolution: {integrity: sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==}
-
-  bn.js@5.2.2:
-    resolution: {integrity: sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw==}
+  bn.js@5.2.3:
+    resolution: {integrity: sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==}
 
   body-parser@1.20.3:
     resolution: {integrity: sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==}
@@ -4100,7 +4096,7 @@ packages:
   ox@0.6.9:
     resolution: {integrity: sha512-wi5ShvzE4eOcTwQVsIPdFr+8ycyX+5le/96iAJutaZAvCes1J0+RvpEPg5QDPDiaR0XQQAvZVl7AwqQcINuUug==}
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -4108,7 +4104,7 @@ packages:
   ox@0.8.1:
     resolution: {integrity: sha512-e+z5epnzV+Zuz91YYujecW8cF01mzmrUtWotJ0oEPym/G82uccs7q0WDHTYL3eiONbTUEvcZrptAKLgTBD3u2A==}
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -4116,7 +4112,7 @@ packages:
   ox@0.9.6:
     resolution: {integrity: sha512-8SuCbHPvv2eZLYXrNmC0EC12rdzXQLdhnOMlHDW2wiCPLxBrOOJwX5L5E61by+UjTPOryqQiRSnjIKCI+GykKg==}
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -4642,7 +4638,7 @@ packages:
     resolution: {integrity: sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==}
     engines: {node: '>=18.12'}
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=4.8.4'
 
   tsc-esm-fix@3.1.2:
     resolution: {integrity: sha512-1/OpZssMcEp2ae6DyZV+yvDviofuCdDf7dEWEaBvm/ac8vtS04lFyl0LVs8LQE56vjKHytgzVjPIL9udM4QuNg==}
@@ -4653,7 +4649,7 @@ packages:
     resolution: {integrity: sha512-N+yt68b/L22zVr1T4yyRjG0OihgfExkDlNTPJyhFa7yh/27h4y8qNzKqSzloLjelQn9R5laDeTY6iwMpURHnLw==}
     hasBin: true
     peerDependencies:
-      typescript: 5.9.3
+      typescript: ^5
 
   tshy@3.0.3:
     resolution: {integrity: sha512-bUX6HQCvVdPyPLy2VZuKw95CtYD5aRSEgYEK7IPV9l9xN/z284kl5/hIwOfLY/mZOOdhrO34dFOOcL1VUMVyaw==}
@@ -4720,18 +4716,23 @@ packages:
     engines: {node: '>= 18', pnpm: '>= 10'}
     hasBin: true
     peerDependencies:
-      typescript: 5.9.3
+      typescript: 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x
 
   typescript-eslint@8.42.0:
     resolution: {integrity: sha512-ozR/rQn+aQXQxh1YgbCzQWDFrsi9mcg+1PM3l/z5o1+20P7suOIaNg515bpr/OYt6FObz/NHcBstydDLHWeEKg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
-      typescript: 5.9.3
+      typescript: '>=4.8.4 <6.0.0'
 
   typescript-language-server@4.4.0:
     resolution: {integrity: sha512-enWhplhHX7PA0q+IcKHBMpTQh9I2Bmb3L45rwnkATHMsZ7YLduyyCdOmVUWJSYZfkWaBMiKwi/e2FQo4xsKeWw==}
     engines: {node: '>=18'}
+    hasBin: true
+
+  typescript@5.5.4:
+    resolution: {integrity: sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==}
+    engines: {node: '>=14.17'}
     hasBin: true
 
   typescript@5.9.3:
@@ -4828,7 +4829,7 @@ packages:
   viem@2.33.1:
     resolution: {integrity: sha512-++Dkj8HvSOLPMKEs+ZBNNcWbBRlUHcXNWktjIU22hgr6YmbUldV1sPTGLZa6BYRm06WViMjXj6HIsHt8rD+ZKQ==}
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=5.0.4'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -4836,7 +4837,7 @@ packages:
   viem@2.41.2:
     resolution: {integrity: sha512-LYliajglBe1FU6+EH9mSWozp+gRA/QcHfxeD9Odf83AdH5fwUS7DroH4gHvlv6Sshqi1uXrYFA2B/EOczxd15g==}
     peerDependencies:
-      typescript: 5.9.3
+      typescript: '>=5.0.4'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -5026,7 +5027,7 @@ snapshots:
       '@coral-xyz/borsh': 0.31.1(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10))
       '@noble/hashes': 1.8.0
       '@solana/web3.js': 1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10)
-      bn.js: 5.2.2
+      bn.js: 5.2.3
       bs58: 4.0.1
       buffer-layout: 1.2.2
       camelcase: 6.3.0
@@ -5044,7 +5045,7 @@ snapshots:
   '@coral-xyz/borsh@0.31.1(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10))':
     dependencies:
       '@solana/web3.js': 1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10)
-      bn.js: 5.2.2
+      bn.js: 5.2.3
       buffer-layout: 1.2.2
 
   '@crossmint/client-sdk-window@1.0.5':
@@ -5075,7 +5076,7 @@ snapshots:
       '@hey-api/client-fetch': 0.8.1
       '@solana/web3.js': 1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@stellar/stellar-sdk': 14.0.0-rc.3
-      abitype: 1.1.0(typescript@5.9.3)(zod@3.22.4)
+      abitype: 1.0.8(typescript@5.9.3)(zod@3.22.4)
       bs58: 5.0.0
       ox: 0.6.9(typescript@5.9.3)(zod@3.22.4)
       tweetnacl: 1.0.3
@@ -5259,7 +5260,7 @@ snapshots:
     dependencies:
       '@ethersproject/bytes': 5.8.0
       '@ethersproject/logger': 5.8.0
-      bn.js: 5.2.2
+      bn.js: 5.2.3
 
   '@ethersproject/bytes@5.8.0':
     dependencies:
@@ -5306,7 +5307,7 @@ snapshots:
       '@ethersproject/bytes': 5.8.0
       '@ethersproject/logger': 5.8.0
       '@ethersproject/properties': 5.8.0
-      bn.js: 5.2.2
+      bn.js: 5.2.3
       elliptic: 6.6.1
       hash.js: 1.1.7
 
@@ -5349,7 +5350,7 @@ snapshots:
       '@solana/spl-token': 0.4.13(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@solana/web3.js': 1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10)
       arktype: 2.1.21
-      bn.js: 5.2.2
+      bn.js: 5.2.3
       bs58: 6.0.0
     transitivePeerDependencies:
       - bufferutil
@@ -5398,6 +5399,22 @@ snapshots:
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
 
+  '@isaacs/ts-node-temp-fork-for-pr-2009@10.9.7(@types/node@20.19.11)(typescript@5.5.4)':
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node14': 14.1.5
+      '@tsconfig/node16': 16.1.6
+      '@tsconfig/node18': 18.2.4
+      '@tsconfig/node20': 20.1.6
+      '@types/node': 20.19.11
+      acorn: 8.15.0
+      acorn-walk: 8.3.4
+      arg: 4.1.3
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.5.4
+      v8-compile-cache-lib: 3.0.1
+
   '@isaacs/ts-node-temp-fork-for-pr-2009@10.9.7(@types/node@20.19.11)(typescript@5.9.3)':
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
@@ -5412,6 +5429,22 @@ snapshots:
       diff: 4.0.2
       make-error: 1.3.6
       typescript: 5.9.3
+      v8-compile-cache-lib: 3.0.1
+
+  '@isaacs/ts-node-temp-fork-for-pr-2009@10.9.7(@types/node@24.3.0)(typescript@5.5.4)':
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node14': 14.1.5
+      '@tsconfig/node16': 16.1.6
+      '@tsconfig/node18': 18.2.4
+      '@tsconfig/node20': 20.1.6
+      '@types/node': 24.3.0
+      acorn: 8.15.0
+      acorn-walk: 8.3.4
+      arg: 4.1.3
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.5.4
       v8-compile-cache-lib: 3.0.1
 
   '@isaacs/ts-node-temp-fork-for-pr-2009@10.9.7(@types/node@24.3.0)(typescript@5.9.3)':
@@ -5581,7 +5614,7 @@ snapshots:
   '@metaplex-foundation/beet@0.7.1':
     dependencies:
       ansicolors: 0.3.2
-      bn.js: 5.2.2
+      bn.js: 5.2.3
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
@@ -5822,10 +5855,6 @@ snapshots:
       '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
 
   '@solana-program/memo@0.10.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)))':
-    dependencies:
-      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-
-  '@solana-program/system@0.7.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)))':
     dependencies:
       '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
 
@@ -6552,7 +6581,7 @@ snapshots:
       '@solana/buffer-layout': 4.0.1
       '@solana/codecs-numbers': 2.3.0(typescript@5.9.3)
       agentkeepalive: 4.6.0
-      bn.js: 5.2.2
+      bn.js: 5.2.3
       borsh: 0.7.0
       bs58: 4.0.1
       buffer: 6.0.3
@@ -6576,7 +6605,7 @@ snapshots:
       '@solana/web3.js': 1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@types/bn.js': 5.2.0
       assert: 2.1.0
-      bn.js: 5.2.2
+      bn.js: 5.2.3
       buffer: 6.0.3
       invariant: 2.2.4
     transitivePeerDependencies:
@@ -7179,7 +7208,7 @@ snapshots:
 
   '@tapjs/test@4.0.1(@tapjs/core@4.0.1(@types/node@20.19.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/node@20.19.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@isaacs/ts-node-temp-fork-for-pr-2009': 10.9.7(@types/node@20.19.11)(typescript@5.9.3)
+      '@isaacs/ts-node-temp-fork-for-pr-2009': 10.9.7(@types/node@20.19.11)(typescript@5.5.4)
       '@tapjs/after': 3.0.1(@tapjs/core@4.0.1(@types/node@20.19.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@tapjs/after-each': 4.0.1(@tapjs/core@4.0.1(@types/node@20.19.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@tapjs/asserts': 4.0.1(@tapjs/core@4.0.1(@types/node@20.19.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -7195,7 +7224,7 @@ snapshots:
       '@tapjs/snapshot': 4.0.1(@tapjs/core@4.0.1(@types/node@20.19.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@tapjs/spawn': 4.0.1(@tapjs/core@4.0.1(@types/node@20.19.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@tapjs/stdin': 4.0.1(@tapjs/core@4.0.1(@types/node@20.19.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@tapjs/typescript': 3.1.0(@tapjs/core@4.0.1(@types/node@20.19.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/node@20.19.11)(typescript@5.9.3)
+      '@tapjs/typescript': 3.1.0(@tapjs/core@4.0.1(@types/node@20.19.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/node@20.19.11)(typescript@5.5.4)
       '@tapjs/worker': 4.0.1(@tapjs/core@4.0.1(@types/node@20.19.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       glob: 11.0.3
       jackspeak: 4.1.1
@@ -7206,7 +7235,7 @@ snapshots:
       sync-content: 2.0.1
       tap-parser: 18.0.0
       tshy: 3.0.3
-      typescript: 5.9.3
+      typescript: 5.5.4
       walk-up-path: 4.0.0
     transitivePeerDependencies:
       - '@swc/core'
@@ -7217,7 +7246,7 @@ snapshots:
 
   '@tapjs/test@4.0.1(@tapjs/core@4.0.1(@types/node@24.3.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/node@24.3.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@isaacs/ts-node-temp-fork-for-pr-2009': 10.9.7(@types/node@24.3.0)(typescript@5.9.3)
+      '@isaacs/ts-node-temp-fork-for-pr-2009': 10.9.7(@types/node@24.3.0)(typescript@5.5.4)
       '@tapjs/after': 3.0.1(@tapjs/core@4.0.1(@types/node@24.3.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@tapjs/after-each': 4.0.1(@tapjs/core@4.0.1(@types/node@24.3.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@tapjs/asserts': 4.0.1(@tapjs/core@4.0.1(@types/node@24.3.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -7233,7 +7262,7 @@ snapshots:
       '@tapjs/snapshot': 4.0.1(@tapjs/core@4.0.1(@types/node@24.3.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@tapjs/spawn': 4.0.1(@tapjs/core@4.0.1(@types/node@24.3.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@tapjs/stdin': 4.0.1(@tapjs/core@4.0.1(@types/node@24.3.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@tapjs/typescript': 3.1.0(@tapjs/core@4.0.1(@types/node@24.3.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/node@24.3.0)(typescript@5.9.3)
+      '@tapjs/typescript': 3.1.0(@tapjs/core@4.0.1(@types/node@24.3.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/node@24.3.0)(typescript@5.5.4)
       '@tapjs/worker': 4.0.1(@tapjs/core@4.0.1(@types/node@24.3.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       glob: 11.0.3
       jackspeak: 4.1.1
@@ -7244,7 +7273,7 @@ snapshots:
       sync-content: 2.0.1
       tap-parser: 18.0.0
       tshy: 3.0.3
-      typescript: 5.9.3
+      typescript: 5.5.4
       walk-up-path: 4.0.0
     transitivePeerDependencies:
       - '@swc/core'
@@ -7255,7 +7284,7 @@ snapshots:
 
   '@tapjs/test@4.0.1(@tapjs/core@4.0.1(@types/node@24.3.0)(react@18.3.1))(@types/node@24.3.0)(react@18.3.1)':
     dependencies:
-      '@isaacs/ts-node-temp-fork-for-pr-2009': 10.9.7(@types/node@24.3.0)(typescript@5.9.3)
+      '@isaacs/ts-node-temp-fork-for-pr-2009': 10.9.7(@types/node@24.3.0)(typescript@5.5.4)
       '@tapjs/after': 3.0.1(@tapjs/core@4.0.1(@types/node@24.3.0)(react@18.3.1))
       '@tapjs/after-each': 4.0.1(@tapjs/core@4.0.1(@types/node@24.3.0)(react@18.3.1))
       '@tapjs/asserts': 4.0.1(@tapjs/core@4.0.1(@types/node@24.3.0)(react@18.3.1))(react@18.3.1)
@@ -7271,7 +7300,7 @@ snapshots:
       '@tapjs/snapshot': 4.0.1(@tapjs/core@4.0.1(@types/node@24.3.0)(react@18.3.1))(react@18.3.1)
       '@tapjs/spawn': 4.0.1(@tapjs/core@4.0.1(@types/node@24.3.0)(react@18.3.1))
       '@tapjs/stdin': 4.0.1(@tapjs/core@4.0.1(@types/node@24.3.0)(react@18.3.1))
-      '@tapjs/typescript': 3.1.0(@tapjs/core@4.0.1(@types/node@24.3.0)(react@18.3.1))(@types/node@24.3.0)(typescript@5.9.3)
+      '@tapjs/typescript': 3.1.0(@tapjs/core@4.0.1(@types/node@24.3.0)(react@18.3.1))(@types/node@24.3.0)(typescript@5.5.4)
       '@tapjs/worker': 4.0.1(@tapjs/core@4.0.1(@types/node@24.3.0)(react@18.3.1))
       glob: 11.0.3
       jackspeak: 4.1.1
@@ -7282,7 +7311,7 @@ snapshots:
       sync-content: 2.0.1
       tap-parser: 18.0.0
       tshy: 3.0.3
-      typescript: 5.9.3
+      typescript: 5.5.4
       walk-up-path: 4.0.0
     transitivePeerDependencies:
       - '@swc/core'
@@ -7301,6 +7330,16 @@ snapshots:
       '@tapjs/core': 4.0.1(@types/node@24.3.0)(react@18.3.1)
       tsx: 4.20.5
 
+  '@tapjs/typescript@3.1.0(@tapjs/core@4.0.1(@types/node@20.19.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/node@20.19.11)(typescript@5.5.4)':
+    dependencies:
+      '@isaacs/ts-node-temp-fork-for-pr-2009': 10.9.7(@types/node@20.19.11)(typescript@5.5.4)
+      '@tapjs/core': 4.0.1(@types/node@20.19.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+    transitivePeerDependencies:
+      - '@swc/core'
+      - '@swc/wasm'
+      - '@types/node'
+      - typescript
+
   '@tapjs/typescript@3.1.0(@tapjs/core@4.0.1(@types/node@20.19.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/node@20.19.11)(typescript@5.9.3)':
     dependencies:
       '@isaacs/ts-node-temp-fork-for-pr-2009': 10.9.7(@types/node@20.19.11)(typescript@5.9.3)
@@ -7311,10 +7350,30 @@ snapshots:
       - '@types/node'
       - typescript
 
+  '@tapjs/typescript@3.1.0(@tapjs/core@4.0.1(@types/node@24.3.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/node@24.3.0)(typescript@5.5.4)':
+    dependencies:
+      '@isaacs/ts-node-temp-fork-for-pr-2009': 10.9.7(@types/node@24.3.0)(typescript@5.5.4)
+      '@tapjs/core': 4.0.1(@types/node@24.3.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+    transitivePeerDependencies:
+      - '@swc/core'
+      - '@swc/wasm'
+      - '@types/node'
+      - typescript
+
   '@tapjs/typescript@3.1.0(@tapjs/core@4.0.1(@types/node@24.3.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/node@24.3.0)(typescript@5.9.3)':
     dependencies:
       '@isaacs/ts-node-temp-fork-for-pr-2009': 10.9.7(@types/node@24.3.0)(typescript@5.9.3)
       '@tapjs/core': 4.0.1(@types/node@24.3.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+    transitivePeerDependencies:
+      - '@swc/core'
+      - '@swc/wasm'
+      - '@types/node'
+      - typescript
+
+  '@tapjs/typescript@3.1.0(@tapjs/core@4.0.1(@types/node@24.3.0)(react@18.3.1))(@types/node@24.3.0)(typescript@5.5.4)':
+    dependencies:
+      '@isaacs/ts-node-temp-fork-for-pr-2009': 10.9.7(@types/node@24.3.0)(typescript@5.5.4)
+      '@tapjs/core': 4.0.1(@types/node@24.3.0)(react@18.3.1)
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
@@ -7550,6 +7609,11 @@ snapshots:
 
   abbrev@2.0.0: {}
 
+  abitype@1.0.8(typescript@5.9.3)(zod@3.22.4):
+    optionalDependencies:
+      typescript: 5.9.3
+      zod: 3.22.4
+
   abitype@1.1.0(typescript@5.9.3)(zod@3.22.4):
     optionalDependencies:
       typescript: 5.9.3
@@ -7695,9 +7759,7 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
-  bn.js@4.12.2: {}
-
-  bn.js@5.2.2: {}
+  bn.js@5.2.3: {}
 
   body-parser@1.20.3:
     dependencies:
@@ -7732,7 +7794,7 @@ snapshots:
 
   borsh@0.7.0:
     dependencies:
-      bn.js: 5.2.2
+      bn.js: 5.2.3
       bs58: 4.0.1
       text-encoding-utf-8: 1.0.2
 
@@ -8020,7 +8082,7 @@ snapshots:
 
   elliptic@6.6.1:
     dependencies:
-      bn.js: 4.12.2
+      bn.js: 5.2.3
       brorand: 1.1.0
       hash.js: 1.1.7
       hmac-drbg: 1.0.1
@@ -9957,6 +10019,8 @@ snapshots:
       vscode-jsonrpc: 5.0.1
       vscode-languageserver-protocol: 3.17.5
 
+  typescript@5.5.4: {}
+
   typescript@5.9.3: {}
 
   uc.micro@2.1.0: {}
@@ -10041,7 +10105,7 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.1.0(typescript@5.9.3)(zod@3.22.4)
+      abitype: 1.0.8(typescript@5.9.3)(zod@3.22.4)
       isows: 1.0.7(ws@8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       ox: 0.8.1(typescript@5.9.3)(zod@3.22.4)
       ws: 8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)

--- a/scripts/.env.example
+++ b/scripts/.env.example
@@ -1,0 +1,6 @@
+# Solana keypair paths (relative to scripts/)
+PAYER_KEYPAIR_PATH=../keypairs/payer.json
+PAYTO_KEYPAIR_PATH=../keypairs/payto.json
+
+# Also set ADMIN_KEYPAIR_PATH for the facilitator (apps/facilitator/.env)
+# ADMIN_KEYPAIR_PATH=../../keypairs/admin.json

--- a/scripts/solana-example/ows-exact-payment.ts
+++ b/scripts/solana-example/ows-exact-payment.ts
@@ -1,6 +1,7 @@
 import "dotenv/config";
 import { logger, logResponse } from "../logger";
-import { Connection, Keypair, PublicKey, clusterApiUrl } from "@solana/web3.js";
+import { clusterApiUrl, Keypair, PublicKey } from "@solana/web3.js";
+import { createSolanaRpc } from "@solana/kit";
 import { bytesToHex } from "viem";
 import { createOWSSolanaWallet } from "@faremeter/wallet-ows";
 import {
@@ -57,12 +58,12 @@ logger.info(
   `OWS wallet "${WALLET_NAME}" address: ${wallet.publicKey.toBase58()}`,
 );
 
-const connection = new Connection(clusterApiUrl(network));
+const rpc = createSolanaRpc(clusterApiUrl(network));
 const mint = new PublicKey(usdcInfo.address);
 
 try {
   const fetchWithPayer = wrapFetch(fetch, {
-    handlers: [createPaymentHandler(wallet, mint, connection)],
+    handlers: [createPaymentHandler(wallet, mint, { rpc })],
   });
 
   const req = await fetchWithPayer("http://127.0.0.1:3000/protected");

--- a/scripts/solana-example/solana-exact-payment.ts
+++ b/scripts/solana-example/solana-exact-payment.ts
@@ -1,12 +1,12 @@
 import "dotenv/config";
 import { logResponse } from "../logger";
-import { Connection, Keypair, PublicKey } from "@solana/web3.js";
+import { clusterApiUrl, Keypair, PublicKey } from "@solana/web3.js";
+import { createSolanaRpc } from "@solana/kit";
 import { createLocalWallet } from "@faremeter/wallet-solana";
 import { lookupKnownSPLToken } from "@faremeter/info/solana";
 import { createPaymentHandler } from "@faremeter/payment-solana/exact";
 import { wrap as wrapFetch } from "@faremeter/fetch";
 import fs from "fs";
-import { clusterApiUrl } from "@solana/web3.js";
 
 const { PAYER_KEYPAIR_PATH } = process.env;
 
@@ -27,12 +27,11 @@ const keypair = Keypair.fromSecretKey(
   Uint8Array.from(JSON.parse(fs.readFileSync(PAYER_KEYPAIR_PATH, "utf-8"))),
 );
 
-const connection = new Connection(clusterApiUrl(network));
-
+const rpc = createSolanaRpc(clusterApiUrl(network));
 const mint = new PublicKey(usdcInfo.address);
 const wallet = await createLocalWallet(network, keypair);
 const fetchWithPayer = wrapFetch(fetch, {
-  handlers: [createPaymentHandler(wallet, mint, connection)],
+  handlers: [createPaymentHandler(wallet, mint, { rpc })],
 });
 
 const req = await fetchWithPayer("http://127.0.0.1:3000/protected");

--- a/scripts/solana-example/token2022-exact-payment.ts
+++ b/scripts/solana-example/token2022-exact-payment.ts
@@ -1,12 +1,12 @@
 import "dotenv/config";
 import { logResponse } from "../logger";
-import { Connection, Keypair, PublicKey } from "@solana/web3.js";
+import { clusterApiUrl, Keypair, PublicKey } from "@solana/web3.js";
+import { createSolanaRpc } from "@solana/kit";
 import { createLocalWallet } from "@faremeter/wallet-solana";
 import { lookupKnownSPLToken } from "@faremeter/info/solana";
 import { createPaymentHandler } from "@faremeter/payment-solana/exact";
 import { wrap as wrapFetch } from "@faremeter/fetch";
 import fs from "fs";
-import { clusterApiUrl } from "@solana/web3.js";
 
 const { PAYER_KEYPAIR_PATH } = process.env;
 
@@ -25,12 +25,11 @@ const keypair = Keypair.fromSecretKey(
   Uint8Array.from(JSON.parse(fs.readFileSync(PAYER_KEYPAIR_PATH, "utf-8"))),
 );
 
-const connection = new Connection(clusterApiUrl(network));
-
+const rpc = createSolanaRpc(clusterApiUrl(network));
 const mint = new PublicKey(pyusdInfo.address);
 const wallet = await createLocalWallet(network, keypair);
 const fetchWithPayer = wrapFetch(fetch, {
-  handlers: [createPaymentHandler(wallet, mint, connection)],
+  handlers: [createPaymentHandler(wallet, mint, { rpc })],
 });
 
 const req = await fetchWithPayer("http://127.0.0.1:3000/protected");


### PR DESCRIPTION
## Summary

Migrate the exact payment client in `payment-solana` from `@solana/spl-token` to `@solana-program/token` and `@solana-program/compute-budget` (v2 equivalents). Add a pnpm override forcing `bn.js` to `^5.2.3` to resolve the GHSA infinite loop vulnerability.

## Changes

### Exact client rewrite (`exact/client.ts`)
- `getAssociatedTokenAddressSync` → async `findAssociatedTokenPda`
- `createTransferCheckedInstruction` → `getTransferCheckedInstruction` + `toTransactionInstruction` bridge
- `ComputeBudgetProgram` → `@solana-program/compute-budget` equivalents
- `getMint` → `fetchMint` from `@solana-program/token`
- `Connection` parameter replaced with optional `rpc` in options (deprecated overload preserved)
- Removed `token` options (`allowOwnerOffCurve`, custom `programId`, `associatedTokenProgramId`); token program now derived from `extra.tokenProgram` or defaults to `TOKEN_PROGRAM_ADDRESS`

### Verify changes (`exact/verify.ts`)
- Import migration to `@solana-program/token` and `@solana-program/compute-budget`
- Memo instruction validation now conditional: only enforced when `extra.memo` is set (previously always required exactly 1 memo instruction)
- Removed blanket check that rejected transactions where the facilitator appeared in any instruction account — the specific checks on transfer authority and source ATA remain

### Updated call sites
- `packages/rides/src/solana.ts` — passes `rpc` via options instead of `Connection`
- Example scripts (`solana-exact-payment.ts`, `token2022-exact-payment.ts`, `ows-exact-payment.ts`) — updated to new `createPaymentHandler` signature

### Documentation
- `packages/payment-solana/README.md` — new usage guide, options reference, migration notes
- `QUICKSTART.md` — added exact payment script entries
- `scripts/.env.example` — new environment template

### Infrastructure
- `package.json` — pnpm override forcing `bn.js` to `^5.2.3` (resolves GHSA infinite loop vulnerability)

## Testing

- All 1544 tests pass (`make` clean through test phase)
- `toTransactionInstruction` bridge tested for all 4 `AccountRole` variants, data/no-data, accounts/no-accounts
- Deprecated `Connection` overload has a backward-compat test

🤖 Generated with [Claude Code](https://claude.com/claude-code)