### PR TITLE
FMTR-387 Prototype MPP sessions on Solana using Faremeter Flex

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -12,6 +12,320 @@ MPP is a settle-only flow; there is no separate verify step as there is with x40
 - Request body digest verification (MPP Spec Section 5.1.3) is not yet implemented.
 - Challenge replay protection (MPP Spec Section 11.3) is not yet implemented.
 
+## MPP `solana` / `session` intent
+
+Faremeter ships an experimental `session` intent handler for the `solana`
+method at `packages/payment-solana/src/session/`. It is settled against
+the [Faremeter Flex](https://github.com/faremeter/flex) escrow program,
+which is a generalised batched-authorization escrow rather than a
+purpose-built payment-channel program.
+
+The handler is **not** a conforming implementation of
+`draft-solana-session-00`. The reference spec assumes a payment-channel
+program (one cumulative `settled` watermark per channel, single-shot
+settle, payer-initiated grace-period close); Flex is structurally a
+different shape and the gaps between them cannot be closed by off-chain
+code alone.
+
+Where the spec is prescriptive about a particular wire format or field
+shape and Flex doesn't take a position, the handler can — and over time
+will — match the spec exactly. Where the spec depends on functionality
+the Flex on-chain program doesn't have, the handler diverges and this
+section documents why.
+
+### Functional gaps in Flex relative to the spec
+
+These are capabilities the spec depends on that Flex's on-chain program
+does not have. Closing them requires program changes, not handler
+changes.
+
+#### Cumulative-amount on-chain settlement
+
+The spec's `settle` instruction takes a voucher that attests to a
+cumulative total and pulls `cumulativeAmount - settled` to the payee in
+a single transaction. The Flex program has no instruction shaped this
+way. Each Flex settlement is a discrete `submit_authorization` for a
+fresh `(authorizationId, max_amount, splits)` tuple, two-phase, with a
+mandatory wait between phases. Cumulative-amount semantics are
+trackable off-chain but not enforceable on-chain — the Flex program
+will never refuse a duplicate or out-of-order claim against a
+cumulative watermark, because it has no concept of one.
+
+This is the deepest mismatch and the reason the handler carries
+Flex-specific fields (`mint`, `authorizationId`, `maxAmount`,
+`splits`) on the voucher payload alongside the spec-shaped
+`cumulativeAmount`. The signed bytes for the two views differ; a
+single signature cannot satisfy both claims.
+
+The direct consequence is that **the on-chain program never verifies
+the spec voucher's `cumulativeAmount` bytes**. Spec §"On-Chain
+Voucher Verification" MUSTs that channel programs verify the signed
+voucher message on chain via an `ed25519` precompile instruction
+and correlate the verified bytes to `channelId`, `cumulativeAmount`,
+and signer. Flex's `submit_authorization` instruction verifies a
+different byte layout (a packed binary over `programId`, `escrow`,
+`mint`, `maxAmount`, `authorizationId`, `expiresAtSlot`, and
+`splits`). The spec voucher signature is verified off-chain by the
+Faremeter session handler; nothing on chain ever consumes it.
+Closing this gap requires either (a) a Flex program change that
+adds a new settle path correlating an ed25519-verified spec voucher
+message to on-chain state, or (b) a second `ed25519` pre-verify
+instruction bundled with `submit_authorization` and a matching
+program-side check — neither of which are possible without touching
+the on-chain program.
+
+#### Payer-initiated immediate close with grace period
+
+The spec's `requestClose` lets the payer signal "I'm done, server has
+N minutes to drain pending vouchers, then refund the remainder." Flex
+does not have a payer-initiated close path that begins a grace
+window. Flex's `force_close` is gated on `last_activity_slot +
+deadman_timeout_slots` — that is, on inactivity, not on a payer
+request — so a payer who wants to leave a session that is still being
+served has no on-chain mechanism to do so. The closest equivalent is
+to stop submitting vouchers and wait for the deadman timeout to
+expire.
+
+#### No `closeRequestedAt` / `ClosedChannel` discriminator
+
+Spec §"Voucher Verification" steps 6 and 7 require the server to
+check, before accepting a voucher, that the channel's on-chain
+discriminator is not `ClosedChannel` and that `closeRequestedAt ==
+0`. Both are on-chain fields the spec's reference channel program
+maintains. Flex has neither. A Flex escrow lives in a single account
+shape from `create_escrow` until `finalize`/`refund`/`force_close`
+removes it; there is no in-band "closing" state the on-chain
+program surfaces, and there is no payer-initiated close request
+the spec's `closeRequestedAt` would reflect.
+
+The Faremeter handler approximates the spec's intent with an
+off-chain `SessionStatus` (`"open" | "closing" | "closed"`) carried
+in its `SessionStore`, and will reject voucher acceptance on
+channels whose off-chain status is not `"open"` once that
+enforcement is wired through `handleSettle`. This is sufficient
+**only when the handler is in-band for every close**. A close
+initiated directly on chain — for example, the Flex deadman path
+firing after `last_activity_slot + deadman_timeout_slots`, or a
+payer calling `refund` on an expired `PendingSettlement` — will
+not update the off-chain `SessionStatus` until the handler reads
+the escrow account back from RPC. Until that read happens, the
+handler will continue to accept vouchers against an escrow that
+has already been torn down on chain. Spec-literal enforcement
+would require a matching on-chain field; with Flex the closest
+available signal is "the escrow account no longer exists," which
+requires an RPC read per voucher to detect.
+
+#### MAX_PENDING = 16 ceiling
+
+The Flex program enforces a hard cap of 16 simultaneous unsettled
+authorizations per escrow. A workload that needs to push more than 16
+vouchers between server-side finalizations is back-pressured at the
+program level. The spec's single-watermark model has no equivalent
+ceiling; once a cumulative voucher is accepted, the server can take
+arbitrarily long to actually settle without blocking new vouchers.
+
+The handler exposes this as a non-spec extension Problem Details
+response so clients can back off and retry, but spec-compliant clients
+have no way to handle it.
+
+#### Settlement latency from `refund_timeout_slots`
+
+Flex's two-phase model holds settled funds in a `PendingSettlement`
+PDA for `refund_timeout_slots` before the merchant can call
+`finalize` to claim them. During that window the payer can call
+`refund` to reclaim the funds. The spec's `settle` is a single
+transaction with no mandatory waiting period — the merchant gets
+funds immediately. On Flex the merchant is exposed to a latency floor
+on every settlement equal to the refund window.
+
+#### Token-2022 transfer hooks
+
+The spec requires deposit, settle, and refund flows to resolve and
+include the extra accounts a Token-2022 transfer-hook program needs.
+The Flex program does not currently pass these accounts, so any token
+mint with a transfer-hook extension is unusable as a session asset.
+This is a hard capability gap, not a shape difference.
+
+#### Channel PDA seed binding
+
+The spec mandates (§"Channel State") that the channel PDA seeds bind
+the program ID, payer, payee, asset, authorized signer, and a
+client-chosen salt or nonce, and that "Relying on a client-declared
+`channelId` string alone is NOT sufficient." The Flex escrow PDA is
+derived from `(programId, "escrow", owner, index)` only — there is no
+slot for the payee, the asset (mint), or the authorized signer in the
+seed set. The Flex program will reject any attempt to create an
+escrow with seeds that include those fields, because the
+`seeds = [b"escrow", owner.key().as_ref(), &index.to_le_bytes()]`
+constraint is enforced at the program level.
+
+The handler re-derives the Flex PDA from `(owner, index)` and
+verifies the credential's `channelId` matches what the open
+transaction is creating, but the spec MUST that the channel address
+cryptographically binds payee/asset/signer cannot be satisfied
+without changing the on-chain program. A voucher signed for one
+Flex escrow cannot be replayed to another one (the voucher signature
+includes the escrow address), but the channel address by itself
+does not attest to the payee, asset, or signer.
+
+The same seed limitation means the spec's "Settlement Procedure /
+Open" step 6 requirement that the open transaction's payee match
+the challenge `recipient` cannot be verified against the escrow
+itself — the escrow is not a per-payee account and does not carry
+a payee field on chain. On Flex, a payee assertion only exists
+per-authorization via the `splits` array inside `submit_authorization`,
+which the handler can (and should) cross-check against the
+challenge's `defaultSplits` at voucher time. At open time there is
+no payee to check, because Flex doesn't model one.
+
+### Spec-aligned wire details
+
+These are places where the spec is opinionated, Flex has no on-chain
+stake, and the handler matches the spec wire format. They were
+realigned in this branch:
+
+- **Open credential schema**: spec §"Action: open" requires `payer`,
+  `depositAmount`, `transaction`, and an initial signed `voucher`.
+  The handler's `solanaSessionOpenPayload` carries all four; the
+  Flex extension on the open path is optional because Flex doesn't
+  need an on-chain authorization for a 0-cumulative initial voucher.
+- **TopUp credential schema**: spec §"Action: topUp" carries
+  `channelId`, `additionalAmount`, and `transaction`. The handler's
+  `solanaSessionTopUpPayload` matches; the field is named
+  `additionalAmount` per spec, not `additionalDeposit`.
+- **Voucher / close credential schemas**: spec §"Action: voucher"
+  and §"Action: close" carry `channelId` and the (optional, for
+  close) signed voucher only. No top-level `sessionKey` (the
+  sessionKey is implicit from the channel's authorized signer); the
+  voucher's `signer` field is the source of truth for who attested
+  to it.
+- **Voucher payload shape**: nested `voucher` object carrying spec
+  voucher data, with `signer`, `signature`, `signatureType: "ed25519"`
+  per spec §"Signed Voucher". Flex-specific authorization fields
+  live alongside under a sibling `flex` extension object documented
+  below.
+- **Voucher `expiresAt` enforcement**: the spec voucher data
+  `expiresAt` field (ISO 8601) is checked against the system clock
+  with a configurable skew tolerance per spec §"Voucher Verification"
+  step 9. The handler's `clockSkewSeconds` arg defaults to 30
+  seconds per spec §"Clock Skew".
+- **Voucher signing**: the client signs JCS-canonicalized voucher
+  data and encodes the signature as base58 per spec §"Voucher
+  Signing". The server verifies this signature first; the Flex
+  authorization signature is also carried and verified, because the
+  Flex on-chain `submit_authorization` instruction needs it. Both
+  signatures are produced by the same Ed25519 session key.
+- **Method-details field naming**: `channelProgram`, `decimals`,
+  `tokenProgram`, `feePayer`, `feePayerKey`, `minVoucherDelta`,
+  `ttlSeconds`, `gracePeriodSeconds`, `network` (restricted to
+  `mainnet-beta`/`devnet`/`localnet`), `channelId` follow the spec
+  exactly. Flex-specific configuration (`facilitator`,
+  `recentBlockhash`, `splits`, `refundTimeoutSlots`,
+  `deadmanTimeoutSlots`, `minGracePeriodSlots`) lives under a nested
+  `flex` sub-object so the spec slice stays clean.
+- **Receipt fields**: `mppReceipt` carries `intent`,
+  `acceptedCumulative`, `spent`, and `challengeId` as top-level
+  fields per spec §"Receipt Format". The `extra` map remains for
+  handler-specific data but the spec-defined fields are no longer
+  hidden inside it.
+- **Problem Details URIs**: error responses use
+  `https://paymentauth.org/problems/verification-failed` (and the
+  other two spec-defined types) per spec §"Error Responses". The
+  handler's `buildInsufficientHoldProblem` and
+  `buildSessionNotFoundProblem` both return `verification-failed`
+  with descriptive `detail` strings.
+- **`WWW-Authenticate` on error responses**: the handler exposes
+  `formatProblemResponse(problem, pricing, resourceURL)` which mints
+  a fresh challenge and attaches it as `WWW-Authenticate: Payment
+...` to the 402 response, satisfying the spec MUST that all error
+  responses include a fresh challenge.
+- **`Idempotency-Key` header support**: the handler exposes
+  `lookupIdempotent(challengeId, key)` and `recordIdempotent(...)`
+  for the protected-resource body callback to dedupe duplicate
+  requests per spec §"Concurrency and Idempotency". The
+  `(challengeId, key)` cache is in-memory.
+- **Per-channel serialization**: `tryRegisterVoucher` and
+  `chargeSession` are wrapped in a per-`channelId` mutex internally;
+  the handler also exposes `withChannelLock(channelId, fn)` for
+  application code that needs to serialize additional state-mutating
+  work against the same channel.
+- **Idempotent equal-cumulative voucher resubmission**: equal
+  resubmission returns success without state change; lower-cumulative
+  replays return success without reducing state per spec §"Concurrency
+  and Idempotency".
+- **Open-credential verification**: `handleSettle` for an `open`
+  action verifies the initial signed voucher per spec §"Voucher
+  Verification" (signature, channelId binding, optional
+  `expiresAt`), then decodes the wire transaction in
+  `payload.transaction`, locates the three Flex instructions
+  (`create_escrow`, `deposit`, `register_session_key`), re-derives
+  the escrow PDA from `(owner, index)` and verifies it matches the
+  credential's `channelId`, re-derives the vault and
+  session-key-account PDAs from the parsed instruction args, and
+  verifies all three instructions reference consistent accounts. The
+  voucher's `signer` field is the source of truth for the session
+  key that must be registered by `register_session_key`. This
+  satisfies the off-chain pre-broadcast portion of spec
+  §"Settlement Procedure / Open"; on-chain confirmation reads are
+  still deferred (see Deferred section below). The PDA seed binding
+  gap is documented under "Functional gaps in Flex" above and
+  cannot be closed off-chain.
+
+### Faremeter extension Problem Details
+
+The Flex on-chain back-pressure has no spec equivalent and is
+exposed as a Faremeter-namespaced extension Problem Details type
+clients can recognise:
+
+- `https://faremeter.org/problems/flex-pending-limit` — emitted when
+  the escrow already has the maximum 16 unsettled
+  `PendingSettlement` PDAs the Flex program enforces. Spec-compliant
+  clients have no way to handle this; only Faremeter-aware clients
+  can back off and retry.
+
+### Where Flex is a superset
+
+These are places where the spec is more restrictive than Flex. The
+handler exposes the spec slice by default and treats the extra
+capability as a Faremeter extension:
+
+- Multiple session keys per escrow (Flex allows up to 8; spec assumes
+  one `authorizedSigner`). The handler's `SessionStore` is keyed by
+  `channelId` alone, matching the spec's one-session-per-channel
+  model. Flex's multi-key feature is unused by the handler.
+- Multiple mints per escrow (Flex allows up to 8; spec assumes one
+  token per channel)
+- Per-authorization splits (Flex routes per-payment; spec assumes one
+  `payee` per channel)
+- Configurable per-escrow refund and deadman timeouts (Flex
+  parameterises both at create time; spec defines a single grace
+  period)
+
+### Deferred (not yet implemented in the handler)
+
+These are spec MUSTs that the handler does not currently satisfy.
+They're not blocked by Flex; they're just not done yet:
+
+- **On-chain confirmation reads after open**. The handler verifies
+  the open transaction's structure off-chain and re-derives the PDAs
+  it expects, but does not broadcast the transaction or read the
+  confirmed channel state back from RPC. Spec §"Settlement Procedure
+  / Open" requires both. (The `rpc` parameter on the handler is
+  unused for now.)
+- **`topUp` / `close` settlement paths**. The credential validators
+  exist for both actions and `handleSettle` returns a stub receipt,
+  but neither broadcasts to chain or updates session state.
+- **Background flush/finalize loop** for in-flight Flex
+  authorizations. Vouchers are accepted into the session store and
+  the `inFlightAuthorizationIds` list grows, but nothing actually
+  submits them to chain.
+- **Streaming-response receipts** (spec §"Receipt Format").
+- **Crash-safe persistence**. The default `SessionStore` is
+  in-memory; the spec MUSTs persistent storage of `acceptedCumulative`
+  before relying on a new voucher and `spent` before serving the
+  resource. The `SessionStore` interface is pluggable, so a durable
+  backend is straightforward to add.
+
 ## x402
 
 Faremeter supports both v1 and v2 of the x402 protocol. The middleware negotiates protocol versions automatically, preferring v2 when both sides support it. Adapters handle translation between versions, so handlers written against either version work transparently.

--- a/packages/middleware/src/common.test.ts
+++ b/packages/middleware/src/common.test.ts
@@ -140,6 +140,7 @@ await t.test("MPP digest binding", async (t) => {
       handleSettle: async () => ({
         status: "success" as const,
         method: "test-method",
+        intent: "test-intent",
         timestamp: new Date().toISOString(),
         reference: "ref",
       }),

--- a/packages/middleware/src/common.test.ts
+++ b/packages/middleware/src/common.test.ts
@@ -1,7 +1,22 @@
 #!/usr/bin/env pnpm tsx
 
 import t from "tap";
-import { findMatchingPaymentRequirements } from "./common";
+import {
+  findMatchingPaymentRequirements,
+  handleMiddlewareRequest,
+  resolveSupportedVersions,
+} from "./common";
+import type {
+  MPPMethodHandler,
+  mppChallengeParams,
+  mppCredential,
+} from "@faremeter/types/mpp";
+import {
+  AUTHORIZATION_HEADER,
+  MPP_PAYMENT_SCHEME,
+  serializeCredential,
+} from "@faremeter/types/mpp";
+import type { ResourcePricing } from "@faremeter/types/pricing";
 
 await t.test("findMatchingPaymentRequirements", async (t) => {
   await t.test(
@@ -94,6 +109,129 @@ await t.test("findMatchingPaymentRequirements", async (t) => {
     t.equal(result, undefined, "should not match different networks");
     t.end();
   });
+
+  t.end();
+});
+
+await t.test("MPP digest binding", async (t) => {
+  const pricing: ResourcePricing[] = [
+    {
+      amount: "1",
+      asset: "test-asset",
+      recipient: "test-recipient",
+      network: "test-network",
+    },
+  ];
+
+  const makeHandler = (challengeDigest?: string): MPPMethodHandler => {
+    const challenge: mppChallengeParams = {
+      id: "challenge-id",
+      realm: "test",
+      method: "test-method",
+      intent: "test-intent",
+      request: "req",
+      ...(challengeDigest !== undefined ? { digest: challengeDigest } : {}),
+    };
+    return {
+      method: "test-method",
+      capabilities: { networks: [], assets: [] },
+      getSupportedIntents: () => ["test-intent"],
+      getChallenge: async () => challenge,
+      handleSettle: async () => ({
+        status: "success" as const,
+        method: "test-method",
+        timestamp: new Date().toISOString(),
+        reference: "ref",
+      }),
+    };
+  };
+
+  const runRequest = async (args: {
+    handler: MPPMethodHandler;
+    body: ArrayBuffer | null;
+    credentialDigest?: string;
+  }) => {
+    const pricingEntry = pricing[0];
+    if (!pricingEntry) throw new Error("pricing entry missing");
+    const challenge = await args.handler.getChallenge(
+      "test-intent",
+      pricingEntry,
+      "http://test/resource",
+    );
+    const credential: mppCredential = {
+      challenge: {
+        ...challenge,
+        ...(args.credentialDigest !== undefined
+          ? { digest: args.credentialDigest }
+          : {}),
+      },
+      payload: {},
+    };
+    const authHeader = `${MPP_PAYMENT_SCHEME} ${serializeCredential(credential)}`;
+
+    let bodyCalled = false;
+    let lastStatus: number | undefined;
+
+    await handleMiddlewareRequest<string>({
+      mppMethodHandlers: [args.handler],
+      pricing,
+      resource: "http://test/resource",
+      supportedVersions: resolveSupportedVersions(undefined),
+      getHeader: (key) =>
+        key.toLowerCase() === AUTHORIZATION_HEADER.toLowerCase()
+          ? authHeader
+          : undefined,
+      getBody: async () => args.body,
+      sendJSONResponse: (status) => {
+        lastStatus = status;
+        return `status:${status}`;
+      },
+      body: async () => {
+        bodyCalled = true;
+        return "ok";
+      },
+    });
+
+    return { bodyCalled, lastStatus };
+  };
+
+  await t.test(
+    "challenge without digest accepts body-bearing request",
+    async (t) => {
+      const body = new TextEncoder().encode(
+        JSON.stringify({ hello: "world" }),
+      ).buffer;
+      const result = await runRequest({
+        handler: makeHandler(),
+        body,
+      });
+      t.ok(
+        result.bodyCalled,
+        "body callback should fire when challenge has no digest",
+      );
+      t.end();
+    },
+  );
+
+  await t.test(
+    "challenge with digest still enforces match against body",
+    async (t) => {
+      const body = new TextEncoder().encode(
+        JSON.stringify({ hello: "world" }),
+      ).buffer;
+      const result = await runRequest({
+        handler: makeHandler("sha-256=:wrong:"),
+        body,
+        credentialDigest: "sha-256=:wrong:",
+      });
+      t.notOk(
+        result.bodyCalled,
+        "body callback should not fire when digests mismatch request body",
+      );
+      t.equal(result.lastStatus, 402, "should re-challenge on digest mismatch");
+      t.end();
+    },
+  );
 
   t.end();
 });

--- a/packages/middleware/src/common.ts
+++ b/packages/middleware/src/common.ts
@@ -949,10 +949,13 @@ async function handleMPPRequest<MiddlewareResponse>(
     return args.sendJSONResponse(402, undefined, headers);
   };
 
-  // Per spec Section 5.1.3: reject credential if digests don't match.
-  // Both directions: credential has digest but server doesn't (or vice versa),
-  // and digest values differ.
-  if (credential.challenge.digest !== undefined || digest !== undefined) {
+  // Per Payment HTTP Auth Section 11.2, the server SHOULD include the
+  // digest parameter in the challenge when the request has a body. Binding
+  // is therefore opt-in on the server: only enforce the check when the
+  // challenge carries a digest. This lets long-lived session challenges
+  // (minted once, no body) be reused across POST requests carrying
+  // per-call bodies.
+  if (credential.challenge.digest !== undefined) {
     if (credential.challenge.digest !== digest) {
       logger.warning("MPP credential digest does not match request body");
       return sendPaymentRequired();

--- a/packages/payment-solana/package.json
+++ b/packages/payment-solana/package.json
@@ -48,6 +48,7 @@
     "typescript-language-server": "catalog:"
   },
   "dependencies": {
+    "@faremeter/flex-solana": "catalog:",
     "@faremeter/info": "workspace:^",
     "@faremeter/logs": "workspace:^",
     "@faremeter/types": "workspace:^",

--- a/packages/payment-solana/package.json
+++ b/packages/payment-solana/package.json
@@ -33,6 +33,11 @@
       "require": "./dist/src/charge/index.js",
       "import": "./dist/src/charge/index.js",
       "types": "./dist/src/charge/index.d.ts"
+    },
+    "./session": {
+      "require": "./dist/src/session/index.js",
+      "import": "./dist/src/session/index.js",
+      "types": "./dist/src/session/index.d.ts"
     }
   },
   "devDependencies": {
@@ -64,7 +69,8 @@
     "@solana/spl-token": "catalog:",
     "@solana/transactions": "catalog:",
     "@solana/web3.js": "catalog:",
-    "arktype": "catalog:"
+    "arktype": "catalog:",
+    "bs58": "catalog:"
   },
   "tap": {
     "plugin": [

--- a/packages/payment-solana/src/charge/server.ts
+++ b/packages/payment-solana/src/charge/server.ts
@@ -317,6 +317,7 @@ export async function createMPPSolanaChargeHandler(
       return {
         status: "success",
         method: "solana",
+        intent: "charge",
         timestamp: new Date().toISOString(),
         reference: validatedPayload.signature,
       };
@@ -358,6 +359,7 @@ export async function createMPPSolanaChargeHandler(
     return {
       status: "success",
       method: "solana",
+      intent: "charge",
       timestamp: new Date().toISOString(),
       reference: txResult.signature,
     };
@@ -540,6 +542,7 @@ export async function createMPPSolanaNativeChargeHandler(
       return {
         status: "success",
         method: "solana",
+        intent: "charge",
         timestamp: new Date().toISOString(),
         reference: validatedPayload.signature,
       };
@@ -581,6 +584,7 @@ export async function createMPPSolanaNativeChargeHandler(
     return {
       status: "success",
       method: "solana",
+      intent: "charge",
       timestamp: new Date().toISOString(),
       reference: txResult.signature,
     };

--- a/packages/payment-solana/src/charge/server.ts
+++ b/packages/payment-solana/src/charge/server.ts
@@ -9,6 +9,8 @@ import {
   encodeBase64URL,
   canonicalizeSortedJSON,
   decodeBase64URL,
+  generateChallengeID,
+  verifyChallengeID,
 } from "@faremeter/types/mpp";
 import type { ResourcePricing } from "@faremeter/types/pricing";
 import { isValidationError } from "@faremeter/types";
@@ -43,48 +45,6 @@ import {
   verifyNativeChargeTransaction,
 } from "./verify";
 import { logger } from "./logger";
-
-async function generateChallengeID(
-  secret: Uint8Array,
-  params: Omit<mppChallengeParams, "id">,
-): Promise<string> {
-  const slots = [
-    params.realm,
-    params.method,
-    params.intent,
-    params.request,
-    params.expires ?? "",
-    params.digest ?? "",
-    params.opaque ?? "",
-  ];
-  // Per spec: pipe-delimited. Safe because slot values are either
-  // server-controlled constants or base64url-encoded (no pipe chars).
-  const message = new TextEncoder().encode(slots.join("|"));
-  const keyData = new Uint8Array(secret);
-  const key = await crypto.subtle.importKey(
-    "raw",
-    keyData,
-    { name: "HMAC", hash: "SHA-256" },
-    false,
-    ["sign"],
-  );
-  const sig = await crypto.subtle.sign("HMAC", key, message);
-  return encodeBase64URL(String.fromCharCode(...new Uint8Array(sig)));
-}
-
-async function verifyChallengeID(
-  secret: Uint8Array,
-  params: mppChallengeParams,
-): Promise<boolean> {
-  const { id, ...rest } = params;
-  const computed = await generateChallengeID(secret, rest);
-  const encoder = new TextEncoder();
-  const a = encoder.encode(computed);
-  const b = encoder.encode(id);
-  if (a.byteLength !== b.byteLength) return false;
-  const { timingSafeEqual } = await import("node:crypto");
-  return timingSafeEqual(a, b);
-}
 
 export type CreateMPPSolanaChargeHandlerArgs = {
   network: string | SolanaCAIP2Network;

--- a/packages/payment-solana/src/session/client.test.ts
+++ b/packages/payment-solana/src/session/client.test.ts
@@ -1,0 +1,179 @@
+#!/usr/bin/env pnpm tsx
+
+// Forward spec-conformance test: the client must produce credentials
+// whose payloads validate against the server's spec-shaped validators.
+// draft-solana-session-00 §"Action: open" requires the open credential
+// to carry `payer`, `depositAmount`, `transaction`, AND an initial
+// signed `voucher`. This test asserts the round trip end-to-end via
+// the public client/server APIs without touching any RPC.
+
+import t from "tap";
+import {
+  address,
+  generateKeyPairSigner,
+  type Rpc,
+  type SolanaRpcApi,
+} from "@solana/kit";
+import type { webcrypto } from "node:crypto";
+import bs58 from "bs58";
+
+import { createMPPSolanaSessionClient } from "./client";
+import { createMPPSolanaSessionHandler } from "./server";
+import { solanaSessionPayload, solanaSessionRequest } from "./common";
+import { isValidationError } from "@faremeter/types";
+import { SESSION_INTENT, decodeBase64URL } from "@faremeter/types/mpp";
+import { FLEX_PROGRAM_ADDRESS } from "@faremeter/flex-solana";
+
+type SessionKeyPair = webcrypto.CryptoKeyPair;
+
+const MINT = address("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v");
+const RECIPIENT = address("3QFU3r76XiQVdqkaX5K6FWkDyiBKN7EK3UjRSWxMXHt3");
+const ESCROW = address("9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM");
+
+const stubRpc = {} as unknown as Rpc<SolanaRpcApi>;
+
+async function makeClientServerEnv() {
+  const facilitatorSigner = await generateKeyPairSigner();
+  const handler = await createMPPSolanaSessionHandler({
+    network: "solana-devnet",
+    rpc: stubRpc,
+    facilitatorSigner,
+    supportedMints: [MINT],
+    mintDecimals: 6,
+    defaultSplits: [{ recipient: RECIPIENT.toString(), bps: 10000 }],
+    realm: "test",
+    secretKey: new TextEncoder().encode("client-test-secret"),
+    refundTimeoutSlots: 150n,
+    deadmanTimeoutSlots: 1000n,
+    minGracePeriodSlots: 150n,
+    challengeExpiresSeconds: 3600,
+    maxRetries: 1,
+    retryDelayMs: 1,
+    flushIntervalMs: 1000,
+    programAddress: FLEX_PROGRAM_ADDRESS,
+  });
+
+  const sessionKeyPair = (await crypto.subtle.generateKey("Ed25519", true, [
+    "sign",
+    "verify",
+  ])) as SessionKeyPair;
+  const raw = new Uint8Array(
+    await crypto.subtle.exportKey("raw", sessionKeyPair.publicKey),
+  );
+  const sessionKeyAddress = address(bs58.encode(raw));
+
+  const walletSigner = await generateKeyPairSigner();
+  const wallet = { address: walletSigner.address };
+
+  const depositAmount = 1_000_000n;
+
+  const client = createMPPSolanaSessionClient({
+    wallet,
+    sessionKeyPair,
+    sessionKeyAddress,
+    programAddress: FLEX_PROGRAM_ADDRESS,
+    buildOpenTransaction: async () => ({
+      // The client test does not exercise verifyFlexOpenTransaction
+      // (which lives behind the server's handleSettle). The dedicated
+      // middleware integration test in tests/mpp-session/ wires a real
+      // wire transaction through the verify path.
+      transaction: "AA",
+      escrow: ESCROW,
+      mint: MINT,
+      depositAmount,
+      payer: wallet.address,
+    }),
+  });
+
+  return {
+    handler,
+    client,
+    wallet,
+    sessionKeyPair,
+    sessionKeyAddress,
+    depositAmount,
+  };
+}
+
+await t.test(
+  "spec §Action: open — client emits a credential payload that validates",
+  async (t) => {
+    const env = await makeClientServerEnv();
+
+    const challenge = await env.handler.getChallenge(
+      SESSION_INTENT,
+      {
+        amount: "25",
+        asset: MINT.toString(),
+        recipient: RECIPIENT.toString(),
+        network: "solana-devnet",
+      },
+      "http://test/api",
+    );
+
+    const requestParsed = solanaSessionRequest(
+      JSON.parse(decodeBase64URL(challenge.request)),
+    );
+    if (isValidationError(requestParsed)) {
+      throw new Error(
+        `server emitted a request that fails its own validator: ${requestParsed.summary}`,
+      );
+    }
+
+    const execer = await env.client(challenge);
+    if (!execer) {
+      throw new Error("client refused a session-intent solana challenge");
+    }
+
+    const credential = await execer.exec();
+    const validated = solanaSessionPayload(credential.payload);
+
+    t.notOk(
+      isValidationError(validated),
+      "client open credential payload must validate against solanaSessionPayload",
+    );
+
+    if (!isValidationError(validated)) {
+      t.equal(
+        validated.action,
+        "open",
+        "credential payload must carry the open action",
+      );
+      if (validated.action === "open") {
+        t.equal(
+          validated.channelId,
+          ESCROW.toString(),
+          "credential channelId must match the escrow returned by buildOpenTransaction",
+        );
+        t.equal(
+          validated.payer,
+          env.wallet.address.toString(),
+          "credential payer must match the wallet address",
+        );
+        t.equal(
+          validated.depositAmount,
+          env.depositAmount.toString(),
+          "credential depositAmount must match the value buildOpenTransaction returned",
+        );
+        t.equal(
+          validated.voucher.signer,
+          env.sessionKeyAddress.toString(),
+          "initial voucher must be signed by the session key",
+        );
+        t.equal(
+          validated.voucher.voucher.cumulativeAmount,
+          "0",
+          "initial voucher cumulative amount must be 0",
+        );
+        t.equal(
+          validated.voucher.voucher.channelId,
+          ESCROW.toString(),
+          "initial voucher channelId must match the credential channelId",
+        );
+      }
+    }
+
+    void requestParsed;
+    t.end();
+  },
+);

--- a/packages/payment-solana/src/session/client.ts
+++ b/packages/payment-solana/src/session/client.ts
@@ -1,0 +1,359 @@
+import type {
+  MPPPaymentHandler,
+  MPPPaymentExecer,
+  mppChallengeParams,
+  mppCredential,
+} from "@faremeter/types/mpp";
+import {
+  decodeBase64URL,
+  SESSION_INTENT,
+  serializeCredential,
+} from "@faremeter/types/mpp";
+import { isValidationError } from "@faremeter/types";
+import { address, type Address } from "@solana/kit";
+import type { webcrypto } from "node:crypto";
+
+type SessionKeyPair = webcrypto.CryptoKeyPair;
+
+import bs58 from "bs58";
+import { solanaSessionRequest } from "./common";
+import { serializeSpecVoucherMessage, serializeVoucherMessage } from "./verify";
+import { type flexPendingLimitProblem } from "./problem";
+import { logger } from "./logger";
+
+export class SessionExpiredError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SessionExpiredError";
+  }
+}
+
+type ClientSessionState = {
+  challenge: mppChallengeParams;
+  escrow: Address;
+  sessionKey: Address;
+  mint: Address;
+  acceptedCumulative: bigint;
+  /**
+   * Splits the server expects on every Flex authorization. Read from
+   * the challenge's `methodDetails.flex.splits` at open time and
+   * applied to every voucher this client builds for this channel —
+   * the handler cross-checks the client's splits against its own
+   * `defaultSplits`, and any mismatch is rejected.
+   */
+  splits: { recipient: string; bps: number }[];
+};
+
+export type SessionClientWallet = {
+  address: Address;
+};
+
+export type CreateMPPSolanaSessionClientArgs = {
+  wallet: SessionClientWallet;
+  sessionKeyPair: SessionKeyPair;
+  sessionKeyAddress: Address;
+  programAddress: Address;
+  /**
+   * Builds the initial session open transaction. Returns the base64
+   * wire transaction plus the escrow address the server should see,
+   * the mint, the payer pubkey, and the deposit amount the open
+   * transaction encodes. The payer and depositAmount are spec-required
+   * fields on the open credential per draft-solana-session-00 §"Action:
+   * open".
+   */
+  buildOpenTransaction: (args: {
+    challenge: mppChallengeParams;
+    request: solanaSessionRequest;
+    sessionKey: Address;
+  }) => Promise<{
+    transaction: string;
+    escrow: Address;
+    mint: Address;
+    payer: Address;
+    depositAmount: bigint;
+  }>;
+  /**
+   * TTL (seconds) applied to the `expiresAt` field on every signed
+   * voucher the client produces. draft-solana-session-00 §"Delegated
+   * Signer Risks" MUSTs that delegated keys be treated as short-lived
+   * single-session credentials — a finite TTL bounds exposure if the
+   * session key is compromised. Recommended: on the order of minutes.
+   * Defaults to 300s (5 minutes).
+   */
+  voucherTTLSeconds?: number;
+};
+
+export type MPPSolanaSessionClient = MPPPaymentHandler & {
+  /**
+   * Handles a `verification-failed` Problem Details response that the
+   * server emitted because the session's accepted cumulative would
+   * exceed the deposit. Returns a fresh `Authorization: Payment ...`
+   * header value carrying a new voucher with the additional delta the
+   * caller specifies.
+   */
+  handleInsufficientHold(args: {
+    channelId: string;
+    requiredTopUp: bigint;
+  }): Promise<string>;
+  /**
+   * Handles a Faremeter `flex-pending-limit` Problem Details response.
+   * Returns a fresh Authorization header after polling for the pending
+   * count to drop. The caller chooses the back-off policy.
+   */
+  handlePendingLimit(problem: flexPendingLimitProblem): Promise<string>;
+  /**
+   * Handles a `verification-failed` Problem Details response that the
+   * server emitted because the channel is not present in its session
+   * store. Throws SessionExpiredError so the application can re-open.
+   */
+  handleSessionNotFound(channelId: string): never;
+  readonly sessions: ReadonlyMap<string, ClientSessionState>;
+};
+
+function sessionKey(escrow: Address, sessionKeyAddress: Address): string {
+  return `${escrow.toString()}:${sessionKeyAddress.toString()}`;
+}
+
+export function createMPPSolanaSessionClient(
+  args: CreateMPPSolanaSessionClientArgs,
+): MPPSolanaSessionClient {
+  const sessions = new Map<string, ClientSessionState>();
+  const voucherTTLSeconds = args.voucherTTLSeconds ?? 300;
+  const nowISOPlusTTL = (): string =>
+    new Date(Date.now() + voucherTTLSeconds * 1000).toISOString();
+
+  const handler: MPPPaymentHandler = async (
+    challenge: mppChallengeParams,
+  ): Promise<MPPPaymentExecer | null> => {
+    if (challenge.method !== "solana") return null;
+    if (challenge.intent !== SESSION_INTENT) return null;
+
+    let requestBody: unknown;
+    try {
+      requestBody = JSON.parse(decodeBase64URL(challenge.request));
+    } catch {
+      return null;
+    }
+    const request = solanaSessionRequest(requestBody);
+    if (isValidationError(request)) return null;
+
+    return {
+      challenge,
+      exec: async (): Promise<mppCredential> => {
+        const built = await args.buildOpenTransaction({
+          challenge,
+          request,
+          sessionKey: args.sessionKeyAddress,
+        });
+        const state: ClientSessionState = {
+          challenge,
+          escrow: built.escrow,
+          sessionKey: args.sessionKeyAddress,
+          mint: built.mint,
+          acceptedCumulative: 0n,
+          splits: request.methodDetails.flex.splits,
+        };
+        sessions.set(sessionKey(built.escrow, args.sessionKeyAddress), state);
+
+        // draft-solana-session-00 §"Action: open" requires the open
+        // credential to carry an initial signed voucher. The initial
+        // voucher's cumulativeAmount is 0; the spec voucher signature
+        // is computed over JCS-canonicalized voucher data and base58
+        // encoded. Spec §"Delegated Signer Risks" MUSTs a finite TTL.
+        const initialExpiresAt = nowISOPlusTTL();
+        const initialVoucherMessage = serializeSpecVoucherMessage({
+          channelId: built.escrow.toString(),
+          cumulativeAmount: "0",
+          expiresAt: initialExpiresAt,
+        });
+        const initialVoucherSig = new Uint8Array(
+          await crypto.subtle.sign(
+            "Ed25519",
+            args.sessionKeyPair.privateKey,
+            initialVoucherMessage,
+          ),
+        );
+
+        return {
+          challenge,
+          payload: {
+            action: "open",
+            channelId: built.escrow.toString(),
+            payer: built.payer.toString(),
+            depositAmount: built.depositAmount.toString(),
+            transaction: built.transaction,
+            voucher: {
+              voucher: {
+                channelId: built.escrow.toString(),
+                cumulativeAmount: "0",
+                expiresAt: initialExpiresAt,
+              },
+              signer: args.sessionKeyAddress.toString(),
+              signature: bs58.encode(initialVoucherSig),
+              signatureType: "ed25519",
+            },
+          },
+        };
+      },
+    };
+  };
+
+  const buildVoucherCredential = async (
+    state: ClientSessionState,
+    delta: bigint,
+  ): Promise<string> => {
+    const newCumulative = state.acceptedCumulative + delta;
+    const authorizationId = randomU64();
+    // Flex's on-chain `expiresAtSlot` is a slot number; we have no
+    // Clock read from here and the server's RPC will supply one if
+    // it needs to bind the authorization. For now we pass 0 (no
+    // slot-level expiry); the spec voucher `expiresAt` below bounds
+    // the delegated key's exposure regardless.
+    const expiresAtSlot = 0n;
+    const expiresAt = nowISOPlusTTL();
+
+    // 1. Spec voucher: JCS canonicalized, base58 signature, with a
+    // finite TTL per §"Delegated Signer Risks".
+    const specMessage = serializeSpecVoucherMessage({
+      channelId: state.escrow.toString(),
+      cumulativeAmount: newCumulative.toString(),
+      expiresAt,
+    });
+    const specSig = new Uint8Array(
+      await crypto.subtle.sign(
+        "Ed25519",
+        args.sessionKeyPair.privateKey,
+        specMessage,
+      ),
+    );
+    const specSignature = bs58.encode(specSig);
+
+    // 2. Flex authorization: packed binary, base64 signature. Splits
+    // come from the challenge the channel was opened against, not from
+    // the client — the handler cross-checks them against its
+    // `defaultSplits` and rejects any mismatch.
+    const flexMessage = serializeVoucherMessage({
+      programAddress: args.programAddress,
+      escrow: state.escrow,
+      mint: state.mint,
+      maxAmount: delta,
+      authorizationId,
+      expiresAtSlot,
+      splits: state.splits.map((s) => ({
+        recipient: address(s.recipient),
+        bps: s.bps,
+      })),
+    });
+    const flexSig = new Uint8Array(
+      await crypto.subtle.sign(
+        "Ed25519",
+        args.sessionKeyPair.privateKey,
+        flexMessage,
+      ),
+    );
+    const flexSignature = bytesToBase64(flexSig);
+
+    state.acceptedCumulative = newCumulative;
+
+    // draft-solana-session-00 §"Action: voucher" defines exactly three
+    // fields on the voucher credential payload: `action`, `channelId`,
+    // and the signed `voucher`. The Flex authorization extension rides
+    // alongside as a Faremeter extension under `flex`. No other
+    // top-level keys belong here.
+    const credential: mppCredential = {
+      challenge: state.challenge,
+      payload: {
+        action: "voucher",
+        channelId: state.escrow.toString(),
+        voucher: {
+          voucher: {
+            channelId: state.escrow.toString(),
+            cumulativeAmount: newCumulative.toString(),
+            expiresAt,
+          },
+          signer: state.sessionKey.toString(),
+          signature: specSignature,
+          signatureType: "ed25519",
+        },
+        flex: {
+          mint: state.mint.toString(),
+          authorizationId: authorizationId.toString(),
+          maxAmount: delta.toString(),
+          expiresAtSlot: expiresAtSlot.toString(),
+          splits: state.splits,
+          signature: flexSignature,
+        },
+      },
+    };
+    return `Payment ${serializeCredential(credential)}`;
+  };
+
+  return Object.assign(handler, {
+    sessions,
+    handleInsufficientHold: async (args: {
+      channelId: string;
+      requiredTopUp: bigint;
+    }) => {
+      const state = findSession(sessions, args.channelId);
+      if (!state) {
+        throw new SessionExpiredError(
+          `no cached session state for ${args.channelId}`,
+        );
+      }
+      return buildVoucherCredential(state, args.requiredTopUp);
+    },
+    handlePendingLimit: async (problem: flexPendingLimitProblem) => {
+      logger.info("pending-limit problem received, backing off", {
+        channelId: problem.channelId,
+        pendingCount: problem.pendingCount,
+      });
+      const state = findSession(sessions, problem.channelId);
+      if (!state) {
+        throw new SessionExpiredError(
+          `no cached session state for ${problem.channelId}`,
+        );
+      }
+      return buildVoucherCredential(state, 0n);
+    },
+    handleSessionNotFound: (channelId: string): never => {
+      const iterKey = [...sessions.keys()].find((k) =>
+        k.startsWith(`${channelId}:`),
+      );
+      if (iterKey) sessions.delete(iterKey);
+      throw new SessionExpiredError(
+        `server reported session not found for ${channelId}`,
+      );
+    },
+  });
+}
+
+function findSession(
+  sessions: Map<string, ClientSessionState>,
+  channelId: string,
+): ClientSessionState | undefined {
+  for (const [k, v] of sessions) {
+    if (k.startsWith(`${channelId}:`)) return v;
+  }
+  return undefined;
+}
+
+function randomU64(): bigint {
+  const buf = new Uint8Array(8);
+  crypto.getRandomValues(buf);
+  let out = 0n;
+  for (let i = 0; i < 8; i++) {
+    out = (out << 8n) | BigInt(buf[i] ?? 0);
+  }
+  return out;
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = "";
+  for (const b of bytes) binary += String.fromCharCode(b);
+  return btoa(binary);
+}
+
+// `address` is imported so the public API can type-narrow user-supplied
+// strings at the edges; keep it referenced even if unused by the current
+// body.
+void address;

--- a/packages/payment-solana/src/session/common.test.ts
+++ b/packages/payment-solana/src/session/common.test.ts
@@ -1,0 +1,188 @@
+#!/usr/bin/env pnpm tsx
+
+// Forward spec-conformance tests for the Solana session credential
+// payloads. Each test asserts the spec-correct shape from
+// draft-solana-session-00 §"Credential Schema" / §"Action: *". Failing
+// tests document a wire-format divergence between the handler's
+// validators and the spec.
+
+import t from "tap";
+import { isValidationError } from "@faremeter/types";
+import {
+  solanaSessionOpenPayload,
+  solanaSessionTopUpPayload,
+  solanaSessionVoucherPayload,
+  solanaSessionClosePayload,
+} from "./common";
+
+const CHANNEL = "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM";
+const SIGNER = "DFo9vd1eiRFGQuCkReqvZvRPJVwwYu8NwCiaa9tB5pWZ";
+
+const minimalSpecVoucher = {
+  voucher: {
+    channelId: CHANNEL,
+    cumulativeAmount: "100",
+  },
+  signer: SIGNER,
+  signature: "1".repeat(88),
+  signatureType: "ed25519" as const,
+};
+
+await t.test(
+  "spec §Action: open — minimal spec-shaped credential validates",
+  (t) => {
+    const result = solanaSessionOpenPayload({
+      action: "open",
+      channelId: CHANNEL,
+      payer: "owner-pubkey",
+      depositAmount: "1000000",
+      transaction: "base64transactionbytes",
+      voucher: minimalSpecVoucher,
+    });
+    t.notOk(
+      isValidationError(result),
+      "spec-shaped open credential must validate",
+    );
+    t.end();
+  },
+);
+
+await t.test(
+  "spec §Action: topUp — minimal spec-shaped credential validates",
+  (t) => {
+    const result = solanaSessionTopUpPayload({
+      action: "topUp",
+      channelId: CHANNEL,
+      additionalAmount: "500000",
+      transaction: "base64topupbytes",
+    });
+    t.notOk(
+      isValidationError(result),
+      "spec-shaped topUp credential must validate",
+    );
+    t.end();
+  },
+);
+
+await t.test(
+  "spec §Action: voucher — minimal spec-shaped credential validates",
+  (t) => {
+    // Spec §"Action: voucher" carries `action`, `channelId`, and the
+    // signed voucher object only. The `flex` extension is a Faremeter
+    // extension and MUST NOT be required for the credential to
+    // validate.
+    const result = solanaSessionVoucherPayload({
+      action: "voucher",
+      channelId: CHANNEL,
+      voucher: minimalSpecVoucher,
+    });
+    t.notOk(
+      isValidationError(result),
+      "spec-shaped voucher credential must validate without a Flex extension",
+    );
+    t.end();
+  },
+);
+
+await t.test(
+  "spec §Action: close — minimal spec-shaped credential without voucher validates",
+  (t) => {
+    // Spec §"Action: close" makes `voucher` OPTIONAL and does not
+    // define a `closeTransaction` field. A close credential carrying
+    // only `action` and `channelId` MUST validate.
+    const result = solanaSessionClosePayload({
+      action: "close",
+      channelId: CHANNEL,
+    });
+    t.notOk(
+      isValidationError(result),
+      "spec-shaped bare close credential must validate",
+    );
+    t.end();
+  },
+);
+
+await t.test(
+  "spec §Action: close — spec-shaped credential with optional voucher validates",
+  (t) => {
+    const result = solanaSessionClosePayload({
+      action: "close",
+      channelId: CHANNEL,
+      voucher: minimalSpecVoucher,
+    });
+    t.notOk(
+      isValidationError(result),
+      "spec-shaped close credential with voucher must validate",
+    );
+    t.end();
+  },
+);
+
+await t.test(
+  "spec §Voucher Format / Voucher Data — voucher cumulativeAmount rejects decimals and negatives",
+  (t) => {
+    // draft-solana-session-00 §"Voucher Format / Voucher Data"
+    // specifies cumulativeAmount as a "total amount in base units".
+    // Base units are non-negative integers; decimals and negatives
+    // are not meaningful and must be rejected by the validator.
+    const decimal = solanaSessionVoucherPayload({
+      action: "voucher",
+      channelId: CHANNEL,
+      voucher: {
+        ...minimalSpecVoucher,
+        voucher: {
+          channelId: CHANNEL,
+          cumulativeAmount: "1.5",
+        },
+      },
+    });
+    t.ok(
+      isValidationError(decimal),
+      "cumulativeAmount with a decimal point must be rejected",
+    );
+
+    const negative = solanaSessionVoucherPayload({
+      action: "voucher",
+      channelId: CHANNEL,
+      voucher: {
+        ...minimalSpecVoucher,
+        voucher: {
+          channelId: CHANNEL,
+          cumulativeAmount: "-1",
+        },
+      },
+    });
+    t.ok(
+      isValidationError(negative),
+      "negative cumulativeAmount must be rejected",
+    );
+    t.end();
+  },
+);
+
+await t.test(
+  "spec §Signed Voucher — schema rejects signatureType other than ed25519",
+  (t) => {
+    // Spec §"Signed Voucher" defines signatureType as the literal
+    // "ed25519". A bare voucher claiming any other algorithm MUST
+    // fail validation at the schema layer.
+    const result = solanaSessionVoucherPayload({
+      action: "voucher",
+      channelId: CHANNEL,
+      voucher: {
+        voucher: {
+          channelId: CHANNEL,
+          cumulativeAmount: "100",
+        },
+        signer: SIGNER,
+        signature: "1".repeat(88),
+        signatureType: "secp256r1",
+      },
+    });
+    t.ok(
+      isValidationError(result),
+      "voucher with signatureType !== 'ed25519' must fail validation",
+    );
+    t.end();
+  },
+);

--- a/packages/payment-solana/src/session/common.ts
+++ b/packages/payment-solana/src/session/common.ts
@@ -1,0 +1,144 @@
+import { type } from "arktype";
+import {
+  sessionOpenBase,
+  sessionTopUpBase,
+  sessionVoucherBase,
+  sessionCloseBase,
+  sessionRequestBase,
+} from "@faremeter/types/mpp";
+
+// Spec-aligned challenge `methodDetails` for the Solana session intent.
+// Field names track draft-solana-session-00 §"Method Details" where the
+// spec is opinionated; Flex-specific extensions live under the nested
+// `flex` sub-object so the spec slice stays clean.
+export const solanaSessionMethodDetails = type({
+  // draft-solana-session-00 §"Method Details"
+  "network?": "'mainnet-beta'|'devnet'|'localnet'",
+  channelProgram: "string",
+  "channelId?": "string",
+  decimals: "number",
+  "tokenProgram?": "string",
+  "feePayer?": "boolean",
+  "feePayerKey?": "string",
+  "minVoucherDelta?": "string.numeric",
+  "ttlSeconds?": "number",
+  "gracePeriodSeconds?": "number",
+  // Flex-specific extension. The Flex on-chain program needs the
+  // facilitator pubkey, recent blockhash, splits, and per-escrow
+  // refund/deadman slot counters that the spec doesn't model.
+  // Documented in COMPATIBILITY.md.
+  flex: type({
+    facilitator: "string",
+    "recentBlockhash?": "string",
+    splits: type({ recipient: "string", bps: "number" }).array(),
+    refundTimeoutSlots: "string.numeric",
+    deadmanTimeoutSlots: "string.numeric",
+    minGracePeriodSlots: "string.numeric",
+  }),
+});
+export type solanaSessionMethodDetails =
+  typeof solanaSessionMethodDetails.infer;
+
+export const solanaSessionRequest = sessionRequestBase.and({
+  methodDetails: solanaSessionMethodDetails,
+});
+export type solanaSessionRequest = typeof solanaSessionRequest.infer;
+
+// `transaction` (the wire-format base64 transaction) and the spec
+// `voucher` (REQUIRED initial signed voucher) are forward declared so
+// the open and topUp payloads can reference them. The voucher
+// definition lives below alongside the per-action voucher payload.
+
+export const solanaSessionTopUpPayload = sessionTopUpBase.and({
+  transaction: "string",
+});
+export type solanaSessionTopUpPayload = typeof solanaSessionTopUpPayload.infer;
+
+export const solanaSessionVoucherSplit = type({
+  recipient: "string",
+  bps: "number",
+});
+export type solanaSessionVoucherSplit = typeof solanaSessionVoucherSplit.infer;
+
+// Spec-shaped voucher data per draft-solana-session-00 §"Voucher Format /
+// Voucher Data". This is what the spec signature is computed over (JCS-
+// canonicalized).
+//
+// `cumulativeAmount` is constrained to a non-negative decimal integer
+// string. arktype's `string.numeric` admits decimals (`"1.5"`) and
+// negatives (`"-1"`), neither of which is meaningful in base units.
+export const solanaVoucherData = type({
+  channelId: "string",
+  cumulativeAmount: /^(0|[1-9][0-9]*)$/,
+  "expiresAt?": "string",
+});
+export type solanaVoucherData = typeof solanaVoucherData.infer;
+
+// Spec-shaped signed voucher per §"Signed Voucher".
+export const solanaSignedVoucher = type({
+  voucher: solanaVoucherData,
+  signer: "string",
+  signature: "string",
+  signatureType: "'ed25519'",
+});
+export type solanaSignedVoucher = typeof solanaSignedVoucher.infer;
+
+// Faremeter extension carried alongside the spec-shaped voucher. The
+// Flex on-chain program signs over a different byte layout (packed
+// binary including programId, mint, splits, authorizationId,
+// maxAmount, expiresAtSlot) and uses a fresh per-authorization id, so
+// we carry the Flex authorization fields and Flex signature as a
+// sibling extension. Documented in COMPATIBILITY.md.
+export const flexVoucherExtension = type({
+  mint: "string",
+  authorizationId: "string.numeric",
+  maxAmount: "string.numeric",
+  expiresAtSlot: "string.numeric",
+  splits: solanaSessionVoucherSplit.array(),
+  signature: "string",
+});
+export type flexVoucherExtension = typeof flexVoucherExtension.infer;
+
+// Per draft-solana-session-00 §"Action: voucher": the credential
+// carries `action`, `channelId`, and the signed `voucher` only. The
+// `flex` extension is a Faremeter extension required by the Flex
+// on-chain settlement path; spec-conforming clients omit it. The
+// handler enforces its presence at the actual Flex-settlement step,
+// not at credential-validation time.
+export const solanaSessionVoucherPayload = sessionVoucherBase.and({
+  voucher: solanaSignedVoucher,
+  "flex?": flexVoucherExtension,
+});
+export type solanaSessionVoucherPayload =
+  typeof solanaSessionVoucherPayload.infer;
+
+// Spec §"Action: open" requires the open credential to carry an
+// initial signed voucher. Flex doesn't need an on-chain authorization
+// for a 0-cumulative initial voucher, so the `flex` extension is
+// optional here — clients SHOULD set it only when the initial voucher
+// authorizes a non-zero amount that the server should be able to
+// settle on chain.
+export const solanaSessionOpenPayload = sessionOpenBase.and({
+  transaction: "string",
+  voucher: solanaSignedVoucher,
+  "flex?": flexVoucherExtension,
+});
+export type solanaSessionOpenPayload = typeof solanaSessionOpenPayload.infer;
+
+// Per draft-solana-session-00 §"Action: close": `voucher` is OPTIONAL
+// and the spec does not define a `closeTransaction` field. We accept
+// an optional `closeTransaction` as a Faremeter extension carrying
+// the partially-signed close transaction the server will co-sign and
+// broadcast — but it MUST NOT be required for the credential to
+// validate.
+export const solanaSessionClosePayload = sessionCloseBase.and({
+  "voucher?": solanaSignedVoucher,
+  "closeTransaction?": "string",
+});
+export type solanaSessionClosePayload = typeof solanaSessionClosePayload.infer;
+
+export const solanaSessionPayload = solanaSessionOpenPayload
+  .or(solanaSessionTopUpPayload)
+  .or(solanaSessionVoucherPayload)
+  .or(solanaSessionClosePayload);
+export type solanaSessionPayload = typeof solanaSessionPayload.infer;

--- a/packages/payment-solana/src/session/index.ts
+++ b/packages/payment-solana/src/session/index.ts
@@ -1,0 +1,74 @@
+// MPP `solana` / `session` intent handler, settled against the
+// Faremeter Flex escrow program.
+//
+// This is NOT a conforming implementation of draft-solana-session-00.
+// Flex's on-chain shape is structurally different from a payment-channel
+// program, and several spec MUSTs cannot be satisfied without changing
+// the program. The wire format will be aligned with the spec where
+// possible; the load-bearing divergences are documented in
+// COMPATIBILITY.md at the repository root.
+
+export {
+  createMPPSolanaSessionHandler,
+  VoucherRegistrationError,
+  type CreateMPPSolanaSessionHandlerArgs,
+  type FlexSessionHandler,
+  type TryRegisterResult,
+  type VoucherRegistration,
+  type VoucherRegistrationReason,
+} from "./server";
+
+export {
+  createMPPSolanaSessionClient,
+  type CreateMPPSolanaSessionClientArgs,
+  type MPPSolanaSessionClient,
+  type SessionClientWallet,
+  SessionExpiredError,
+} from "./client";
+
+export {
+  createInMemorySessionStore,
+  type SessionState,
+  type SessionStatus,
+  type SessionStore,
+} from "./state";
+
+export {
+  solanaSessionPayload,
+  solanaSessionRequest,
+  solanaSessionOpenPayload,
+  solanaSessionTopUpPayload,
+  solanaSessionVoucherPayload,
+  solanaSessionClosePayload,
+  type solanaSessionMethodDetails,
+} from "./common";
+
+export {
+  buildInsufficientHoldProblem,
+  buildPendingLimitProblem,
+  buildSessionNotFoundProblem,
+  PENDING_LIMIT_MAX,
+  FLEX_PROBLEM_PENDING_LIMIT,
+  flexPendingLimitProblem,
+} from "./problem";
+
+export {
+  serializeVoucherMessage,
+  serializeSpecVoucherMessage,
+  verifyVoucherSignature,
+  type SerializeVoucherArgs,
+  type VoucherSplit,
+} from "./verify";
+
+export { FLEX_PROGRAM_ADDRESS } from "@faremeter/flex-solana";
+
+// Re-export the Faremeter session-open batch builder. This composes
+// the three on-chain steps a session-open performs (create_escrow,
+// deposit, register_session_key) — all from `@faremeter/flex-solana` —
+// into a single instruction array suitable for assembly into a
+// versioned transaction message.
+export {
+  buildSessionOpenInstructions,
+  type BuildSessionOpenInstructionsArgs,
+  type SessionOpenInstructions,
+} from "./open";

--- a/packages/payment-solana/src/session/logger.ts
+++ b/packages/payment-solana/src/session/logger.ts
@@ -1,0 +1,3 @@
+import { getLogger } from "@faremeter/logs";
+
+export const logger = await getLogger(["faremeter", "payment-solana-session"]);

--- a/packages/payment-solana/src/session/open.test.ts
+++ b/packages/payment-solana/src/session/open.test.ts
@@ -1,0 +1,117 @@
+#!/usr/bin/env pnpm tsx
+
+import t from "tap";
+import { address, generateKeyPairSigner, AccountRole } from "@solana/kit";
+import {
+  FLEX_PROGRAM_ADDRESS,
+  CREATE_ESCROW_DISCRIMINATOR,
+  findEscrowPda,
+  findRegisterSessionKeySessionKeyAccountPda,
+  findVaultPda,
+} from "@faremeter/flex-solana";
+import { buildSessionOpenInstructions } from "./open";
+
+const FACILITATOR = address("9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM");
+const SESSION_KEY = address("DFo9vd1eiRFGQuCkReqvZvRPJVwwYu8NwCiaa9tB5pWZ");
+const MINT = address("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v");
+const SOURCE = address("3QFU3r76XiQVdqkaX5K6FWkDyiBKN7EK3UjRSWxMXHt3");
+
+await t.test(
+  "buildSessionOpenInstructions returns three instructions targeting the expected PDAs",
+  async (t) => {
+    const owner = await generateKeyPairSigner();
+
+    const result = await buildSessionOpenInstructions({
+      owner,
+      facilitator: FACILITATOR,
+      sessionKey: SESSION_KEY,
+      mint: MINT,
+      source: SOURCE,
+      index: 0n,
+      depositAmount: 1_000_000n,
+      refundTimeoutSlots: 150n,
+      deadmanTimeoutSlots: 1000n,
+      maxSessionKeys: 4,
+      sessionKeyExpiresAtSlot: 2_000_000n,
+      sessionKeyGracePeriodSlots: 150n,
+    });
+
+    t.equal(result.instructions.length, 3);
+
+    const [expectedEscrow] = await findEscrowPda({
+      owner: owner.address,
+      index: 0n,
+    });
+    t.equal(result.escrow, expectedEscrow);
+
+    const [expectedVault] = await findVaultPda({
+      escrow: expectedEscrow,
+      mint: MINT,
+    });
+    t.equal(result.vault, expectedVault);
+
+    const [expectedSessionKeyAccount] =
+      await findRegisterSessionKeySessionKeyAccountPda({
+        escrow: expectedEscrow,
+        sessionKey: SESSION_KEY,
+      });
+    t.equal(result.sessionKeyAccount, expectedSessionKeyAccount);
+
+    for (const ix of result.instructions) {
+      t.equal(ix.programAddress, FLEX_PROGRAM_ADDRESS);
+    }
+    t.end();
+  },
+);
+
+await t.test(
+  "buildSessionOpenInstructions encodes the create_escrow discriminator",
+  async (t) => {
+    const owner = await generateKeyPairSigner();
+    const { instructions } = await buildSessionOpenInstructions({
+      owner,
+      facilitator: FACILITATOR,
+      sessionKey: SESSION_KEY,
+      mint: MINT,
+      source: SOURCE,
+      index: 7n,
+      depositAmount: 1_000_000n,
+      refundTimeoutSlots: 150n,
+      deadmanTimeoutSlots: 1000n,
+      maxSessionKeys: 4,
+      sessionKeyExpiresAtSlot: 2_000_000n,
+      sessionKeyGracePeriodSlots: 150n,
+    });
+
+    const createEscrowIx = instructions[0];
+    t.ok(createEscrowIx.data);
+    const actual = (createEscrowIx.data ?? new Uint8Array()).slice(0, 8);
+    t.matchOnly(Array.from(actual), Array.from(CREATE_ESCROW_DISCRIMINATOR));
+    t.end();
+  },
+);
+
+await t.test("create_escrow owner is a writable signer", async (t) => {
+  const owner = await generateKeyPairSigner();
+  const { instructions } = await buildSessionOpenInstructions({
+    owner,
+    facilitator: FACILITATOR,
+    sessionKey: SESSION_KEY,
+    mint: MINT,
+    source: SOURCE,
+    index: 0n,
+    depositAmount: 1n,
+    refundTimeoutSlots: 150n,
+    deadmanTimeoutSlots: 1000n,
+    maxSessionKeys: 1,
+    sessionKeyExpiresAtSlot: 2n,
+    sessionKeyGracePeriodSlots: 1n,
+  });
+
+  const createEscrowIx = instructions[0];
+  const firstAccount = createEscrowIx.accounts?.[0];
+  t.ok(firstAccount);
+  t.equal(firstAccount?.address, owner.address);
+  t.equal(firstAccount?.role, AccountRole.WRITABLE_SIGNER);
+  t.end();
+});

--- a/packages/payment-solana/src/session/open.ts
+++ b/packages/payment-solana/src/session/open.ts
@@ -1,0 +1,117 @@
+// Open batch builder: composes the three on-chain steps a session-open
+// performs against the Flex escrow program — create_escrow, deposit,
+// and register_session_key — into a single instruction array suitable
+// for assembly into a versioned transaction message. The underlying
+// instruction encoders come from `@faremeter/flex-solana`; this helper
+// is Faremeter glue that the session client uses to produce a single
+// open transaction.
+
+import type { Address, Instruction, TransactionSigner } from "@solana/kit";
+
+import {
+  FLEX_PROGRAM_ADDRESS,
+  findEscrowPda,
+  findRegisterSessionKeySessionKeyAccountPda,
+  findVaultPda,
+  getCreateEscrowInstructionAsync,
+  getDepositInstructionAsync,
+  getRegisterSessionKeyInstructionAsync,
+} from "@faremeter/flex-solana";
+
+export type BuildSessionOpenInstructionsArgs = {
+  owner: TransactionSigner;
+  facilitator: Address;
+  sessionKey: Address;
+  mint: Address;
+  source: Address;
+  index: bigint;
+  depositAmount: bigint;
+  refundTimeoutSlots: bigint;
+  deadmanTimeoutSlots: bigint;
+  maxSessionKeys: number;
+  sessionKeyExpiresAtSlot: bigint | null;
+  sessionKeyGracePeriodSlots: bigint;
+  programAddress?: Address;
+};
+
+export type SessionOpenInstructions = {
+  instructions: [Instruction, Instruction, Instruction];
+  escrow: Address;
+  vault: Address;
+  sessionKeyAccount: Address;
+};
+
+/**
+ * Returns the three-instruction batch that opens a Flex session.
+ * The caller is responsible for assembling the instructions into a
+ * versioned transaction message, signing, and submitting.
+ */
+export async function buildSessionOpenInstructions(
+  args: BuildSessionOpenInstructionsArgs,
+): Promise<SessionOpenInstructions> {
+  const programAddress = args.programAddress ?? FLEX_PROGRAM_ADDRESS;
+  const programConfig = { programAddress };
+
+  // Re-derive the PDAs the three instructions will reference. The
+  // generated `getCreateEscrowInstructionAsync` etc. helpers also
+  // accept these as optional fields and derive them when omitted, but
+  // we want the addresses returned to the caller alongside the
+  // instructions so the session handler can echo them in its
+  // credential.
+  const [escrow] = await findEscrowPda(
+    { owner: args.owner.address, index: args.index },
+    programConfig,
+  );
+  const [vault] = await findVaultPda(
+    { escrow, mint: args.mint },
+    programConfig,
+  );
+  const [sessionKeyAccount] = await findRegisterSessionKeySessionKeyAccountPda(
+    { escrow, sessionKey: args.sessionKey },
+    programConfig,
+  );
+
+  const createEscrow = await getCreateEscrowInstructionAsync(
+    {
+      owner: args.owner,
+      escrow,
+      index: args.index,
+      facilitator: args.facilitator,
+      refundTimeoutSlots: args.refundTimeoutSlots,
+      deadmanTimeoutSlots: args.deadmanTimeoutSlots,
+      maxSessionKeys: args.maxSessionKeys,
+    },
+    programConfig,
+  );
+
+  const deposit = await getDepositInstructionAsync(
+    {
+      depositor: args.owner,
+      escrow,
+      mint: args.mint,
+      vault,
+      source: args.source,
+      amount: args.depositAmount,
+    },
+    programConfig,
+  );
+
+  const registerSessionKey = await getRegisterSessionKeyInstructionAsync(
+    {
+      owner: args.owner,
+      escrow,
+      sessionKeyAccount,
+      sessionKey: args.sessionKey,
+      expiresAtSlot: args.sessionKeyExpiresAtSlot,
+      revocationGracePeriodSlots: args.sessionKeyGracePeriodSlots,
+    },
+    programConfig,
+  );
+
+  return {
+    instructions: [createEscrow, deposit, registerSessionKey],
+    escrow,
+    vault,
+    sessionKeyAccount,
+  };
+}

--- a/packages/payment-solana/src/session/problem.ts
+++ b/packages/payment-solana/src/session/problem.ts
@@ -1,0 +1,84 @@
+import { type } from "arktype";
+import {
+  buildVerificationFailedProblem as buildSpecVerificationFailedProblem,
+  type verificationFailedProblem,
+} from "@faremeter/types/mpp";
+import type { SessionState } from "./state";
+
+export const PENDING_LIMIT_MAX = 16;
+
+/**
+ * Faremeter-namespaced extension Problem Details type for the
+ * Flex-imposed pending settlement back-pressure. The spec
+ * (draft-solana-session-00) has no concept of pending settlements
+ * because it assumes a cumulative single-watermark settlement model;
+ * this URI marks the response as a Faremeter extension carrying
+ * Flex-specific state. See COMPATIBILITY.md.
+ */
+export const FLEX_PROBLEM_PENDING_LIMIT =
+  "https://faremeter.org/problems/flex-pending-limit";
+
+export const flexPendingLimitProblem = type({
+  type: `"${FLEX_PROBLEM_PENDING_LIMIT}"`,
+  title: "string",
+  status: "402",
+  channelId: "string",
+  pendingCount: "number",
+  maxPending: "number",
+  "detail?": "string",
+});
+export type flexPendingLimitProblem = typeof flexPendingLimitProblem.infer;
+
+/**
+ * Builds a spec `verification-failed` Problem Details for the
+ * "voucher cumulative would exceed escrow deposit" case. Detail
+ * carries the running channel state so clients can compute the top-up
+ * amount they need.
+ */
+export function buildInsufficientHoldProblem(
+  state: SessionState,
+  requiredTopUp: bigint,
+): verificationFailedProblem {
+  return buildSpecVerificationFailedProblem({
+    title: "Insufficient hold",
+    detail:
+      `channelId=${state.channelId.toString()} ` +
+      `acceptedCumulative=${state.acceptedCumulative.toString()} ` +
+      `spent=${state.spent.toString()} ` +
+      `requiredTopUp=${requiredTopUp.toString()}`,
+  });
+}
+
+/**
+ * Builds a spec `verification-failed` Problem Details for the
+ * "no live session for this (channelId, sessionKey)" case.
+ */
+export function buildSessionNotFoundProblem(
+  channelId: string,
+  detail?: string,
+): verificationFailedProblem {
+  return buildSpecVerificationFailedProblem({
+    title: "Channel not found",
+    detail:
+      detail ??
+      `channelId=${channelId} not present in session store; re-open required`,
+  });
+}
+
+/**
+ * Builds the Faremeter-extension `flex-pending-limit` Problem Details
+ * for the back-pressure case. Not a spec problem type — see
+ * COMPATIBILITY.md for why this lives outside the spec catalogue.
+ */
+export function buildPendingLimitProblem(
+  state: SessionState,
+): flexPendingLimitProblem {
+  return {
+    type: FLEX_PROBLEM_PENDING_LIMIT,
+    title: "Pending settlement limit reached",
+    status: 402,
+    channelId: state.channelId.toString(),
+    pendingCount: state.inFlightAuthorizationIds.length,
+    maxPending: PENDING_LIMIT_MAX,
+  };
+}

--- a/packages/payment-solana/src/session/server.test.ts
+++ b/packages/payment-solana/src/session/server.test.ts
@@ -1,0 +1,2833 @@
+#!/usr/bin/env pnpm tsx
+
+import t from "tap";
+import {
+  address,
+  appendTransactionMessageInstructions,
+  compileTransaction,
+  createTransactionMessage,
+  generateKeyPairSigner,
+  getBase64EncodedWireTransaction,
+  pipe,
+  setTransactionMessageFeePayerSigner,
+  setTransactionMessageLifetimeUsingBlockhash,
+  signTransactionMessageWithSigners,
+  type Blockhash,
+  type Rpc,
+  type SolanaRpcApi,
+} from "@solana/kit";
+import {
+  canonicalizeSortedJSON,
+  encodeBase64URL,
+  mppReceipt,
+  SESSION_INTENT,
+  type mppCredential,
+} from "@faremeter/types/mpp";
+import { isValidationError } from "@faremeter/types";
+
+import { createMPPSolanaSessionHandler } from "./server";
+import { createInMemorySessionStore, type SessionState } from "./state";
+import { serializeSpecVoucherMessage, serializeVoucherMessage } from "./verify";
+import { verifyFlexOpenTransaction } from "./verify-open";
+import type { solanaSessionMethodDetails } from "./common";
+import { FLEX_PROGRAM_ADDRESS } from "@faremeter/flex-solana";
+import { buildSessionOpenInstructions } from "./index";
+
+const MINT = address("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v");
+const RECIPIENT = address("3QFU3r76XiQVdqkaX5K6FWkDyiBKN7EK3UjRSWxMXHt3");
+
+// Minimal stub; the handler doesn't actually issue RPC calls in the paths
+// exercised by these tests.
+const stubRpc = {} as unknown as Rpc<SolanaRpcApi>;
+
+const SECRET_KEY = new TextEncoder().encode("session-handler-test-secret");
+
+async function makeHandler() {
+  const facilitatorSigner = await generateKeyPairSigner();
+  return createMPPSolanaSessionHandler({
+    network: "solana-devnet",
+    rpc: stubRpc,
+    facilitatorSigner,
+    supportedMints: [MINT],
+    defaultSplits: [{ recipient: RECIPIENT.toString(), bps: 10000 }],
+    realm: "test",
+    secretKey: SECRET_KEY,
+    mintDecimals: 6,
+    refundTimeoutSlots: 150n,
+    deadmanTimeoutSlots: 1000n,
+    minGracePeriodSlots: 150n,
+    challengeExpiresSeconds: 3600,
+    maxRetries: 1,
+    retryDelayMs: 1,
+    flushIntervalMs: 1000,
+    programAddress: FLEX_PROGRAM_ADDRESS,
+  });
+}
+
+await t.test("getChallenge mints a session-intent challenge", async (t) => {
+  const handler = await makeHandler();
+  const challenge = await handler.getChallenge(
+    SESSION_INTENT,
+    {
+      amount: "25",
+      asset: MINT.toString(),
+      recipient: RECIPIENT.toString(),
+      network: "solana-devnet",
+    },
+    "http://test/resource",
+  );
+  t.equal(challenge.method, "solana");
+  t.equal(challenge.intent, SESSION_INTENT);
+  t.ok(challenge.id);
+  t.ok(challenge.expires);
+  t.end();
+});
+
+await t.test("handleSettle rejects non-session intents", async (t) => {
+  const handler = await makeHandler();
+  const credential: mppCredential = {
+    challenge: {
+      id: "x",
+      realm: "test",
+      method: "solana",
+      intent: "charge",
+      request: "x",
+    },
+    payload: {},
+  };
+  const result = await handler.handleSettle(credential);
+  t.equal(result, null);
+  t.end();
+});
+
+await t.test("tryRegisterVoucher voucher monotonicity rules", async (t) => {
+  const store = createInMemorySessionStore();
+  const facilitatorSigner = await generateKeyPairSigner();
+  const withStore = await createMPPSolanaSessionHandler({
+    network: "solana-devnet",
+    rpc: stubRpc,
+    facilitatorSigner,
+    supportedMints: [MINT],
+    defaultSplits: [{ recipient: RECIPIENT.toString(), bps: 10000 }],
+    realm: "test",
+    secretKey: SECRET_KEY,
+    sessionStore: store,
+    mintDecimals: 6,
+    refundTimeoutSlots: 150n,
+    deadmanTimeoutSlots: 1000n,
+    minGracePeriodSlots: 150n,
+    challengeExpiresSeconds: 3600,
+    maxRetries: 1,
+    retryDelayMs: 1,
+    flushIntervalMs: 1000,
+    programAddress: FLEX_PROGRAM_ADDRESS,
+  });
+
+  const channelId = address("9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM");
+  const sessionKey = address("DFo9vd1eiRFGQuCkReqvZvRPJVwwYu8NwCiaa9tB5pWZ");
+
+  const seed: SessionState = {
+    channelId,
+    sessionKey,
+    mint: MINT,
+    escrowedAmount: 1_000_000n,
+    acceptedCumulative: 100n,
+    spent: 50n,
+    inFlightAuthorizationIds: [],
+    status: "open",
+  };
+  await store.put(seed);
+
+  const buildRegistration = (
+    cumulativeAmount: string,
+    authorizationId: string,
+  ) => ({
+    channelId,
+    sessionKey,
+    voucher: {
+      voucher: {
+        channelId: channelId.toString(),
+        cumulativeAmount,
+      },
+      signer: sessionKey.toString(),
+      signature: "",
+      signatureType: "ed25519" as const,
+    },
+    flex: {
+      mint: MINT.toString(),
+      authorizationId,
+      maxAmount: cumulativeAmount,
+      expiresAtSlot: "0",
+      splits: [],
+      signature: "",
+    },
+  });
+
+  // Lower cumulativeAmount: must succeed without mutating state
+  // (replay tolerance per draft-solana-session-00 §"Concurrency and
+  // Idempotency").
+  const lower = await withStore.tryRegisterVoucher(
+    buildRegistration("50", "1"),
+  );
+  t.equal(lower.ok, true);
+  let after = await store.get(channelId);
+  t.equal(after?.acceptedCumulative, 100n);
+  t.equal(after?.inFlightAuthorizationIds.length, 0);
+
+  // Equal cumulativeAmount: idempotent success without mutating state.
+  const equal = await withStore.tryRegisterVoucher(
+    buildRegistration("100", "2"),
+  );
+  t.equal(equal.ok, true);
+  after = await store.get(channelId);
+  t.equal(after?.acceptedCumulative, 100n);
+  t.equal(after?.inFlightAuthorizationIds.length, 0);
+
+  // Strictly greater cumulativeAmount: accepted, state advances.
+  const ok = await withStore.tryRegisterVoucher(buildRegistration("200", "3"));
+  t.equal(ok.ok, true);
+  after = await store.get(channelId);
+  t.equal(after?.acceptedCumulative, 200n);
+  t.equal(after?.inFlightAuthorizationIds.length, 1);
+
+  t.end();
+});
+
+await t.test("chargeSession rejects overdrafts", async (t) => {
+  const facilitatorSigner = await generateKeyPairSigner();
+  const store = createInMemorySessionStore();
+  const handler = await createMPPSolanaSessionHandler({
+    network: "solana-devnet",
+    rpc: stubRpc,
+    facilitatorSigner,
+    supportedMints: [MINT],
+    defaultSplits: [{ recipient: RECIPIENT.toString(), bps: 10000 }],
+    realm: "test",
+    secretKey: SECRET_KEY,
+    sessionStore: store,
+    mintDecimals: 6,
+    refundTimeoutSlots: 150n,
+    deadmanTimeoutSlots: 1000n,
+    minGracePeriodSlots: 150n,
+    challengeExpiresSeconds: 3600,
+    maxRetries: 1,
+    retryDelayMs: 1,
+    flushIntervalMs: 1000,
+    programAddress: FLEX_PROGRAM_ADDRESS,
+  });
+
+  const channelId = address("9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM");
+  const sessionKey = address("DFo9vd1eiRFGQuCkReqvZvRPJVwwYu8NwCiaa9tB5pWZ");
+  await store.put({
+    channelId,
+    sessionKey,
+    mint: MINT,
+    escrowedAmount: 1_000_000n,
+    acceptedCumulative: 100n,
+    spent: 0n,
+    inFlightAuthorizationIds: [],
+    status: "open",
+  });
+
+  await handler.chargeSession(channelId, 40n);
+  t.equal(await handler.remainingHold(channelId), 60n);
+
+  await t.rejects(() => handler.chargeSession(channelId, 100n));
+  void sessionKey;
+  t.end();
+});
+
+await t.test(
+  "voucher signature verification rejects bad signatures",
+  async (t) => {
+    const facilitatorSigner = await generateKeyPairSigner();
+    const handler = await createMPPSolanaSessionHandler({
+      network: "solana-devnet",
+      rpc: stubRpc,
+      facilitatorSigner,
+      supportedMints: [MINT],
+      mintDecimals: 6,
+      defaultSplits: [{ recipient: RECIPIENT.toString(), bps: 10000 }],
+      realm: "test",
+      secretKey: SECRET_KEY,
+      refundTimeoutSlots: 150n,
+      deadmanTimeoutSlots: 1000n,
+      minGracePeriodSlots: 150n,
+      challengeExpiresSeconds: 3600,
+      maxRetries: 1,
+      retryDelayMs: 1,
+      flushIntervalMs: 1000,
+      programAddress: FLEX_PROGRAM_ADDRESS,
+    });
+
+    const challenge = await handler.getChallenge(
+      SESSION_INTENT,
+      {
+        amount: "25",
+        asset: MINT.toString(),
+        recipient: RECIPIENT.toString(),
+        network: "solana-devnet",
+      },
+      "http://test/resource",
+    );
+
+    const escrow = address("9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM");
+    const sessionKeyAddress = address(
+      "DFo9vd1eiRFGQuCkReqvZvRPJVwwYu8NwCiaa9tB5pWZ",
+    );
+
+    const credential: mppCredential = {
+      challenge,
+      payload: {
+        action: "voucher",
+        channelId: escrow.toString(),
+        voucher: {
+          voucher: {
+            channelId: escrow.toString(),
+            cumulativeAmount: "25",
+          },
+          signer: sessionKeyAddress.toString(),
+          // 64 zero bytes base58-encoded — fails Ed25519 verification.
+          signature: "1".repeat(88),
+          signatureType: "ed25519",
+        },
+        flex: {
+          mint: MINT.toString(),
+          authorizationId: "1",
+          maxAmount: "25",
+          expiresAtSlot: "0",
+          splits: [],
+          signature: "AAAA",
+        },
+      },
+    };
+
+    await t.rejects(() => handler.handleSettle(credential));
+    t.end();
+  },
+);
+
+await t.test("withChannelLock serializes concurrent operations", async (t) => {
+  const facilitatorSigner = await generateKeyPairSigner();
+  const handler = await createMPPSolanaSessionHandler({
+    network: "solana-devnet",
+    rpc: stubRpc,
+    facilitatorSigner,
+    supportedMints: [MINT],
+    mintDecimals: 6,
+    defaultSplits: [{ recipient: RECIPIENT.toString(), bps: 10000 }],
+    realm: "test",
+    secretKey: SECRET_KEY,
+    refundTimeoutSlots: 150n,
+    deadmanTimeoutSlots: 1000n,
+    minGracePeriodSlots: 150n,
+    challengeExpiresSeconds: 3600,
+    maxRetries: 1,
+    retryDelayMs: 1,
+    flushIntervalMs: 1000,
+    programAddress: FLEX_PROGRAM_ADDRESS,
+  });
+
+  const channelId = address("9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM");
+
+  const events: string[] = [];
+  const op = (label: string, ms: number) =>
+    handler.withChannelLock(channelId, async () => {
+      events.push(`${label}-start`);
+      await new Promise((resolve) => setTimeout(resolve, ms));
+      events.push(`${label}-end`);
+    });
+
+  await Promise.all([op("a", 30), op("b", 5), op("c", 5)]);
+
+  // Each op must complete before the next starts.
+  t.matchOnly(events, [
+    "a-start",
+    "a-end",
+    "b-start",
+    "b-end",
+    "c-start",
+    "c-end",
+  ]);
+  t.end();
+});
+
+await t.test("idempotency cache returns previous receipt", async (t) => {
+  const handler = await makeHandler();
+  const cached = await handler.lookupIdempotent("challenge-id", "key-1");
+  t.equal(cached, undefined);
+
+  const receipt = {
+    status: "success" as const,
+    method: "solana",
+    intent: SESSION_INTENT,
+    timestamp: new Date().toISOString(),
+    reference: "ch",
+    acceptedCumulative: "100",
+    spent: "25",
+  };
+  await handler.recordIdempotent("challenge-id", "key-1", receipt);
+  const found = await handler.lookupIdempotent("challenge-id", "key-1");
+  t.matchOnly(found, receipt);
+
+  // Different idempotency key on the same challenge: distinct entry.
+  t.equal(await handler.lookupIdempotent("challenge-id", "key-2"), undefined);
+  t.end();
+});
+
+await t.test("formatProblemResponse attaches WWW-Authenticate", async (t) => {
+  const handler = await makeHandler();
+  const channelId = address("9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM");
+  const problem = handler.buildSessionNotFoundProblem(channelId);
+  const response = await handler.formatProblemResponse(
+    problem,
+    {
+      amount: "25",
+      asset: MINT.toString(),
+      recipient: RECIPIENT.toString(),
+      network: "solana-devnet",
+    },
+    "http://test/resource",
+  );
+  t.equal(response.status, 402);
+  t.equal(response.headers["Content-Type"], "application/problem+json");
+  t.ok(response.headers["WWW-Authenticate"]?.startsWith("Payment "));
+  t.match(response.headers["WWW-Authenticate"], /method="solana"/);
+  t.match(response.headers["WWW-Authenticate"], /intent="session"/);
+  t.end();
+});
+
+// Smoke: a handler round-trips its own challenge canonicalization.
+await t.test("challenge request survives JSON canonicalization", async (t) => {
+  const handler = await makeHandler();
+  const challenge = await handler.getChallenge(
+    SESSION_INTENT,
+    {
+      amount: "25",
+      asset: MINT.toString(),
+      recipient: RECIPIENT.toString(),
+      network: "solana-devnet",
+    },
+    "http://test/resource",
+  );
+  const requestBody = JSON.parse(
+    Buffer.from(
+      challenge.request.replace(/-/g, "+").replace(/_/g, "/"),
+      "base64",
+    ).toString("utf-8"),
+  ) as {
+    amount: string;
+    currency: string;
+    methodDetails: solanaSessionMethodDetails;
+  };
+  t.equal(requestBody.amount, "25");
+  t.equal(requestBody.currency, MINT.toString());
+  t.equal(requestBody.methodDetails.channelProgram, FLEX_PROGRAM_ADDRESS);
+  t.equal(requestBody.methodDetails.flex.facilitator !== undefined, true);
+
+  // The canonical JSON round-trip must be idempotent.
+  const reserialized = encodeBase64URL(canonicalizeSortedJSON(requestBody));
+  t.equal(reserialized, challenge.request);
+  // serializeVoucherMessage kept for reference; unused here.
+  void serializeVoucherMessage;
+  t.end();
+});
+
+// Forward spec-conformance tests for handleSettle's voucher path.
+// draft-solana-session-00 §"Voucher Verification" lists ten MUSTs the
+// server has to enforce before serving a metered request. These tests
+// assert the spec-correct rejection behavior; failing tests document
+// a missing enforcement step in handleSettle.
+
+import bs58 from "bs58";
+import type { webcrypto } from "node:crypto";
+import { serializeVoucherMessage as flexSerialize } from "./verify";
+
+type SessionKeyPair = webcrypto.CryptoKeyPair;
+
+async function makeStoreAndHandler(opts: { sponsorFees?: boolean } = {}) {
+  const facilitatorSigner = await generateKeyPairSigner();
+  const store = createInMemorySessionStore();
+  const handler = await createMPPSolanaSessionHandler({
+    network: "solana-devnet",
+    rpc: stubRpc,
+    facilitatorSigner,
+    ...(opts.sponsorFees !== undefined
+      ? { sponsorFees: opts.sponsorFees }
+      : {}),
+    supportedMints: [MINT],
+    mintDecimals: 6,
+    defaultSplits: [{ recipient: RECIPIENT.toString(), bps: 10000 }],
+    realm: "test",
+    secretKey: SECRET_KEY,
+    sessionStore: store,
+    refundTimeoutSlots: 150n,
+    deadmanTimeoutSlots: 1000n,
+    minGracePeriodSlots: 150n,
+    challengeExpiresSeconds: 3600,
+    maxRetries: 1,
+    retryDelayMs: 1,
+    flushIntervalMs: 1000,
+    programAddress: FLEX_PROGRAM_ADDRESS,
+  });
+  return { handler, store, facilitatorSigner };
+}
+
+async function makeRealKeypairAddress() {
+  const keypair = (await crypto.subtle.generateKey("Ed25519", true, [
+    "sign",
+    "verify",
+  ])) as SessionKeyPair;
+  const raw = new Uint8Array(
+    await crypto.subtle.exportKey("raw", keypair.publicKey),
+  );
+  return { keypair, address: address(bs58.encode(raw)) };
+}
+
+async function buildSignedVoucher(args: {
+  keypair: SessionKeyPair;
+  signerAddress: string;
+  channelId: string;
+  cumulativeAmount: string;
+  expiresAt?: string;
+}) {
+  const message = serializeSpecVoucherMessage({
+    channelId: args.channelId,
+    cumulativeAmount: args.cumulativeAmount,
+    ...(args.expiresAt !== undefined ? { expiresAt: args.expiresAt } : {}),
+  });
+  const sig = new Uint8Array(
+    await crypto.subtle.sign("Ed25519", args.keypair.privateKey, message),
+  );
+  return {
+    voucher: {
+      channelId: args.channelId,
+      cumulativeAmount: args.cumulativeAmount,
+      ...(args.expiresAt !== undefined ? { expiresAt: args.expiresAt } : {}),
+    },
+    signer: args.signerAddress,
+    signature: bs58.encode(sig),
+    signatureType: "ed25519" as const,
+  };
+}
+
+// Splits signed by the Flex authorization MUST match the challenge's
+// `defaultSplits` or the handler will reject the voucher (splits
+// cross-check lives alongside the signature verification in
+// handleSettle). These helpers sign the canonical default splits the
+// test handler declares.
+const TEST_DEFAULT_SPLITS = [{ recipient: RECIPIENT.toString(), bps: 10000 }];
+
+async function buildFlexExtension(args: {
+  keypair: SessionKeyPair;
+  channelId: string;
+  authorizationId: string;
+  maxAmount: string;
+}) {
+  const message = flexSerialize({
+    programAddress: FLEX_PROGRAM_ADDRESS,
+    escrow: address(args.channelId),
+    mint: MINT,
+    maxAmount: BigInt(args.maxAmount),
+    authorizationId: BigInt(args.authorizationId),
+    expiresAtSlot: 0n,
+    splits: TEST_DEFAULT_SPLITS.map((s) => ({
+      recipient: address(s.recipient),
+      bps: s.bps,
+    })),
+  });
+  const sig = new Uint8Array(
+    await crypto.subtle.sign("Ed25519", args.keypair.privateKey, message),
+  );
+  let binary = "";
+  for (const b of sig) binary += String.fromCharCode(b);
+  return {
+    mint: MINT.toString(),
+    authorizationId: args.authorizationId,
+    maxAmount: args.maxAmount,
+    expiresAtSlot: "0",
+    splits: TEST_DEFAULT_SPLITS,
+    signature: btoa(binary),
+  };
+}
+
+await t.test(
+  "spec §Concurrency and Idempotency — handleSettle returns current receipt for a lower-cumulative replay",
+  async (t) => {
+    // Spec text: "Submitting a voucher with lower cumulativeAmount
+    // than the highest accepted voucher SHOULD return the current
+    // receipt state and MUST NOT reduce channel state."
+    const env = await makeStoreAndHandler();
+    const { keypair, address: sessionKey } = await makeRealKeypairAddress();
+    const channelId = address("9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM");
+
+    await env.store.put({
+      channelId,
+      sessionKey,
+      mint: MINT,
+      escrowedAmount: 1_000_000n,
+      acceptedCumulative: 200n,
+      spent: 0n,
+      inFlightAuthorizationIds: [],
+      status: "open",
+    });
+
+    const challenge = await env.handler.getChallenge(
+      SESSION_INTENT,
+      {
+        amount: "25",
+        asset: MINT.toString(),
+        recipient: RECIPIENT.toString(),
+        network: "solana-devnet",
+      },
+      "http://test/resource",
+    );
+
+    const signedVoucher = await buildSignedVoucher({
+      keypair,
+      signerAddress: sessionKey.toString(),
+      channelId: channelId.toString(),
+      cumulativeAmount: "100",
+    });
+    const flex = await buildFlexExtension({
+      keypair,
+      channelId: channelId.toString(),
+      authorizationId: "1",
+      maxAmount: "100",
+    });
+
+    const credential = {
+      challenge,
+      payload: {
+        action: "voucher",
+        channelId: channelId.toString(),
+        voucher: signedVoucher,
+        flex,
+      },
+    };
+
+    const receipt = await env.handler.handleSettle(credential);
+    t.ok(receipt, "handleSettle must return a receipt, not throw");
+    t.equal(
+      receipt?.acceptedCumulative,
+      "200",
+      "receipt must report the channel's current acceptedCumulative, not the replay's cumulative",
+    );
+
+    // State must be unchanged.
+    const state = await env.store.get(channelId);
+    t.equal(
+      state?.acceptedCumulative,
+      200n,
+      "replay must not reduce channel state",
+    );
+    t.end();
+  },
+);
+
+await t.test(
+  "spec §Voucher Verification step 10 — handleSettle persists acceptedCumulative before returning",
+  async (t) => {
+    const env = await makeStoreAndHandler();
+    const { keypair, address: sessionKey } = await makeRealKeypairAddress();
+    const channelId = address("9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM");
+
+    await env.store.put({
+      channelId,
+      sessionKey,
+      mint: MINT,
+      escrowedAmount: 1_000_000n,
+      acceptedCumulative: 0n,
+      spent: 0n,
+      inFlightAuthorizationIds: [],
+      status: "open",
+    });
+
+    const challenge = await env.handler.getChallenge(
+      SESSION_INTENT,
+      {
+        amount: "25",
+        asset: MINT.toString(),
+        recipient: RECIPIENT.toString(),
+        network: "solana-devnet",
+      },
+      "http://test/resource",
+    );
+
+    const signedVoucher = await buildSignedVoucher({
+      keypair,
+      signerAddress: sessionKey.toString(),
+      channelId: channelId.toString(),
+      cumulativeAmount: "500",
+    });
+    const flex = await buildFlexExtension({
+      keypair,
+      channelId: channelId.toString(),
+      authorizationId: "42",
+      maxAmount: "500",
+    });
+
+    const receipt = await env.handler.handleSettle({
+      challenge,
+      payload: {
+        action: "voucher",
+        channelId: channelId.toString(),
+        voucher: signedVoucher,
+        flex,
+      },
+    });
+    t.equal(
+      receipt?.acceptedCumulative,
+      "500",
+      "receipt must reflect the new acceptedCumulative",
+    );
+
+    const state = await env.store.get(channelId);
+    t.equal(
+      state?.acceptedCumulative,
+      500n,
+      "session store must be advanced to the voucher's cumulativeAmount",
+    );
+    t.matchOnly(
+      state?.inFlightAuthorizationIds,
+      [42n],
+      "Flex authorizationId must be tracked against the escrow's pending cap",
+    );
+    t.end();
+  },
+);
+
+await t.test(
+  "spec §Voucher Verification step 7 — handleSettle rejects voucher on a closing channel",
+  async (t) => {
+    const env = await makeStoreAndHandler();
+    const { keypair, address: sessionKey } = await makeRealKeypairAddress();
+    const channelId = address("9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM");
+
+    await env.store.put({
+      channelId,
+      sessionKey,
+      mint: MINT,
+      escrowedAmount: 1_000_000n,
+      acceptedCumulative: 0n,
+      spent: 0n,
+      inFlightAuthorizationIds: [],
+      status: "closing",
+    });
+
+    const challenge = await env.handler.getChallenge(
+      SESSION_INTENT,
+      {
+        amount: "25",
+        asset: MINT.toString(),
+        recipient: RECIPIENT.toString(),
+        network: "solana-devnet",
+      },
+      "http://test/resource",
+    );
+    const signedVoucher = await buildSignedVoucher({
+      keypair,
+      signerAddress: sessionKey.toString(),
+      channelId: channelId.toString(),
+      cumulativeAmount: "100",
+    });
+    const flex = await buildFlexExtension({
+      keypair,
+      channelId: channelId.toString(),
+      authorizationId: "1",
+      maxAmount: "100",
+    });
+
+    await t.rejects(
+      () =>
+        env.handler.handleSettle({
+          challenge,
+          payload: {
+            action: "voucher",
+            channelId: channelId.toString(),
+            voucher: signedVoucher,
+            flex,
+          },
+        }),
+      "handleSettle must reject a voucher on a non-open channel",
+    );
+    t.end();
+  },
+);
+
+await t.test(
+  "spec §Voucher Verification step 8 — handleSettle rejects voucher whose cumulative exceeds escrow",
+  async (t) => {
+    const env = await makeStoreAndHandler();
+    const { keypair, address: sessionKey } = await makeRealKeypairAddress();
+    const channelId = address("9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM");
+
+    await env.store.put({
+      channelId,
+      sessionKey,
+      mint: MINT,
+      escrowedAmount: 1000n,
+      acceptedCumulative: 0n,
+      spent: 0n,
+      inFlightAuthorizationIds: [],
+      status: "open",
+    });
+
+    const challenge = await env.handler.getChallenge(
+      SESSION_INTENT,
+      {
+        amount: "25",
+        asset: MINT.toString(),
+        recipient: RECIPIENT.toString(),
+        network: "solana-devnet",
+      },
+      "http://test/resource",
+    );
+    const signedVoucher = await buildSignedVoucher({
+      keypair,
+      signerAddress: sessionKey.toString(),
+      channelId: channelId.toString(),
+      cumulativeAmount: "9999999",
+    });
+    const flex = await buildFlexExtension({
+      keypair,
+      channelId: channelId.toString(),
+      authorizationId: "1",
+      maxAmount: "9999999",
+    });
+
+    await t.rejects(
+      () =>
+        env.handler.handleSettle({
+          challenge,
+          payload: {
+            action: "voucher",
+            channelId: channelId.toString(),
+            voucher: signedVoucher,
+            flex,
+          },
+        }),
+      "handleSettle must reject a voucher whose cumulativeAmount exceeds escrowedAmount",
+    );
+    t.end();
+  },
+);
+
+await t.test(
+  "spec §Voucher Verification step 3 — handleSettle rejects voucher signed by a key not registered for the channel",
+  async (t) => {
+    const env = await makeStoreAndHandler();
+    const registered = await makeRealKeypairAddress();
+    const attacker = await makeRealKeypairAddress();
+    const channelId = address("9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM");
+
+    await env.store.put({
+      channelId,
+      sessionKey: registered.address,
+      mint: MINT,
+      escrowedAmount: 1_000_000n,
+      acceptedCumulative: 0n,
+      spent: 0n,
+      inFlightAuthorizationIds: [],
+      status: "open",
+    });
+
+    const challenge = await env.handler.getChallenge(
+      SESSION_INTENT,
+      {
+        amount: "25",
+        asset: MINT.toString(),
+        recipient: RECIPIENT.toString(),
+        network: "solana-devnet",
+      },
+      "http://test/resource",
+    );
+
+    // Voucher is signed by `attacker`, not by the channel's
+    // registered session key.
+    const signedVoucher = await buildSignedVoucher({
+      keypair: attacker.keypair,
+      signerAddress: attacker.address.toString(),
+      channelId: channelId.toString(),
+      cumulativeAmount: "100",
+    });
+    const flex = await buildFlexExtension({
+      keypair: attacker.keypair,
+      channelId: channelId.toString(),
+      authorizationId: "1",
+      maxAmount: "100",
+    });
+
+    const credential = {
+      challenge,
+      payload: {
+        action: "voucher",
+        channelId: channelId.toString(),
+        voucher: signedVoucher,
+        flex,
+      },
+    };
+
+    await t.rejects(
+      () => env.handler.handleSettle(credential),
+      "handleSettle must reject a voucher whose signer is not the channel's registered session key",
+    );
+    t.end();
+  },
+);
+
+await t.test(
+  "spec §Action: close — handleSettle rejects a close credential carrying an attacker-signed final voucher",
+  async (t) => {
+    const env = await makeStoreAndHandler();
+    const registered = await makeRealKeypairAddress();
+    const attacker = await makeRealKeypairAddress();
+    const channelId = address("9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM");
+
+    await env.store.put({
+      channelId,
+      sessionKey: registered.address,
+      mint: MINT,
+      escrowedAmount: 1_000_000n,
+      acceptedCumulative: 100n,
+      spent: 0n,
+      inFlightAuthorizationIds: [],
+      status: "open",
+    });
+
+    const challenge = await env.handler.getChallenge(
+      SESSION_INTENT,
+      {
+        amount: "25",
+        asset: MINT.toString(),
+        recipient: RECIPIENT.toString(),
+        network: "solana-devnet",
+      },
+      "http://test/resource",
+    );
+
+    const forged = await buildSignedVoucher({
+      keypair: attacker.keypair,
+      signerAddress: attacker.address.toString(),
+      channelId: channelId.toString(),
+      cumulativeAmount: "999",
+    });
+
+    await t.rejects(
+      () =>
+        env.handler.handleSettle({
+          challenge,
+          payload: {
+            action: "close",
+            channelId: channelId.toString(),
+            voucher: forged,
+          },
+        }),
+      "close must reject a final voucher not signed by the channel's session key",
+    );
+
+    // State must be unchanged.
+    const after = await env.store.get(channelId);
+    t.equal(after?.acceptedCumulative, 100n, "state acceptedCumulative intact");
+    t.end();
+  },
+);
+
+await t.test(
+  "spec §Action: close — handleSettle close with no voucher marks the channel as closing",
+  async (t) => {
+    const env = await makeStoreAndHandler();
+    const { address: sessionKey } = await makeRealKeypairAddress();
+    const channelId = address("9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM");
+
+    await env.store.put({
+      channelId,
+      sessionKey,
+      mint: MINT,
+      escrowedAmount: 1_000_000n,
+      acceptedCumulative: 100n,
+      spent: 0n,
+      inFlightAuthorizationIds: [],
+      status: "open",
+    });
+
+    const challenge = await env.handler.getChallenge(
+      SESSION_INTENT,
+      {
+        amount: "25",
+        asset: MINT.toString(),
+        recipient: RECIPIENT.toString(),
+        network: "solana-devnet",
+      },
+      "http://test/resource",
+    );
+
+    const receipt = await env.handler.handleSettle({
+      challenge,
+      payload: {
+        action: "close",
+        channelId: channelId.toString(),
+      },
+    });
+    t.ok(receipt, "close without voucher must return a receipt");
+
+    const after = await env.store.get(channelId);
+    t.equal(
+      after?.status,
+      "closing",
+      "close must transition the channel status to closing",
+    );
+    t.end();
+  },
+);
+
+await t.test(
+  "spec §Action: topUp — handleSettle throws because topUp settlement is not implemented",
+  async (t) => {
+    const env = await makeStoreAndHandler();
+    const { address: sessionKey } = await makeRealKeypairAddress();
+    const channelId = address("9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM");
+
+    await env.store.put({
+      channelId,
+      sessionKey,
+      mint: MINT,
+      escrowedAmount: 1_000_000n,
+      acceptedCumulative: 0n,
+      spent: 0n,
+      inFlightAuthorizationIds: [],
+      status: "open",
+    });
+
+    const challenge = await env.handler.getChallenge(
+      SESSION_INTENT,
+      {
+        amount: "25",
+        asset: MINT.toString(),
+        recipient: RECIPIENT.toString(),
+        network: "solana-devnet",
+      },
+      "http://test/resource",
+    );
+
+    await t.rejects(
+      () =>
+        env.handler.handleSettle({
+          challenge,
+          payload: {
+            action: "topUp",
+            channelId: channelId.toString(),
+            additionalAmount: "500",
+            transaction: "not-verified",
+          },
+        }),
+      "topUp must be rejected instead of silently returning a success receipt",
+    );
+    t.end();
+  },
+);
+
+await t.test(
+  "spec §Action: close — handleSettle rejects a close credential after the channel is already closing",
+  async (t) => {
+    const env = await makeStoreAndHandler();
+    const { address: sessionKey } = await makeRealKeypairAddress();
+    const channelId = address("9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM");
+
+    await env.store.put({
+      channelId,
+      sessionKey,
+      mint: MINT,
+      escrowedAmount: 1_000_000n,
+      acceptedCumulative: 100n,
+      spent: 0n,
+      inFlightAuthorizationIds: [],
+      status: "closing",
+    });
+
+    const challenge = await env.handler.getChallenge(
+      SESSION_INTENT,
+      {
+        amount: "25",
+        asset: MINT.toString(),
+        recipient: RECIPIENT.toString(),
+        network: "solana-devnet",
+      },
+      "http://test/resource",
+    );
+
+    await t.rejects(
+      () =>
+        env.handler.handleSettle({
+          challenge,
+          payload: {
+            action: "close",
+            channelId: channelId.toString(),
+          },
+        }),
+      "close on a non-open channel must be rejected",
+    );
+    t.end();
+  },
+);
+
+await t.test(
+  "spec §Concurrency and Idempotency — concurrent vouchers: each receipt reflects that voucher's own persisted state",
+  async (t) => {
+    // The store.get delay is applied only to reads (not writes) so the
+    // race window is between tryRegisterVoucher returning and the
+    // receipt build. Without a fix, voucher A's receipt reports voucher
+    // B's acceptedCumulative because B raced in between A's lock
+    // release and A's state read.
+    const baseStore = createInMemorySessionStore();
+    let slow = false;
+    const slowStore: typeof baseStore = {
+      async get(id) {
+        if (slow) {
+          await new Promise((r) => setTimeout(r, 40));
+        }
+        return baseStore.get(id);
+      },
+      put: baseStore.put.bind(baseStore),
+      delete: baseStore.delete.bind(baseStore),
+      iterate: baseStore.iterate.bind(baseStore),
+    };
+    const facilitatorSigner = await generateKeyPairSigner();
+    const handler = await createMPPSolanaSessionHandler({
+      network: "solana-devnet",
+      rpc: stubRpc,
+      facilitatorSigner,
+      supportedMints: [MINT],
+      mintDecimals: 6,
+      defaultSplits: [{ recipient: RECIPIENT.toString(), bps: 10000 }],
+      realm: "test",
+      secretKey: SECRET_KEY,
+      sessionStore: slowStore,
+      refundTimeoutSlots: 150n,
+      deadmanTimeoutSlots: 1000n,
+      minGracePeriodSlots: 150n,
+      challengeExpiresSeconds: 3600,
+      maxRetries: 1,
+      retryDelayMs: 1,
+      flushIntervalMs: 1000,
+      programAddress: FLEX_PROGRAM_ADDRESS,
+    });
+
+    const { keypair, address: sessionKey } = await makeRealKeypairAddress();
+    const channelId = address("9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM");
+    await baseStore.put({
+      channelId,
+      sessionKey,
+      mint: MINT,
+      escrowedAmount: 1_000_000n,
+      acceptedCumulative: 0n,
+      spent: 0n,
+      inFlightAuthorizationIds: [],
+      status: "open",
+    });
+
+    const challenge = await handler.getChallenge(
+      SESSION_INTENT,
+      {
+        amount: "25",
+        asset: MINT.toString(),
+        recipient: RECIPIENT.toString(),
+        network: "solana-devnet",
+      },
+      "http://test/resource",
+    );
+
+    const buildCredential = async (cumulative: string, authId: string) => {
+      const voucher = await buildSignedVoucher({
+        keypair,
+        signerAddress: sessionKey.toString(),
+        channelId: channelId.toString(),
+        cumulativeAmount: cumulative,
+      });
+      const flex = await buildFlexExtension({
+        keypair,
+        channelId: channelId.toString(),
+        authorizationId: authId,
+        maxAmount: cumulative,
+      });
+      return {
+        challenge,
+        payload: {
+          action: "voucher",
+          channelId: channelId.toString(),
+          voucher,
+          flex,
+        },
+      };
+    };
+
+    slow = true;
+    const [receiptA, receiptB] = await Promise.all([
+      handler.handleSettle(await buildCredential("100", "1")),
+      handler.handleSettle(await buildCredential("200", "2")),
+    ]);
+
+    // With the race, both receipts report 200 because the outer
+    // state read runs outside the lock. The fix returns the
+    // post-register state from tryRegisterVoucher so each receipt
+    // reflects the state that that voucher persisted.
+    t.ok(receiptA && receiptB);
+    const receipts = [
+      receiptA?.acceptedCumulative,
+      receiptB?.acceptedCumulative,
+    ].sort();
+    t.matchOnly(
+      receipts,
+      ["100", "200"],
+      "the two receipts must reflect each voucher's own persisted cumulative",
+    );
+    t.end();
+  },
+);
+
+await t.test(
+  "spec §Settlement Procedure / Open step 3 — verify-open rejects an open transaction whose fee payer is not the credential payer when sponsorFees is false",
+  async (t) => {
+    // This test targets the non-sponsored-fees branch of the spec's
+    // fee-payer check (§"Settlement Procedure / Open" step 3). We
+    // build the handler with sponsorFees: false and call
+    // verifyFlexOpenTransaction directly with an expectedPayer that
+    // does not match the transaction's fee payer. The handler should
+    // reject.
+    const owner = await generateKeyPairSigner();
+    const source = await generateKeyPairSigner();
+    const otherKey = await generateKeyPairSigner();
+    const sessionKeyRaw = new Uint8Array(
+      await crypto.subtle.exportKey(
+        "raw",
+        (
+          (await crypto.subtle.generateKey("Ed25519", true, [
+            "sign",
+            "verify",
+          ])) as SessionKeyPair
+        ).publicKey,
+      ),
+    );
+    const sessionKey = address(bs58.encode(sessionKeyRaw));
+
+    const built = await buildSessionOpenInstructions({
+      owner,
+      facilitator: otherKey.address,
+      sessionKey,
+      mint: MINT,
+      source: source.address,
+      index: 0n,
+      depositAmount: 1_000_000n,
+      refundTimeoutSlots: 150n,
+      deadmanTimeoutSlots: 1000n,
+      maxSessionKeys: 1,
+      sessionKeyExpiresAtSlot: null,
+      sessionKeyGracePeriodSlots: 150n,
+      programAddress: FLEX_PROGRAM_ADDRESS,
+    });
+    const txMsg = pipe(
+      createTransactionMessage({ version: 0 }),
+      (m) => setTransactionMessageFeePayerSigner(owner, m),
+      (m) =>
+        setTransactionMessageLifetimeUsingBlockhash(
+          {
+            blockhash: "EETubP46DHLkT9hAFKy4x2BoFUqUFvKjiiNVY3CaYRi3" as never,
+            lastValidBlockHeight: 1000n,
+          },
+          m,
+        ),
+      (m) => appendTransactionMessageInstructions(built.instructions, m),
+    );
+    const signed = await signTransactionMessageWithSigners(txMsg);
+    const wire = getBase64EncodedWireTransaction(signed);
+
+    await t.rejects(
+      () =>
+        verifyFlexOpenTransaction({
+          transaction: wire,
+          expectedChannelId: built.escrow,
+          expectedSessionKey: sessionKey,
+          programAddress: FLEX_PROGRAM_ADDRESS,
+          expectedPayer: otherKey.address,
+        }),
+      "verify-open must reject a transaction whose fee payer is not the expected payer",
+    );
+    t.end();
+  },
+);
+
+await t.test(
+  "Flex invariant — verify-open rejects an open transaction whose create_escrow facilitator is not the expected facilitator",
+  async (t) => {
+    const owner = await generateKeyPairSigner();
+    const source = await generateKeyPairSigner();
+    const wrongFacilitator = await generateKeyPairSigner();
+    const expectedFacilitator = await generateKeyPairSigner();
+    const sessionKeyRaw = new Uint8Array(
+      await crypto.subtle.exportKey(
+        "raw",
+        (
+          (await crypto.subtle.generateKey("Ed25519", true, [
+            "sign",
+            "verify",
+          ])) as SessionKeyPair
+        ).publicKey,
+      ),
+    );
+    const sessionKey = address(bs58.encode(sessionKeyRaw));
+
+    const built = await buildSessionOpenInstructions({
+      owner,
+      facilitator: wrongFacilitator.address,
+      sessionKey,
+      mint: MINT,
+      source: source.address,
+      index: 0n,
+      depositAmount: 1_000_000n,
+      refundTimeoutSlots: 150n,
+      deadmanTimeoutSlots: 1000n,
+      maxSessionKeys: 1,
+      sessionKeyExpiresAtSlot: null,
+      sessionKeyGracePeriodSlots: 150n,
+      programAddress: FLEX_PROGRAM_ADDRESS,
+    });
+    const txMsg = pipe(
+      createTransactionMessage({ version: 0 }),
+      (m) => setTransactionMessageFeePayerSigner(owner, m),
+      (m) =>
+        setTransactionMessageLifetimeUsingBlockhash(
+          {
+            blockhash: "EETubP46DHLkT9hAFKy4x2BoFUqUFvKjiiNVY3CaYRi3" as never,
+            lastValidBlockHeight: 1000n,
+          },
+          m,
+        ),
+      (m) => appendTransactionMessageInstructions(built.instructions, m),
+    );
+    const signed = await signTransactionMessageWithSigners(txMsg);
+    const wire = getBase64EncodedWireTransaction(signed);
+
+    await t.rejects(
+      () =>
+        verifyFlexOpenTransaction({
+          transaction: wire,
+          expectedChannelId: built.escrow,
+          expectedSessionKey: sessionKey,
+          programAddress: FLEX_PROGRAM_ADDRESS,
+          expectedFacilitator: expectedFacilitator.address,
+        }),
+      "verify-open must reject a transaction whose create_escrow facilitator is not the expected facilitator",
+    );
+    t.end();
+  },
+);
+
+await t.test(
+  "Flex invariant — verify-open rejects an open transaction whose refund/deadman slots do not match expected",
+  async (t) => {
+    const owner = await generateKeyPairSigner();
+    const source = await generateKeyPairSigner();
+    const facilitator = await generateKeyPairSigner();
+    const sessionKeyRaw = new Uint8Array(
+      await crypto.subtle.exportKey(
+        "raw",
+        (
+          (await crypto.subtle.generateKey("Ed25519", true, [
+            "sign",
+            "verify",
+          ])) as SessionKeyPair
+        ).publicKey,
+      ),
+    );
+    const sessionKey = address(bs58.encode(sessionKeyRaw));
+
+    const built = await buildSessionOpenInstructions({
+      owner,
+      facilitator: facilitator.address,
+      sessionKey,
+      mint: MINT,
+      source: source.address,
+      index: 0n,
+      depositAmount: 1_000_000n,
+      // These differ from what the handler advertises. Handler is built
+      // below with 150n/1000n; the client builds with 75n/500n so the
+      // decoded values should be rejected.
+      refundTimeoutSlots: 75n,
+      deadmanTimeoutSlots: 500n,
+      maxSessionKeys: 1,
+      sessionKeyExpiresAtSlot: null,
+      sessionKeyGracePeriodSlots: 150n,
+      programAddress: FLEX_PROGRAM_ADDRESS,
+    });
+    const txMsg = pipe(
+      createTransactionMessage({ version: 0 }),
+      (m) => setTransactionMessageFeePayerSigner(owner, m),
+      (m) =>
+        setTransactionMessageLifetimeUsingBlockhash(
+          {
+            blockhash: "EETubP46DHLkT9hAFKy4x2BoFUqUFvKjiiNVY3CaYRi3" as never,
+            lastValidBlockHeight: 1000n,
+          },
+          m,
+        ),
+      (m) => appendTransactionMessageInstructions(built.instructions, m),
+    );
+    const signed = await signTransactionMessageWithSigners(txMsg);
+    const wire = getBase64EncodedWireTransaction(signed);
+
+    await t.rejects(
+      () =>
+        verifyFlexOpenTransaction({
+          transaction: wire,
+          expectedChannelId: built.escrow,
+          expectedSessionKey: sessionKey,
+          programAddress: FLEX_PROGRAM_ADDRESS,
+          expectedRefundTimeoutSlots: 150n,
+          expectedDeadmanTimeoutSlots: 1000n,
+        }),
+      "verify-open must reject a transaction whose refund/deadman slot counts differ from the handler's advertised values",
+    );
+    t.end();
+  },
+);
+
+await t.test(
+  "spec §Settlement Procedure / Open step 4 — verify-open rejects an open transaction that carries duplicate Flex instructions",
+  async (t) => {
+    const owner = await generateKeyPairSigner();
+    const source = await generateKeyPairSigner();
+    const facilitator = await generateKeyPairSigner();
+    const sessionKeyRaw = new Uint8Array(
+      await crypto.subtle.exportKey(
+        "raw",
+        (
+          (await crypto.subtle.generateKey("Ed25519", true, [
+            "sign",
+            "verify",
+          ])) as SessionKeyPair
+        ).publicKey,
+      ),
+    );
+    const sessionKey = address(bs58.encode(sessionKeyRaw));
+
+    const built = await buildSessionOpenInstructions({
+      owner,
+      facilitator: facilitator.address,
+      sessionKey,
+      mint: MINT,
+      source: source.address,
+      index: 0n,
+      depositAmount: 1_000_000n,
+      refundTimeoutSlots: 150n,
+      deadmanTimeoutSlots: 1000n,
+      maxSessionKeys: 1,
+      sessionKeyExpiresAtSlot: null,
+      sessionKeyGracePeriodSlots: 150n,
+      programAddress: FLEX_PROGRAM_ADDRESS,
+    });
+    // Append a duplicate deposit instruction — verify-open currently
+    // uses .find() on the discriminator and silently ignores
+    // duplicates.
+    const duplicated = [...built.instructions, built.instructions[1]];
+    const txMsg = pipe(
+      createTransactionMessage({ version: 0 }),
+      (m) => setTransactionMessageFeePayerSigner(owner, m),
+      (m) =>
+        setTransactionMessageLifetimeUsingBlockhash(
+          {
+            blockhash: "EETubP46DHLkT9hAFKy4x2BoFUqUFvKjiiNVY3CaYRi3" as never,
+            lastValidBlockHeight: 1000n,
+          },
+          m,
+        ),
+      (m) => appendTransactionMessageInstructions(duplicated, m),
+    );
+    const signed = await signTransactionMessageWithSigners(txMsg);
+    const wire = getBase64EncodedWireTransaction(signed);
+
+    await t.rejects(
+      () =>
+        verifyFlexOpenTransaction({
+          transaction: wire,
+          expectedChannelId: built.escrow,
+          expectedSessionKey: sessionKey,
+          programAddress: FLEX_PROGRAM_ADDRESS,
+        }),
+      "verify-open must reject a transaction carrying duplicate Flex instructions",
+    );
+    t.end();
+  },
+);
+
+await t.test(
+  "open-tx signature — verify-open rejects a transaction whose fee payer has not signed",
+  async (t) => {
+    const owner = await generateKeyPairSigner();
+    const source = await generateKeyPairSigner();
+    const facilitator = await generateKeyPairSigner();
+    const sessionKeyRaw = new Uint8Array(
+      await crypto.subtle.exportKey(
+        "raw",
+        (
+          (await crypto.subtle.generateKey("Ed25519", true, [
+            "sign",
+            "verify",
+          ])) as SessionKeyPair
+        ).publicKey,
+      ),
+    );
+    const sessionKey = address(bs58.encode(sessionKeyRaw));
+
+    const built = await buildSessionOpenInstructions({
+      owner,
+      facilitator: facilitator.address,
+      sessionKey,
+      mint: MINT,
+      source: source.address,
+      index: 0n,
+      depositAmount: 1_000_000n,
+      refundTimeoutSlots: 150n,
+      deadmanTimeoutSlots: 1000n,
+      maxSessionKeys: 1,
+      sessionKeyExpiresAtSlot: null,
+      sessionKeyGracePeriodSlots: 150n,
+      programAddress: FLEX_PROGRAM_ADDRESS,
+    });
+    // Compile without signing — the resulting wire transaction has
+    // no signatures attached.
+    const txMsg = pipe(
+      createTransactionMessage({ version: 0 }),
+      (m) => setTransactionMessageFeePayerSigner(owner, m),
+      (m) =>
+        setTransactionMessageLifetimeUsingBlockhash(
+          {
+            blockhash: "EETubP46DHLkT9hAFKy4x2BoFUqUFvKjiiNVY3CaYRi3" as never,
+            lastValidBlockHeight: 1000n,
+          },
+          m,
+        ),
+      (m) => appendTransactionMessageInstructions(built.instructions, m),
+    );
+    const compiled = compileTransaction(txMsg);
+    const wire = getBase64EncodedWireTransaction(
+      compiled as unknown as Parameters<
+        typeof getBase64EncodedWireTransaction
+      >[0],
+    );
+
+    await t.rejects(
+      () =>
+        verifyFlexOpenTransaction({
+          transaction: wire,
+          expectedChannelId: built.escrow,
+          expectedSessionKey: sessionKey,
+          programAddress: FLEX_PROGRAM_ADDRESS,
+        }),
+      "verify-open must reject a transaction with no signatures",
+    );
+    t.end();
+  },
+);
+
+await t.test(
+  "spec §Error Responses — handleSettle throws on a malformed challenge.request instead of returning null",
+  async (t) => {
+    const env = await makeStoreAndHandler();
+    const challenge = await env.handler.getChallenge(
+      SESSION_INTENT,
+      {
+        amount: "25",
+        asset: MINT.toString(),
+        recipient: RECIPIENT.toString(),
+        network: "solana-devnet",
+      },
+      "http://test/resource",
+    );
+    const bogus = {
+      ...challenge,
+      request: "!!not-valid-base64-or-json!!",
+    };
+    await t.rejects(
+      () =>
+        env.handler.handleSettle({
+          challenge: bogus,
+          payload: { action: "voucher", channelId: "anything" },
+        }),
+      "malformed challenge.request must throw, not silently return null",
+    );
+    t.end();
+  },
+);
+
+await t.test(
+  "spec §Error Responses — handleSettle throws on a malformed challenge.expires field",
+  async (t) => {
+    const env = await makeStoreAndHandler();
+    const challenge = await env.handler.getChallenge(
+      SESSION_INTENT,
+      {
+        amount: "25",
+        asset: MINT.toString(),
+        recipient: RECIPIENT.toString(),
+        network: "solana-devnet",
+      },
+      "http://test/resource",
+    );
+    const bogus = {
+      ...challenge,
+      expires: "not-a-number",
+    };
+    await t.rejects(
+      () =>
+        env.handler.handleSettle({
+          challenge: bogus,
+          payload: { action: "voucher", channelId: "anything" },
+        }),
+      "malformed challenge.expires must throw, not silently skip",
+    );
+    t.end();
+  },
+);
+
+await t.test(
+  "spec §Channel Exhaustion — handler rejects an open transaction whose depositAmount is below the minimum",
+  async (t) => {
+    const facilitatorSigner = await generateKeyPairSigner();
+    const handler = await createMPPSolanaSessionHandler({
+      network: "solana-devnet",
+      rpc: stubRpc,
+      facilitatorSigner,
+      // This test exercises the minimum-deposit check, not fee-payer
+      // policy, so disable sponsored fees.
+      sponsorFees: false,
+      supportedMints: [MINT],
+      mintDecimals: 6,
+      defaultSplits: [{ recipient: RECIPIENT.toString(), bps: 10000 }],
+      realm: "test",
+      secretKey: SECRET_KEY,
+      refundTimeoutSlots: 150n,
+      deadmanTimeoutSlots: 1000n,
+      minGracePeriodSlots: 150n,
+      challengeExpiresSeconds: 3600,
+      maxRetries: 1,
+      retryDelayMs: 1,
+      flushIntervalMs: 1000,
+      programAddress: FLEX_PROGRAM_ADDRESS,
+      minDepositAmount: 10_000n,
+    });
+
+    const owner = await generateKeyPairSigner();
+    const source = await generateKeyPairSigner();
+    const sessionKeyPair = (await crypto.subtle.generateKey("Ed25519", true, [
+      "sign",
+      "verify",
+    ])) as SessionKeyPair;
+    const raw = new Uint8Array(
+      await crypto.subtle.exportKey("raw", sessionKeyPair.publicKey),
+    );
+    const sessionKey = address(bs58.encode(raw));
+
+    const built = await buildSessionOpenInstructions({
+      owner,
+      facilitator: facilitatorSigner.address,
+      sessionKey,
+      mint: MINT,
+      source: source.address,
+      index: 0n,
+      depositAmount: 1n,
+      refundTimeoutSlots: 150n,
+      deadmanTimeoutSlots: 1000n,
+      maxSessionKeys: 1,
+      sessionKeyExpiresAtSlot: null,
+      sessionKeyGracePeriodSlots: 150n,
+      programAddress: FLEX_PROGRAM_ADDRESS,
+    });
+    const txMsg = pipe(
+      createTransactionMessage({ version: 0 }),
+      (m) => setTransactionMessageFeePayerSigner(owner, m),
+      (m) =>
+        setTransactionMessageLifetimeUsingBlockhash(
+          {
+            blockhash: "EETubP46DHLkT9hAFKy4x2BoFUqUFvKjiiNVY3CaYRi3" as never,
+            lastValidBlockHeight: 1000n,
+          },
+          m,
+        ),
+      (m) => appendTransactionMessageInstructions(built.instructions, m),
+    );
+    const signed = await signTransactionMessageWithSigners(txMsg);
+    const wire = getBase64EncodedWireTransaction(signed);
+
+    const initialVoucherMessage = serializeSpecVoucherMessage({
+      channelId: built.escrow.toString(),
+      cumulativeAmount: "0",
+    });
+    const initialVoucherSig = new Uint8Array(
+      await crypto.subtle.sign(
+        "Ed25519",
+        sessionKeyPair.privateKey,
+        initialVoucherMessage,
+      ),
+    );
+
+    const challenge = await handler.getChallenge(
+      SESSION_INTENT,
+      {
+        amount: "25",
+        asset: MINT.toString(),
+        recipient: RECIPIENT.toString(),
+        network: "solana-devnet",
+      },
+      "http://test/resource",
+    );
+
+    await t.rejects(
+      () =>
+        handler.handleSettle({
+          challenge,
+          payload: {
+            action: "open",
+            channelId: built.escrow.toString(),
+            payer: owner.address.toString(),
+            depositAmount: "1",
+            transaction: wire,
+            voucher: {
+              voucher: {
+                channelId: built.escrow.toString(),
+                cumulativeAmount: "0",
+              },
+              signer: sessionKey.toString(),
+              signature: bs58.encode(initialVoucherSig),
+              signatureType: "ed25519",
+            },
+          },
+        }),
+      "handler must reject an open transaction whose depositAmount is below minDepositAmount",
+    );
+    t.end();
+  },
+);
+
+const TEST_CHANNEL_A = address("9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM");
+const TEST_CHANNEL_B = address("4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi");
+
+async function seedOpenChannel(
+  store: ReturnType<typeof createInMemorySessionStore>,
+  channelId: import("@solana/kit").Address,
+  sessionKey: import("@solana/kit").Address,
+  overrides: Partial<SessionState> = {},
+) {
+  await store.put({
+    channelId,
+    sessionKey,
+    mint: MINT,
+    escrowedAmount: 1_000_000n,
+    acceptedCumulative: 0n,
+    spent: 0n,
+    inFlightAuthorizationIds: [],
+    status: "open",
+    ...overrides,
+  });
+}
+
+await t.test(
+  "spec §Voucher Verification step 4 — voucher inner channelId must equal credential channelId",
+  async (t) => {
+    const env = await makeStoreAndHandler();
+    const { keypair, address: sessionKey } = await makeRealKeypairAddress();
+    await seedOpenChannel(env.store, TEST_CHANNEL_A, sessionKey);
+
+    const challenge = await env.handler.getChallenge(
+      SESSION_INTENT,
+      {
+        amount: "25",
+        asset: MINT.toString(),
+        recipient: RECIPIENT.toString(),
+        network: "solana-devnet",
+      },
+      "http://test/resource",
+    );
+
+    // Voucher signed for channel B but submitted under channelId A.
+    const tampered = await buildSignedVoucher({
+      keypair,
+      signerAddress: sessionKey.toString(),
+      channelId: TEST_CHANNEL_B.toString(),
+      cumulativeAmount: "100",
+    });
+    const flex = await buildFlexExtension({
+      keypair,
+      channelId: TEST_CHANNEL_A.toString(),
+      authorizationId: "1",
+      maxAmount: "100",
+    });
+
+    await t.rejects(
+      () =>
+        env.handler.handleSettle({
+          challenge,
+          payload: {
+            action: "voucher",
+            channelId: TEST_CHANNEL_A.toString(),
+            voucher: tampered,
+            flex,
+          },
+        }),
+      "voucher whose inner channelId differs from the credential channelId must be rejected",
+    );
+    t.end();
+  },
+);
+
+await t.test(
+  "spec §Challenge — handleSettle rejects credentials with tampered challenge fields",
+  async (t) => {
+    const env = await makeStoreAndHandler();
+    const { keypair, address: sessionKey } = await makeRealKeypairAddress();
+    await seedOpenChannel(env.store, TEST_CHANNEL_A, sessionKey);
+
+    const challenge = await env.handler.getChallenge(
+      SESSION_INTENT,
+      {
+        amount: "25",
+        asset: MINT.toString(),
+        recipient: RECIPIENT.toString(),
+        network: "solana-devnet",
+      },
+      "http://test/resource",
+    );
+    const voucher = await buildSignedVoucher({
+      keypair,
+      signerAddress: sessionKey.toString(),
+      channelId: TEST_CHANNEL_A.toString(),
+      cumulativeAmount: "100",
+    });
+    const flex = await buildFlexExtension({
+      keypair,
+      channelId: TEST_CHANNEL_A.toString(),
+      authorizationId: "1",
+      maxAmount: "100",
+    });
+    const payload = {
+      action: "voucher" as const,
+      channelId: TEST_CHANNEL_A.toString(),
+      voucher,
+      flex,
+    };
+
+    await t.rejects(
+      () =>
+        env.handler.handleSettle({
+          challenge: { ...challenge, realm: "evil-realm" },
+          payload,
+        }),
+      "tampered realm must be rejected",
+    );
+
+    await t.rejects(
+      () =>
+        env.handler.handleSettle({
+          challenge: {
+            ...challenge,
+            request: Buffer.from('{"amount":"99999"}', "utf-8")
+              .toString("base64")
+              .replace(/\+/g, "-")
+              .replace(/\//g, "_")
+              .replace(/=+$/, ""),
+          },
+          payload,
+        }),
+      "tampered request body must be rejected",
+    );
+
+    await t.rejects(
+      () =>
+        env.handler.handleSettle({
+          challenge: { ...challenge, id: "fake-id" },
+          payload,
+        }),
+      "tampered challenge id must be rejected",
+    );
+    t.end();
+  },
+);
+
+await t.test(
+  "spec §Challenge — handleSettle rejects an expired challenge",
+  async (t) => {
+    const facilitatorSigner = await generateKeyPairSigner();
+    const handler = await createMPPSolanaSessionHandler({
+      network: "solana-devnet",
+      rpc: stubRpc,
+      facilitatorSigner,
+      sponsorFees: false,
+      supportedMints: [MINT],
+      mintDecimals: 6,
+      defaultSplits: TEST_DEFAULT_SPLITS,
+      realm: "test",
+      secretKey: SECRET_KEY,
+      refundTimeoutSlots: 150n,
+      deadmanTimeoutSlots: 1000n,
+      minGracePeriodSlots: 150n,
+      challengeExpiresSeconds: 1,
+      maxRetries: 1,
+      retryDelayMs: 1,
+      flushIntervalMs: 1000,
+      programAddress: FLEX_PROGRAM_ADDRESS,
+    });
+
+    const challenge = await handler.getChallenge(
+      SESSION_INTENT,
+      {
+        amount: "25",
+        asset: MINT.toString(),
+        recipient: RECIPIENT.toString(),
+        network: "solana-devnet",
+      },
+      "http://test/resource",
+    );
+
+    await new Promise((r) => setTimeout(r, 1500));
+
+    await t.rejects(
+      () =>
+        handler.handleSettle({
+          challenge,
+          payload: {
+            action: "voucher",
+            channelId: TEST_CHANNEL_A.toString(),
+            voucher: {
+              voucher: {
+                channelId: TEST_CHANNEL_A.toString(),
+                cumulativeAmount: "100",
+              },
+              signer: TEST_CHANNEL_A.toString(),
+              signature: "x".repeat(88),
+              signatureType: "ed25519",
+            },
+          },
+        }),
+      "expired challenge must be rejected",
+    );
+    t.end();
+  },
+);
+
+await t.test(
+  "spec §Voucher Verification step 9 — voucher expiresAt in the past must be rejected",
+  async (t) => {
+    const env = await makeStoreAndHandler();
+    const { keypair, address: sessionKey } = await makeRealKeypairAddress();
+    await seedOpenChannel(env.store, TEST_CHANNEL_A, sessionKey);
+
+    const challenge = await env.handler.getChallenge(
+      SESSION_INTENT,
+      {
+        amount: "25",
+        asset: MINT.toString(),
+        recipient: RECIPIENT.toString(),
+        network: "solana-devnet",
+      },
+      "http://test/resource",
+    );
+
+    const expiredAt = new Date(Date.now() - 60_000).toISOString();
+    const voucher = await buildSignedVoucher({
+      keypair,
+      signerAddress: sessionKey.toString(),
+      channelId: TEST_CHANNEL_A.toString(),
+      cumulativeAmount: "100",
+      expiresAt: expiredAt,
+    });
+    const flex = await buildFlexExtension({
+      keypair,
+      channelId: TEST_CHANNEL_A.toString(),
+      authorizationId: "1",
+      maxAmount: "100",
+    });
+
+    await t.rejects(
+      () =>
+        env.handler.handleSettle({
+          challenge,
+          payload: {
+            action: "voucher",
+            channelId: TEST_CHANNEL_A.toString(),
+            voucher,
+            flex,
+          },
+        }),
+      "expired voucher must be rejected",
+    );
+    t.end();
+  },
+);
+
+await t.test(
+  "spec §Voucher Format — voucher with non-ISO-8601 expiresAt must be rejected",
+  async (t) => {
+    const env = await makeStoreAndHandler();
+    const { keypair, address: sessionKey } = await makeRealKeypairAddress();
+    await seedOpenChannel(env.store, TEST_CHANNEL_A, sessionKey);
+
+    const challenge = await env.handler.getChallenge(
+      SESSION_INTENT,
+      {
+        amount: "25",
+        asset: MINT.toString(),
+        recipient: RECIPIENT.toString(),
+        network: "solana-devnet",
+      },
+      "http://test/resource",
+    );
+
+    const voucher = await buildSignedVoucher({
+      keypair,
+      signerAddress: sessionKey.toString(),
+      channelId: TEST_CHANNEL_A.toString(),
+      cumulativeAmount: "100",
+      expiresAt: "yesterday-ish",
+    });
+    const flex = await buildFlexExtension({
+      keypair,
+      channelId: TEST_CHANNEL_A.toString(),
+      authorizationId: "1",
+      maxAmount: "100",
+    });
+
+    await t.rejects(
+      () =>
+        env.handler.handleSettle({
+          challenge,
+          payload: {
+            action: "voucher",
+            channelId: TEST_CHANNEL_A.toString(),
+            voucher,
+            flex,
+          },
+        }),
+      "voucher with non-ISO-8601 expiresAt must be rejected",
+    );
+    t.end();
+  },
+);
+
+await t.test(
+  "spec §Receipt Format — handleSettle receipt validates against mppReceipt",
+  async (t) => {
+    const env = await makeStoreAndHandler();
+    const { keypair, address: sessionKey } = await makeRealKeypairAddress();
+    await seedOpenChannel(env.store, TEST_CHANNEL_A, sessionKey);
+
+    const challenge = await env.handler.getChallenge(
+      SESSION_INTENT,
+      {
+        amount: "25",
+        asset: MINT.toString(),
+        recipient: RECIPIENT.toString(),
+        network: "solana-devnet",
+      },
+      "http://test/resource",
+    );
+    const voucher = await buildSignedVoucher({
+      keypair,
+      signerAddress: sessionKey.toString(),
+      channelId: TEST_CHANNEL_A.toString(),
+      cumulativeAmount: "100",
+    });
+    const flex = await buildFlexExtension({
+      keypair,
+      channelId: TEST_CHANNEL_A.toString(),
+      authorizationId: "1",
+      maxAmount: "100",
+    });
+
+    const receipt = await env.handler.handleSettle({
+      challenge,
+      payload: {
+        action: "voucher",
+        channelId: TEST_CHANNEL_A.toString(),
+        voucher,
+        flex,
+      },
+    });
+    t.ok(receipt, "receipt must be returned");
+    if (receipt) {
+      const validated = mppReceipt(receipt);
+      t.notOk(
+        isValidationError(validated),
+        "session receipt must validate against the mppReceipt arktype",
+      );
+    }
+    t.end();
+  },
+);
+
+await t.test(
+  "spec §Voucher Signing — serializeSpecVoucherMessage is independent of input key order",
+  (t) => {
+    const a = serializeSpecVoucherMessage({
+      channelId: "channel-x",
+      cumulativeAmount: "100",
+      expiresAt: "2026-01-01T00:00:00.000Z",
+    });
+    const reordered: {
+      cumulativeAmount: string;
+      expiresAt: string;
+      channelId: string;
+    } = {
+      cumulativeAmount: "100",
+      expiresAt: "2026-01-01T00:00:00.000Z",
+      channelId: "channel-x",
+    };
+    const b = serializeSpecVoucherMessage(reordered);
+    t.equal(a.length, b.length);
+    for (let i = 0; i < a.length; i++) {
+      t.equal(a[i], b[i]);
+    }
+    t.end();
+  },
+);
+
+await t.test(
+  "spec §Action: close — close with above-cumulative voucher advances state then transitions to closing",
+  async (t) => {
+    const env = await makeStoreAndHandler();
+    const { keypair, address: sessionKey } = await makeRealKeypairAddress();
+    await seedOpenChannel(env.store, TEST_CHANNEL_A, sessionKey, {
+      acceptedCumulative: 50n,
+    });
+
+    const challenge = await env.handler.getChallenge(
+      SESSION_INTENT,
+      {
+        amount: "25",
+        asset: MINT.toString(),
+        recipient: RECIPIENT.toString(),
+        network: "solana-devnet",
+      },
+      "http://test/resource",
+    );
+
+    const voucher = await buildSignedVoucher({
+      keypair,
+      signerAddress: sessionKey.toString(),
+      channelId: TEST_CHANNEL_A.toString(),
+      cumulativeAmount: "150",
+    });
+
+    const receipt = await env.handler.handleSettle({
+      challenge,
+      payload: {
+        action: "close",
+        channelId: TEST_CHANNEL_A.toString(),
+        voucher,
+      },
+    });
+    t.ok(receipt);
+    t.equal(receipt?.acceptedCumulative, "150");
+
+    const after = await env.store.get(TEST_CHANNEL_A);
+    t.equal(after?.acceptedCumulative, 150n);
+    t.equal(after?.status, "closing");
+    t.end();
+  },
+);
+
+await t.test(
+  "spec §Action: close — close with voucher exceeding escrowedAmount must be rejected",
+  async (t) => {
+    const env = await makeStoreAndHandler();
+    const { keypair, address: sessionKey } = await makeRealKeypairAddress();
+    await seedOpenChannel(env.store, TEST_CHANNEL_A, sessionKey, {
+      escrowedAmount: 1000n,
+    });
+
+    const challenge = await env.handler.getChallenge(
+      SESSION_INTENT,
+      {
+        amount: "25",
+        asset: MINT.toString(),
+        recipient: RECIPIENT.toString(),
+        network: "solana-devnet",
+      },
+      "http://test/resource",
+    );
+
+    const voucher = await buildSignedVoucher({
+      keypair,
+      signerAddress: sessionKey.toString(),
+      channelId: TEST_CHANNEL_A.toString(),
+      cumulativeAmount: "9999999",
+    });
+
+    await t.rejects(
+      () =>
+        env.handler.handleSettle({
+          challenge,
+          payload: {
+            action: "close",
+            channelId: TEST_CHANNEL_A.toString(),
+            voucher,
+          },
+        }),
+      "close voucher exceeding escrowedAmount must be rejected",
+    );
+
+    const after = await env.store.get(TEST_CHANNEL_A);
+    t.equal(after?.status, "open", "state must be untouched after rejection");
+    t.end();
+  },
+);
+
+await t.test(
+  "spec §Action: close — close on a non-existent channel must throw",
+  async (t) => {
+    const env = await makeStoreAndHandler();
+
+    const challenge = await env.handler.getChallenge(
+      SESSION_INTENT,
+      {
+        amount: "25",
+        asset: MINT.toString(),
+        recipient: RECIPIENT.toString(),
+        network: "solana-devnet",
+      },
+      "http://test/resource",
+    );
+
+    await t.rejects(
+      () =>
+        env.handler.handleSettle({
+          challenge,
+          payload: {
+            action: "close",
+            channelId: TEST_CHANNEL_A.toString(),
+          },
+        }),
+      "close on a missing channel must throw",
+    );
+    t.end();
+  },
+);
+
+await t.test(
+  "spec §Voucher Verification step 1 — voucher on missing channel raises session-not-found",
+  async (t) => {
+    const env = await makeStoreAndHandler();
+    const { keypair, address: sessionKey } = await makeRealKeypairAddress();
+
+    const challenge = await env.handler.getChallenge(
+      SESSION_INTENT,
+      {
+        amount: "25",
+        asset: MINT.toString(),
+        recipient: RECIPIENT.toString(),
+        network: "solana-devnet",
+      },
+      "http://test/resource",
+    );
+
+    const voucher = await buildSignedVoucher({
+      keypair,
+      signerAddress: sessionKey.toString(),
+      channelId: TEST_CHANNEL_A.toString(),
+      cumulativeAmount: "100",
+    });
+
+    let caught: unknown;
+    try {
+      await env.handler.handleSettle({
+        challenge,
+        payload: {
+          action: "voucher",
+          channelId: TEST_CHANNEL_A.toString(),
+          voucher,
+        },
+      });
+    } catch (err) {
+      caught = err;
+    }
+    t.ok(
+      caught instanceof Error,
+      "voucher on missing channel must throw an Error",
+    );
+    if (caught instanceof Error) {
+      t.match(
+        caught.message.toLowerCase(),
+        /session-not-found/,
+        "error must convey session-not-found reason",
+      );
+    }
+    t.end();
+  },
+);
+
+await t.test(
+  "spec §Action: open — re-open with same params returns existing state without overwriting",
+  async (t) => {
+    // The owner is the fee payer for the open transaction in this
+    // test, so disable sponsored fees on the handler.
+    const env = await makeStoreAndHandler({ sponsorFees: false });
+    const owner = await generateKeyPairSigner();
+    const sessionA = await makeRealKeypairAddress();
+    const source = await generateKeyPairSigner();
+    const FAKE_BLOCKHASH =
+      "EETubP46DHLkT9hAFKy4x2BoFUqUFvKjiiNVY3CaYRi3" as Blockhash;
+
+    const built = await buildSessionOpenInstructions({
+      owner,
+      facilitator: env.facilitatorSigner.address,
+      sessionKey: sessionA.address,
+      mint: MINT,
+      source: source.address,
+      index: 0n,
+      depositAmount: 1_000_000n,
+      refundTimeoutSlots: 150n,
+      deadmanTimeoutSlots: 1000n,
+      maxSessionKeys: 1,
+      sessionKeyExpiresAtSlot: null,
+      sessionKeyGracePeriodSlots: 150n,
+      programAddress: FLEX_PROGRAM_ADDRESS,
+    });
+    const txMsg = pipe(
+      createTransactionMessage({ version: 0 }),
+      (m) => setTransactionMessageFeePayerSigner(owner, m),
+      (m) =>
+        setTransactionMessageLifetimeUsingBlockhash(
+          { blockhash: FAKE_BLOCKHASH, lastValidBlockHeight: 1000n },
+          m,
+        ),
+      (m) => appendTransactionMessageInstructions(built.instructions, m),
+    );
+    const signed = await signTransactionMessageWithSigners(txMsg);
+    const wire = getBase64EncodedWireTransaction(signed);
+
+    const initialMessage = serializeSpecVoucherMessage({
+      channelId: built.escrow.toString(),
+      cumulativeAmount: "0",
+    });
+    const initialSig = new Uint8Array(
+      await crypto.subtle.sign(
+        "Ed25519",
+        sessionA.keypair.privateKey,
+        initialMessage,
+      ),
+    );
+    const challenge = await env.handler.getChallenge(
+      SESSION_INTENT,
+      {
+        amount: "25",
+        asset: MINT.toString(),
+        recipient: RECIPIENT.toString(),
+        network: "solana-devnet",
+      },
+      "http://test/resource",
+    );
+    const credential: mppCredential = {
+      challenge,
+      payload: {
+        action: "open",
+        channelId: built.escrow.toString(),
+        payer: owner.address.toString(),
+        depositAmount: "1000000",
+        transaction: wire,
+        voucher: {
+          voucher: {
+            channelId: built.escrow.toString(),
+            cumulativeAmount: "0",
+          },
+          signer: sessionA.address.toString(),
+          signature: bs58.encode(initialSig),
+          signatureType: "ed25519",
+        },
+      },
+    };
+
+    await env.handler.handleSettle(credential);
+
+    // Mutate the store directly to simulate the channel having served
+    // some traffic since the first open.
+    const live = await env.store.get(built.escrow);
+    if (!live) throw new Error("missing state after first open");
+    await env.store.put({ ...live, acceptedCumulative: 250n, spent: 100n });
+
+    // A second handleSettle on the same credential must NOT reset
+    // live state — the spec §"Action: open" idempotent re-open path
+    // returns the existing state.
+    const receipt = await env.handler.handleSettle(credential);
+    t.equal(
+      receipt?.acceptedCumulative,
+      "250",
+      "re-open must return the live acceptedCumulative",
+    );
+    t.equal(receipt?.spent, "100", "re-open must return the live spent value");
+
+    const after = await env.store.get(built.escrow);
+    t.equal(after?.acceptedCumulative, 250n);
+    t.equal(after?.spent, 100n);
+    t.end();
+  },
+);
+
+await t.test(
+  "spec §Settlement Procedure / Open step 6 — open with mint that doesn't match challenge currency must be rejected",
+  async (t) => {
+    // The owner is the fee payer for the open transaction in this
+    // test, so disable sponsored fees on the handler.
+    const env = await makeStoreAndHandler({ sponsorFees: false });
+    const owner = await generateKeyPairSigner();
+    const sessionKey = await makeRealKeypairAddress();
+    const source = await generateKeyPairSigner();
+    const FAKE_BLOCKHASH =
+      "EETubP46DHLkT9hAFKy4x2BoFUqUFvKjiiNVY3CaYRi3" as Blockhash;
+
+    // Open transaction deposits a mint different from the challenge.
+    const otherMint = address("So11111111111111111111111111111111111111112");
+    const built = await buildSessionOpenInstructions({
+      owner,
+      facilitator: env.facilitatorSigner.address,
+      sessionKey: sessionKey.address,
+      mint: otherMint,
+      source: source.address,
+      index: 0n,
+      depositAmount: 1_000_000n,
+      refundTimeoutSlots: 150n,
+      deadmanTimeoutSlots: 1000n,
+      maxSessionKeys: 1,
+      sessionKeyExpiresAtSlot: null,
+      sessionKeyGracePeriodSlots: 150n,
+      programAddress: FLEX_PROGRAM_ADDRESS,
+    });
+    const txMsg = pipe(
+      createTransactionMessage({ version: 0 }),
+      (m) => setTransactionMessageFeePayerSigner(owner, m),
+      (m) =>
+        setTransactionMessageLifetimeUsingBlockhash(
+          { blockhash: FAKE_BLOCKHASH, lastValidBlockHeight: 1000n },
+          m,
+        ),
+      (m) => appendTransactionMessageInstructions(built.instructions, m),
+    );
+    const signed = await signTransactionMessageWithSigners(txMsg);
+    const wire = getBase64EncodedWireTransaction(signed);
+
+    const initialMessage = serializeSpecVoucherMessage({
+      channelId: built.escrow.toString(),
+      cumulativeAmount: "0",
+    });
+    const initialSig = new Uint8Array(
+      await crypto.subtle.sign(
+        "Ed25519",
+        sessionKey.keypair.privateKey,
+        initialMessage,
+      ),
+    );
+
+    const challenge = await env.handler.getChallenge(
+      SESSION_INTENT,
+      {
+        amount: "25",
+        asset: MINT.toString(),
+        recipient: RECIPIENT.toString(),
+        network: "solana-devnet",
+      },
+      "http://test/resource",
+    );
+
+    await t.rejects(
+      () =>
+        env.handler.handleSettle({
+          challenge,
+          payload: {
+            action: "open",
+            channelId: built.escrow.toString(),
+            payer: owner.address.toString(),
+            depositAmount: "1000000",
+            transaction: wire,
+            voucher: {
+              voucher: {
+                channelId: built.escrow.toString(),
+                cumulativeAmount: "0",
+              },
+              signer: sessionKey.address.toString(),
+              signature: bs58.encode(initialSig),
+              signatureType: "ed25519",
+            },
+          },
+        }),
+      "open with mismatched deposit mint must be rejected",
+    );
+    t.end();
+  },
+);
+
+await t.test(
+  "spec §Settlement Procedure / Open step 4 — open carrying a foreign-program instruction must be rejected",
+  async (t) => {
+    const env = await makeStoreAndHandler();
+    const owner = await generateKeyPairSigner();
+    const sessionKey = await makeRealKeypairAddress();
+    const source = await generateKeyPairSigner();
+    const FAKE_BLOCKHASH =
+      "EETubP46DHLkT9hAFKy4x2BoFUqUFvKjiiNVY3CaYRi3" as Blockhash;
+
+    const built = await buildSessionOpenInstructions({
+      owner,
+      facilitator: env.facilitatorSigner.address,
+      sessionKey: sessionKey.address,
+      mint: MINT,
+      source: source.address,
+      index: 0n,
+      depositAmount: 1_000_000n,
+      refundTimeoutSlots: 150n,
+      deadmanTimeoutSlots: 1000n,
+      maxSessionKeys: 1,
+      sessionKeyExpiresAtSlot: null,
+      sessionKeyGracePeriodSlots: 150n,
+      programAddress: FLEX_PROGRAM_ADDRESS,
+    });
+
+    const memoIx = {
+      programAddress: address("MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"),
+      data: new Uint8Array([1, 2, 3]),
+    };
+
+    const txMsg = pipe(
+      createTransactionMessage({ version: 0 }),
+      (m) => setTransactionMessageFeePayerSigner(owner, m),
+      (m) =>
+        setTransactionMessageLifetimeUsingBlockhash(
+          { blockhash: FAKE_BLOCKHASH, lastValidBlockHeight: 1000n },
+          m,
+        ),
+      (m) =>
+        appendTransactionMessageInstructions(
+          [...built.instructions, memoIx],
+          m,
+        ),
+    );
+    const signed = await signTransactionMessageWithSigners(txMsg);
+    const wire = getBase64EncodedWireTransaction(signed);
+
+    await t.rejects(
+      () =>
+        verifyFlexOpenTransaction({
+          transaction: wire,
+          expectedChannelId: built.escrow,
+          expectedSessionKey: sessionKey.address,
+          programAddress: FLEX_PROGRAM_ADDRESS,
+        }),
+      "open carrying a foreign-program instruction must be rejected",
+    );
+    t.end();
+  },
+);
+
+await t.test(
+  "spec §Settlement Procedure / Open step 1 — open missing required Flex instruction must be rejected",
+  async (t) => {
+    const env = await makeStoreAndHandler();
+    const owner = await generateKeyPairSigner();
+    const sessionKey = await makeRealKeypairAddress();
+    const source = await generateKeyPairSigner();
+    const FAKE_BLOCKHASH =
+      "EETubP46DHLkT9hAFKy4x2BoFUqUFvKjiiNVY3CaYRi3" as Blockhash;
+
+    const built = await buildSessionOpenInstructions({
+      owner,
+      facilitator: env.facilitatorSigner.address,
+      sessionKey: sessionKey.address,
+      mint: MINT,
+      source: source.address,
+      index: 0n,
+      depositAmount: 1_000_000n,
+      refundTimeoutSlots: 150n,
+      deadmanTimeoutSlots: 1000n,
+      maxSessionKeys: 1,
+      sessionKeyExpiresAtSlot: null,
+      sessionKeyGracePeriodSlots: 150n,
+      programAddress: FLEX_PROGRAM_ADDRESS,
+    });
+
+    // Drop the deposit instruction.
+    const onlyTwo = [built.instructions[0], built.instructions[2]];
+
+    const txMsg = pipe(
+      createTransactionMessage({ version: 0 }),
+      (m) => setTransactionMessageFeePayerSigner(owner, m),
+      (m) =>
+        setTransactionMessageLifetimeUsingBlockhash(
+          { blockhash: FAKE_BLOCKHASH, lastValidBlockHeight: 1000n },
+          m,
+        ),
+      (m) => appendTransactionMessageInstructions(onlyTwo, m),
+    );
+    const signed = await signTransactionMessageWithSigners(txMsg);
+    const wire = getBase64EncodedWireTransaction(signed);
+
+    await t.rejects(
+      () =>
+        verifyFlexOpenTransaction({
+          transaction: wire,
+          expectedChannelId: built.escrow,
+          expectedSessionKey: sessionKey.address,
+          programAddress: FLEX_PROGRAM_ADDRESS,
+        }),
+      "open missing the deposit instruction must be rejected",
+    );
+    t.end();
+  },
+);
+
+await t.test(
+  "spec §Concurrency and Idempotency — voucher arriving before open returns session-not-found",
+  async (t) => {
+    const env = await makeStoreAndHandler();
+    const { keypair, address: sessionKey } = await makeRealKeypairAddress();
+    // No seeded state.
+
+    const challenge = await env.handler.getChallenge(
+      SESSION_INTENT,
+      {
+        amount: "25",
+        asset: MINT.toString(),
+        recipient: RECIPIENT.toString(),
+        network: "solana-devnet",
+      },
+      "http://test/resource",
+    );
+
+    const voucher = await buildSignedVoucher({
+      keypair,
+      signerAddress: sessionKey.toString(),
+      channelId: TEST_CHANNEL_A.toString(),
+      cumulativeAmount: "100",
+    });
+
+    await t.rejects(
+      () =>
+        env.handler.handleSettle({
+          challenge,
+          payload: {
+            action: "voucher",
+            channelId: TEST_CHANNEL_A.toString(),
+            voucher,
+          },
+        }),
+      "voucher submitted before open must be rejected",
+    );
+    t.end();
+  },
+);
+
+await t.test(
+  "spec §Voucher Verification step 7 — voucher arriving after close is rejected",
+  async (t) => {
+    const env = await makeStoreAndHandler();
+    const { keypair, address: sessionKey } = await makeRealKeypairAddress();
+    await seedOpenChannel(env.store, TEST_CHANNEL_A, sessionKey);
+
+    const challenge = await env.handler.getChallenge(
+      SESSION_INTENT,
+      {
+        amount: "25",
+        asset: MINT.toString(),
+        recipient: RECIPIENT.toString(),
+        network: "solana-devnet",
+      },
+      "http://test/resource",
+    );
+
+    // First, close the channel via handleSettle.
+    await env.handler.handleSettle({
+      challenge,
+      payload: {
+        action: "close",
+        channelId: TEST_CHANNEL_A.toString(),
+      },
+    });
+
+    const voucher = await buildSignedVoucher({
+      keypair,
+      signerAddress: sessionKey.toString(),
+      channelId: TEST_CHANNEL_A.toString(),
+      cumulativeAmount: "100",
+    });
+
+    await t.rejects(
+      () =>
+        env.handler.handleSettle({
+          challenge,
+          payload: {
+            action: "voucher",
+            channelId: TEST_CHANNEL_A.toString(),
+            voucher,
+          },
+        }),
+      "voucher arriving after close must be rejected",
+    );
+    t.end();
+  },
+);
+
+await t.test(
+  "spec §Method Details — handler construction rejects out-of-range mintDecimals",
+  async (t) => {
+    const facilitatorSigner = await generateKeyPairSigner();
+    await t.rejects(
+      () =>
+        createMPPSolanaSessionHandler({
+          network: "solana-devnet",
+          rpc: stubRpc,
+          facilitatorSigner,
+          supportedMints: [MINT],
+          mintDecimals: 10,
+          defaultSplits: TEST_DEFAULT_SPLITS,
+          realm: "test",
+          secretKey: SECRET_KEY,
+          refundTimeoutSlots: 150n,
+          deadmanTimeoutSlots: 1000n,
+          minGracePeriodSlots: 150n,
+          challengeExpiresSeconds: 3600,
+          maxRetries: 1,
+          retryDelayMs: 1,
+          flushIntervalMs: 1000,
+          programAddress: FLEX_PROGRAM_ADDRESS,
+        }),
+      "mintDecimals=10 must be rejected",
+    );
+    await t.rejects(
+      () =>
+        createMPPSolanaSessionHandler({
+          network: "solana-devnet",
+          rpc: stubRpc,
+          facilitatorSigner,
+          supportedMints: [MINT],
+          mintDecimals: -1,
+          defaultSplits: TEST_DEFAULT_SPLITS,
+          realm: "test",
+          secretKey: SECRET_KEY,
+          refundTimeoutSlots: 150n,
+          deadmanTimeoutSlots: 1000n,
+          minGracePeriodSlots: 150n,
+          challengeExpiresSeconds: 3600,
+          maxRetries: 1,
+          retryDelayMs: 1,
+          flushIntervalMs: 1000,
+          programAddress: FLEX_PROGRAM_ADDRESS,
+        }),
+      "negative mintDecimals must be rejected",
+    );
+    t.end();
+  },
+);
+
+await t.test(
+  "spec §Method Details — handler construction rejects bogus tokenProgram",
+  async (t) => {
+    const facilitatorSigner = await generateKeyPairSigner();
+    const SYSTEM_PROGRAM = address("11111111111111111111111111111111");
+    await t.rejects(
+      () =>
+        createMPPSolanaSessionHandler({
+          network: "solana-devnet",
+          rpc: stubRpc,
+          facilitatorSigner,
+          supportedMints: [MINT],
+          mintDecimals: 6,
+          tokenProgram: SYSTEM_PROGRAM,
+          defaultSplits: TEST_DEFAULT_SPLITS,
+          realm: "test",
+          secretKey: SECRET_KEY,
+          refundTimeoutSlots: 150n,
+          deadmanTimeoutSlots: 1000n,
+          minGracePeriodSlots: 150n,
+          challengeExpiresSeconds: 3600,
+          maxRetries: 1,
+          retryDelayMs: 1,
+          flushIntervalMs: 1000,
+          programAddress: FLEX_PROGRAM_ADDRESS,
+        }),
+      "non-token-program tokenProgram must be rejected",
+    );
+    t.end();
+  },
+);
+
+await t.test(
+  "spec §Concurrency and Idempotency — idempotency cache evicts oldest entries past capacity",
+  async (t) => {
+    const env = await makeStoreAndHandler();
+    const baseReceipt = {
+      status: "success" as const,
+      method: "solana",
+      intent: SESSION_INTENT,
+      timestamp: new Date().toISOString(),
+      reference: "ref",
+      acceptedCumulative: "0",
+      spent: "0",
+    };
+
+    for (let i = 0; i < 4097; i++) {
+      await env.handler.recordIdempotent("ch", `key-${i}`, baseReceipt);
+    }
+
+    const oldest = await env.handler.lookupIdempotent("ch", "key-0");
+    t.equal(
+      oldest,
+      undefined,
+      "oldest entry must be evicted once capacity is exceeded",
+    );
+
+    const newest = await env.handler.lookupIdempotent("ch", "key-4096");
+    t.ok(newest, "newest entry must remain present");
+    t.end();
+  },
+);
+
+await t.test(
+  "spec §Action: voucher — voucher without Flex extension is accepted (spec-pure path)",
+  async (t) => {
+    const env = await makeStoreAndHandler();
+    const { keypair, address: sessionKey } = await makeRealKeypairAddress();
+    await seedOpenChannel(env.store, TEST_CHANNEL_A, sessionKey);
+
+    const challenge = await env.handler.getChallenge(
+      SESSION_INTENT,
+      {
+        amount: "25",
+        asset: MINT.toString(),
+        recipient: RECIPIENT.toString(),
+        network: "solana-devnet",
+      },
+      "http://test/resource",
+    );
+    const voucher = await buildSignedVoucher({
+      keypair,
+      signerAddress: sessionKey.toString(),
+      channelId: TEST_CHANNEL_A.toString(),
+      cumulativeAmount: "100",
+    });
+
+    const receipt = await env.handler.handleSettle({
+      challenge,
+      payload: {
+        action: "voucher",
+        channelId: TEST_CHANNEL_A.toString(),
+        voucher,
+      },
+    });
+    t.ok(receipt, "spec-pure voucher must be accepted");
+    t.equal(receipt?.acceptedCumulative, "100");
+
+    const after = await env.store.get(TEST_CHANNEL_A);
+    t.equal(after?.acceptedCumulative, 100n);
+    t.equal(
+      after?.inFlightAuthorizationIds.length,
+      0,
+      "spec-pure voucher must NOT advance the Flex pending count",
+    );
+    t.end();
+  },
+);

--- a/packages/payment-solana/src/session/server.ts
+++ b/packages/payment-solana/src/session/server.ts
@@ -1,0 +1,1031 @@
+import type {
+  MPPMethodHandler,
+  ChallengeOpts,
+  mppChallengeParams,
+  mppCredential,
+  mppReceipt,
+  verificationFailedProblem,
+} from "@faremeter/types/mpp";
+import {
+  encodeBase64URL,
+  canonicalizeSortedJSON,
+  decodeBase64URL,
+  formatWWWAuthenticate,
+  generateChallengeID,
+  verifyChallengeID,
+  SESSION_INTENT,
+} from "@faremeter/types/mpp";
+import type { ResourcePricing } from "@faremeter/types/pricing";
+import { isValidationError } from "@faremeter/types";
+import {
+  caip2ToCluster,
+  lookupX402Network,
+  type SolanaCAIP2Network,
+} from "@faremeter/info/solana";
+import { TOKEN_PROGRAM_ADDRESS } from "@solana-program/token";
+import { TOKEN_2022_PROGRAM_ADDRESS } from "../splToken";
+import {
+  address,
+  getAddressEncoder,
+  type Address,
+  type Rpc,
+  type SolanaRpcApi,
+  type TransactionSigner,
+} from "@solana/kit";
+import { solanaSessionPayload, solanaSessionRequest } from "./common";
+import type {
+  flexVoucherExtension,
+  solanaSessionMethodDetails,
+  solanaSignedVoucher,
+} from "./common";
+import {
+  createInMemorySessionStore,
+  type SessionState,
+  type SessionStore,
+} from "./state";
+import bs58 from "bs58";
+import {
+  serializeSpecVoucherMessage,
+  serializeVoucherMessage,
+  verifyVoucherSignature,
+} from "./verify";
+import { verifyFlexOpenTransaction } from "./verify-open";
+
+/**
+ * Throws if `actual` does not match `expected` as a splits array.
+ * Equality is position- and value-sensitive. Used to enforce that a
+ * signed Flex voucher's splits match the challenge's `defaultSplits`.
+ */
+function assertSplitsMatch(
+  expected: { recipient: string; bps: number }[],
+  actual: { recipient: string; bps: number }[],
+): void {
+  if (expected.length !== actual.length) {
+    throw new Error(
+      `voucher splits length ${actual.length} does not match challenge defaultSplits length ${expected.length}`,
+    );
+  }
+  for (let i = 0; i < expected.length; i++) {
+    const e = expected[i];
+    const a = actual[i];
+    if (e === undefined || a === undefined) {
+      throw new Error("voucher splits contain undefined entry");
+    }
+    if (e.recipient !== a.recipient || e.bps !== a.bps) {
+      throw new Error(
+        `voucher split ${i} (${a.recipient}/${a.bps}bps) does not match challenge defaultSplits (${e.recipient}/${e.bps}bps)`,
+      );
+    }
+  }
+}
+
+function addressToBytes(addr: Address): Uint8Array<ArrayBuffer> {
+  const encoded = getAddressEncoder().encode(addr);
+  const out = new Uint8Array(new ArrayBuffer(encoded.length));
+  out.set(encoded);
+  return out;
+}
+
+function base64ToBytes(b64: string): Uint8Array<ArrayBuffer> {
+  const binary = atob(b64);
+  const bytes = new Uint8Array(new ArrayBuffer(binary.length));
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+import {
+  PENDING_LIMIT_MAX,
+  buildInsufficientHoldProblem,
+  buildPendingLimitProblem,
+  buildSessionNotFoundProblem,
+  type flexPendingLimitProblem,
+} from "./problem";
+import { logger } from "./logger";
+
+/**
+ * Reason returned by `tryRegisterVoucher` when a voucher cannot be
+ * accepted. Each reason maps to a spec Problem Details type in the
+ * middleware body callback so spec-conforming clients see
+ * `verification-failed` (or a Faremeter-namespaced extension) with
+ * the right `detail`.
+ */
+export type VoucherRegistrationReason =
+  | "pending-limit"
+  | "session-not-found"
+  | "channel-closed"
+  | "insufficient-hold"
+  | "signer-mismatch";
+
+/**
+ * Typed error thrown by `handleSettle` when a voucher submission
+ * fails a spec verification step. The middleware body callback can
+ * distinguish failure modes by `instanceof` + `reason` and build the
+ * appropriate Problem Details response.
+ */
+export class VoucherRegistrationError extends Error {
+  readonly reason: VoucherRegistrationReason;
+  constructor(reason: VoucherRegistrationReason) {
+    super(`voucher registration failed: ${reason}`);
+    this.name = "VoucherRegistrationError";
+    this.reason = reason;
+  }
+}
+
+export type VoucherRegistration = {
+  channelId: Address;
+  sessionKey: Address;
+  voucher: solanaSignedVoucher;
+  /**
+   * Flex authorization extension, OPTIONAL. When present, the
+   * `authorizationId` is tracked against the escrow's in-flight
+   * pending-settlement cap. Absent extensions still advance the
+   * off-chain `acceptedCumulative` but will never be settled on
+   * chain — spec-conforming voucher submissions that skip the Flex
+   * extension are acceptable for metered off-chain state but not
+   * for Flex settlement.
+   */
+  flex?: flexVoucherExtension;
+};
+
+export type TryRegisterResult =
+  | {
+      ok: true;
+      /**
+       * The channel's post-registration state. Callers MUST read
+       * voucher-related fields from this object, not from a fresh
+       * `sessionStore.get()` — those reads would fall outside the
+       * per-channel lock and could reflect a concurrent writer.
+       */
+      state: SessionState;
+    }
+  | {
+      ok: false;
+      reason: VoucherRegistrationReason;
+    };
+
+export type CreateMPPSolanaSessionHandlerArgs = {
+  network: string | SolanaCAIP2Network;
+  rpc: Rpc<SolanaRpcApi>;
+  facilitatorSigner: TransactionSigner;
+  /**
+   * The Flex escrow program address. Spec §"Method Details /
+   * channelProgram" makes this field REQUIRED; we require it on the
+   * handler args rather than letting the challenge ship an empty
+   * string.
+   */
+  programAddress: Address;
+  supportedMints: Address[];
+  /**
+   * Decimals for the supported mint(s). Must be in the range 0–9 per
+   * spec §"Method Details / decimals". The handler validates this
+   * during construction and will throw on out-of-range values.
+   */
+  mintDecimals: number;
+  /**
+   * Token program for the supported mint(s). Must be either the SPL
+   * Token Program or the Token-2022 Program per spec §"Method Details
+   * / tokenProgram". The handler validates this during construction
+   * and will throw on any other value.
+   */
+  tokenProgram?: Address;
+  defaultSplits: { recipient: string; bps: number }[];
+  realm: string;
+  secretKey: Uint8Array;
+  sessionStore?: SessionStore;
+  refundTimeoutSlots: bigint;
+  deadmanTimeoutSlots: bigint;
+  minGracePeriodSlots: bigint;
+  challengeExpiresSeconds: number;
+  /**
+   * Grace-period seconds advertised to clients via the challenge's
+   * `methodDetails.gracePeriodSeconds`. Spec §"Method Details"
+   * RECOMMENDS 900 seconds (15 minutes); defaults to 900.
+   */
+  gracePeriodSeconds?: number;
+  /**
+   * Sponsored fee-payer policy advertised in the challenge. When
+   * true, the handler asserts on the open transaction that the fee
+   * payer equals `facilitatorSigner.address` per spec §"Settlement
+   * Procedure / Open" step 3. Defaults to true because the handler
+   * always carries a facilitatorSigner; set false only if the payer
+   * is expected to fund their own open transaction.
+   */
+  sponsorFees?: boolean;
+  /**
+   * Minimum economically useful deposit, in base units. Spec
+   * §"Channel Exhaustion" SHOULDs that servers reject channel opens
+   * whose deposit is too small to justify signature verification,
+   * storage, and settlement overhead. When set, the handler rejects
+   * open transactions whose decoded `depositAmount` is below this
+   * value. Defaults to undefined (no minimum).
+   */
+  minDepositAmount?: bigint;
+  /** Tolerated clock skew (seconds) for `voucher.expiresAt` checks. */
+  clockSkewSeconds?: number;
+  maxRetries: number;
+  retryDelayMs: number;
+  flushIntervalMs: number;
+};
+
+/**
+ * Result of building a Problem Details response. The `headers`
+ * include `Content-Type: application/problem+json` and a fresh
+ * `WWW-Authenticate: Payment ...` challenge as required by the spec
+ * §"Error Responses" — every error response MUST include a fresh
+ * challenge.
+ */
+export type ProblemResponse = {
+  status: 402;
+  body: Record<string, unknown>;
+  headers: Record<string, string>;
+};
+
+export type FlexSessionHandler = MPPMethodHandler & {
+  getSessionState(channelId: Address): Promise<SessionState | undefined>;
+  remainingHold(channelId: Address): Promise<bigint>;
+  tryRegisterVoucher(args: VoucherRegistration): Promise<TryRegisterResult>;
+  chargeSession(channelId: Address, amount: bigint): Promise<void>;
+  buildReceipt(channelId: Address): Promise<mppReceipt>;
+  buildInsufficientHoldProblem(
+    state: SessionState,
+    requiredTopUp: bigint,
+  ): verificationFailedProblem;
+  buildPendingLimitProblem(state: SessionState): flexPendingLimitProblem;
+  buildSessionNotFoundProblem(
+    channelId: Address,
+    detail?: string,
+  ): verificationFailedProblem;
+  /**
+   * Bundles a Problem Details body with a fresh `WWW-Authenticate`
+   * Payment challenge minted from the supplied pricing/resource. Use
+   * this from the protected-resource body callback to satisfy the
+   * spec MUST that every 402 carries a re-challenge.
+   */
+  formatProblemResponse(
+    problem:
+      | verificationFailedProblem
+      | flexPendingLimitProblem
+      | Record<string, unknown>,
+    pricing: ResourcePricing,
+    resourceURL: string,
+  ): Promise<ProblemResponse>;
+  /**
+   * Wraps an action that mutates session state behind a per-channel
+   * mutex so concurrent voucher submissions or charges on the same
+   * `channelId` are serialized. Required by the spec §"Concurrency
+   * and Idempotency".
+   */
+  withChannelLock<T>(channelId: Address, fn: () => Promise<T>): Promise<T>;
+  /**
+   * Idempotency-Key cache lookup. The body callback hands over the
+   * client's `Idempotency-Key` header (and the challenge id from the
+   * credential) and gets back either the previously cached receipt or
+   * a sentinel telling it to run the work and call `recordIdempotent`.
+   */
+  lookupIdempotent(
+    challengeId: string,
+    idempotencyKey: string,
+  ): Promise<mppReceipt | undefined>;
+  recordIdempotent(
+    challengeId: string,
+    idempotencyKey: string,
+    receipt: mppReceipt,
+  ): Promise<void>;
+  stop(): void;
+};
+
+export async function createMPPSolanaSessionHandler(
+  args: CreateMPPSolanaSessionHandlerArgs,
+): Promise<FlexSessionHandler> {
+  const {
+    network,
+    realm,
+    secretKey,
+    supportedMints,
+    defaultSplits,
+    refundTimeoutSlots,
+    deadmanTimeoutSlots,
+    minGracePeriodSlots,
+    challengeExpiresSeconds,
+    facilitatorSigner,
+    programAddress,
+  } = args;
+  const clockSkewSeconds = args.clockSkewSeconds ?? 30;
+  const gracePeriodSeconds = args.gracePeriodSeconds ?? 900;
+  const sponsorFees = args.sponsorFees ?? true;
+  const minDepositAmount = args.minDepositAmount;
+
+  // Spec §"Method Details / decimals": 0–9. Validate at construction
+  // so a misconfiguration is surfaced before any challenge is minted.
+  if (
+    !Number.isInteger(args.mintDecimals) ||
+    args.mintDecimals < 0 ||
+    args.mintDecimals > 9
+  ) {
+    throw new Error(
+      `session handler: mintDecimals must be an integer in 0..9, got ${args.mintDecimals}`,
+    );
+  }
+
+  // Spec §"Method Details / tokenProgram": MUST be SPL Token or
+  // Token-2022 when present. Validate at construction.
+  if (
+    args.tokenProgram !== undefined &&
+    args.tokenProgram !== TOKEN_PROGRAM_ADDRESS &&
+    args.tokenProgram !== TOKEN_2022_PROGRAM_ADDRESS
+  ) {
+    throw new Error(
+      `session handler: tokenProgram must be SPL Token or Token-2022, got ${args.tokenProgram.toString()}`,
+    );
+  }
+
+  // Spec §"Request Schema / Shared Fields": native SOL is not
+  // supported; clients MUST wrap to wSOL. Reject the System Program
+  // address (the null mint) before it can ship in a challenge.
+  const SYSTEM_PROGRAM_ADDRESS_STR = "11111111111111111111111111111111";
+  for (const m of supportedMints) {
+    if (m.toString() === SYSTEM_PROGRAM_ADDRESS_STR) {
+      throw new Error(
+        "session handler: native SOL is not supported; wrap to wSOL (So11111111111111111111111111111111111111112) before opening a channel",
+      );
+    }
+  }
+
+  const sessionStore = args.sessionStore ?? createInMemorySessionStore();
+  const solanaNetwork = lookupX402Network(network);
+
+  // Spec §"Method Details" allows only "mainnet-beta", "devnet", or
+  // "localnet". `caip2ToCluster` returns "mainnet-beta", "devnet",
+  // "testnet", or null; the spec doesn't admit testnet, so map it
+  // through and let undefined drop the field.
+  const caip2ToSpecNetwork = (
+    caip2: string,
+  ): "mainnet-beta" | "devnet" | "localnet" | undefined => {
+    const cluster = caip2ToCluster(caip2);
+    if (cluster === "mainnet-beta" || cluster === "devnet") {
+      return cluster;
+    }
+    return undefined;
+  };
+
+  if (supportedMints.length === 0) {
+    throw new Error("session handler requires at least one supported mint");
+  }
+
+  const getChallenge = async (
+    intent: string,
+    pricing: ResourcePricing,
+    _resourceURL: string,
+    _opts?: ChallengeOpts,
+  ): Promise<mppChallengeParams> => {
+    if (intent !== SESSION_INTENT) {
+      throw new Error(`session handler received unexpected intent ${intent}`);
+    }
+
+    const mintAddress = pricing.asset;
+    if (mintAddress === SYSTEM_PROGRAM_ADDRESS_STR) {
+      // Defence in depth: even if someone passes pricing with the
+      // System Program as the asset, refuse to issue the challenge.
+      throw new Error(
+        "session handler: native SOL is not supported; wrap to wSOL before opening a channel",
+      );
+    }
+    const network = caip2ToSpecNetwork(solanaNetwork.caip2);
+    const methodDetails: solanaSessionMethodDetails = {
+      ...(network !== undefined ? { network } : {}),
+      channelProgram: programAddress.toString(),
+      decimals: args.mintDecimals,
+      ...(args.tokenProgram !== undefined
+        ? { tokenProgram: args.tokenProgram.toString() }
+        : {}),
+      // Spec §"Method Details": gracePeriodSeconds is RECOMMENDED;
+      // feePayer/feePayerKey describe the sponsored-fees policy a
+      // spec-conforming client MUST cross-check at open construction
+      // time (§"Settlement Procedure / Open" step 3).
+      gracePeriodSeconds,
+      ...(sponsorFees
+        ? {
+            feePayer: true,
+            feePayerKey: facilitatorSigner.address.toString(),
+          }
+        : {}),
+      flex: {
+        facilitator: facilitatorSigner.address.toString(),
+        splits: defaultSplits,
+        refundTimeoutSlots: refundTimeoutSlots.toString(),
+        deadmanTimeoutSlots: deadmanTimeoutSlots.toString(),
+        minGracePeriodSlots: minGracePeriodSlots.toString(),
+      },
+    };
+
+    const requestBody = {
+      amount: pricing.amount,
+      currency: mintAddress,
+      recipient: pricing.recipient,
+      methodDetails,
+    };
+
+    const requestEncoded = encodeBase64URL(canonicalizeSortedJSON(requestBody));
+    const expiresAt = Date.now() + challengeExpiresSeconds * 1000;
+
+    const paramsWithoutID: Omit<mppChallengeParams, "id"> = {
+      realm,
+      method: "solana",
+      intent: SESSION_INTENT,
+      request: requestEncoded,
+      expires: String(Math.floor(expiresAt / 1000)),
+    };
+
+    const id = await generateChallengeID(secretKey, paramsWithoutID);
+    return { id, ...paramsWithoutID };
+  };
+
+  const handleSettle = async (
+    credential: mppCredential,
+  ): Promise<mppReceipt | null> => {
+    const { challenge, payload } = credential;
+
+    // Return null ONLY when the credential isn't for this handler's
+    // method/intent. Any failure past this point is our responsibility
+    // and must throw so the middleware can render a Problem Details
+    // response.
+    if (challenge.method !== "solana") return null;
+    if (challenge.intent !== SESSION_INTENT) return null;
+
+    let requestBody: unknown;
+    try {
+      requestBody = JSON.parse(decodeBase64URL(challenge.request));
+    } catch (cause) {
+      throw new Error(
+        `handleSettle: challenge.request is not valid base64url JSON`,
+        { cause },
+      );
+    }
+    const request = solanaSessionRequest(requestBody);
+    if (isValidationError(request)) {
+      throw new Error(
+        `handleSettle: challenge.request does not match solanaSessionRequest: ${request.summary}`,
+      );
+    }
+
+    const idValid = await verifyChallengeID(secretKey, challenge);
+    if (!idValid) {
+      throw new Error("invalid challenge ID");
+    }
+
+    if (challenge.expires !== undefined) {
+      const expiresSeconds = Number(challenge.expires);
+      if (!Number.isFinite(expiresSeconds) || expiresSeconds <= 0) {
+        throw new Error(
+          `handleSettle: challenge.expires is not a positive number: ${challenge.expires}`,
+        );
+      }
+      const expiresAtMs = expiresSeconds * 1000;
+      if (Date.now() > expiresAtMs) {
+        throw new Error("challenge expired");
+      }
+    }
+
+    const validatedPayload = solanaSessionPayload(payload);
+    if (isValidationError(validatedPayload)) {
+      throw new Error(
+        `invalid credential payload: ${validatedPayload.summary}`,
+      );
+    }
+
+    const buildReceiptFromState = (state: SessionState): mppReceipt => ({
+      status: "success",
+      method: "solana",
+      intent: SESSION_INTENT,
+      timestamp: new Date().toISOString(),
+      reference: validatedPayload.channelId,
+      challengeId: challenge.id,
+      acceptedCumulative: state.acceptedCumulative.toString(),
+      spent: state.spent.toString(),
+    });
+
+    if (validatedPayload.action === "voucher") {
+      // Spec §"Voucher Verification" steps 1, 2, 4 (signature,
+      // canonicalization, channelId match) and step 9 (expiresAt
+      // tolerance) are enforced here against the raw voucher bytes
+      // before any state inspection.
+      await verifyVoucher(validatedPayload.voucher, {
+        channelId: validatedPayload.channelId,
+      });
+
+      // The Flex authorization extension is required for on-chain
+      // Flex settlement. Verify it here when present; its absence is
+      // spec-conforming (Flex is a Faremeter extension) but will
+      // prevent on-chain settlement of this voucher.
+      if (validatedPayload.flex !== undefined) {
+        await verifyFlexAuthorization(
+          validatedPayload.voucher,
+          validatedPayload.flex,
+          {
+            channelId: validatedPayload.channelId,
+            programAddress,
+          },
+        );
+        // Flex-specific cross-check: the signed authorization splits
+        // must match the challenge's `defaultSplits`.
+        assertSplitsMatch(defaultSplits, validatedPayload.flex.splits);
+      }
+
+      // Spec §"Voucher Verification" steps 3 (signer matches
+      // authorized signer), 6 & 7 (channel discriminator / status),
+      // 5 (monotonicity and idempotent replay), 8 (cumulative does
+      // not exceed escrow), and 10 (persist before serving) all live
+      // inside `tryRegisterVoucher`.
+      const channelIdAddress = address(validatedPayload.channelId);
+      const registration: VoucherRegistration = {
+        channelId: channelIdAddress,
+        sessionKey: address(validatedPayload.voucher.signer),
+        voucher: validatedPayload.voucher,
+        ...(validatedPayload.flex !== undefined
+          ? { flex: validatedPayload.flex }
+          : {}),
+      };
+      const result = await tryRegisterVoucher(registration);
+      if (!result.ok) {
+        throw new VoucherRegistrationError(result.reason);
+      }
+      // Build the receipt from the post-register state returned by
+      // tryRegisterVoucher. A separate `sessionStore.get()` would run
+      // outside the per-channel lock and could reflect a concurrent
+      // voucher's state.
+      return buildReceiptFromState(result.state);
+    }
+
+    if (validatedPayload.action === "open") {
+      // The initial signed voucher is REQUIRED by spec §"Action: open".
+      // Verify its signature; we'll use voucher.signer as the session
+      // key for state lookup.
+      await verifyVoucher(validatedPayload.voucher, {
+        channelId: validatedPayload.channelId,
+      });
+      const sessionKey = address(validatedPayload.voucher.signer);
+      const verified = await verifyFlexOpenTransaction({
+        transaction: validatedPayload.transaction,
+        expectedChannelId: address(validatedPayload.channelId),
+        expectedSessionKey: sessionKey,
+        programAddress,
+        expectedFacilitator: facilitatorSigner.address,
+        expectedRefundTimeoutSlots: refundTimeoutSlots,
+        expectedDeadmanTimeoutSlots: deadmanTimeoutSlots,
+        // Sponsored-fees branch: fee payer must equal the declared
+        // facilitatorKey. Non-sponsored branch: fee payer must equal
+        // the credential's payer. Both are spec §"Settlement
+        // Procedure / Open" step 3.
+        ...(sponsorFees
+          ? { expectedFeePayer: facilitatorSigner.address }
+          : { expectedPayer: address(validatedPayload.payer) }),
+      });
+
+      // Spec §"Settlement Procedure / Open" step 6: "token/asset
+      // matches the challenge currency". Cross-check the deposit
+      // instruction's mint against the challenge's parsed currency.
+      if (verified.decoded.mint.toString() !== request.currency) {
+        throw new Error(
+          `open transaction deposits mint ${verified.decoded.mint} but the challenge requested currency ${request.currency}`,
+        );
+      }
+
+      // Spec §"Channel Exhaustion": SHOULD reject opens below a
+      // minimum economically useful deposit to avoid channel spam.
+      if (
+        minDepositAmount !== undefined &&
+        verified.decoded.depositAmount < minDepositAmount
+      ) {
+        throw new Error(
+          `open transaction depositAmount ${verified.decoded.depositAmount} is below minDepositAmount ${minDepositAmount}`,
+        );
+      }
+
+      // Persist the session state derived from the open transaction.
+      // The initial voucher's cumulativeAmount becomes the channel's
+      // initial accepted cumulative (typically 0). The mint is read
+      // from the deposit instruction the client included in the open
+      // batch.
+      const channelIdAddress = address(validatedPayload.channelId);
+      const persistedState = await withChannelLock(
+        channelIdAddress,
+        async (): Promise<SessionState> => {
+          const existing = await sessionStore.get(channelIdAddress);
+          if (existing) {
+            // Idempotent re-open. The spec §"Action: open" allows
+            // re-issuing an open with the same channelId; we don't
+            // overwrite live session state.
+            return existing;
+          }
+          const initialCumulative = BigInt(
+            validatedPayload.voucher.voucher.cumulativeAmount,
+          );
+          const fresh: SessionState = {
+            channelId: channelIdAddress,
+            sessionKey,
+            mint: verified.decoded.mint,
+            escrowedAmount: verified.decoded.depositAmount,
+            acceptedCumulative: initialCumulative,
+            spent: 0n,
+            inFlightAuthorizationIds: [],
+            status: "open",
+          };
+          await sessionStore.put(fresh);
+          return fresh;
+        },
+      );
+      return buildReceiptFromState(persistedState);
+    }
+
+    if (validatedPayload.action === "close") {
+      // Spec §"Action: close": the credential MAY carry a final
+      // voucher. If present, verify it via the same voucher-verification
+      // steps before relying on its cumulative amount.
+      const channelIdAddress = address(validatedPayload.channelId);
+      if (validatedPayload.voucher !== undefined) {
+        await verifyVoucher(validatedPayload.voucher, {
+          channelId: validatedPayload.channelId,
+        });
+        const registration: VoucherRegistration = {
+          channelId: channelIdAddress,
+          sessionKey: address(validatedPayload.voucher.signer),
+          voucher: validatedPayload.voucher,
+        };
+        const result = await tryRegisterVoucher(registration);
+        if (!result.ok) {
+          throw new VoucherRegistrationError(result.reason);
+        }
+      }
+      // Transition status to "closing". On Flex this is the only
+      // close signal the off-chain handler can express; the actual
+      // on-chain close happens via Flex's finalize/refund/force_close
+      // paths per COMPATIBILITY.md "No closeRequestedAt /
+      // ClosedChannel discriminator".
+      const closedState = await withChannelLock(
+        channelIdAddress,
+        async (): Promise<SessionState> => {
+          const existing = await sessionStore.get(channelIdAddress);
+          if (!existing) {
+            throw new Error(
+              `close: no session state for channelId ${validatedPayload.channelId}`,
+            );
+          }
+          if (existing.status !== "open") {
+            throw new Error(
+              `close: channel ${validatedPayload.channelId} is not open (status=${existing.status})`,
+            );
+          }
+          const updated: SessionState = { ...existing, status: "closing" };
+          await sessionStore.put(updated);
+          return updated;
+        },
+      );
+      return buildReceiptFromState(closedState);
+    }
+
+    if (validatedPayload.action === "topUp") {
+      // topUp verification is not yet implemented. The spec's topUp
+      // path requires decoding the additional-deposit transaction,
+      // verifying it targets the existing escrow, and bumping
+      // `escrowedAmount` — none of which we do off-chain today. Per
+      // COMPATIBILITY.md "Deferred — topUp / close settlement paths",
+      // the handler currently REJECTS topUp credentials instead of
+      // silently returning a success receipt so spec-conforming
+      // clients don't believe a top-up went through when it didn't.
+      throw new Error(
+        "topUp action is not implemented on this handler; see COMPATIBILITY.md",
+      );
+    }
+
+    // All action discriminators are covered above; this is
+    // unreachable given arktype validation.
+    throw new Error(
+      `handleSettle: unhandled action ${(validatedPayload as { action: string }).action}`,
+    );
+  };
+
+  /**
+   * Verifies a spec-shaped signed voucher: JCS canonicalization,
+   * base58 Ed25519 signature, signer matches voucher.signer, and the
+   * channelId in the voucher data matches the credential's channelId.
+   * Also enforces `expiresAt` if present (with the configured clock
+   * skew tolerance).
+   */
+  const verifyVoucher = async (
+    voucher: solanaSignedVoucher,
+    ctx: { channelId: string },
+  ): Promise<void> => {
+    if (voucher.signatureType !== "ed25519") {
+      throw new Error(
+        `unsupported voucher signatureType: ${voucher.signatureType}`,
+      );
+    }
+    if (voucher.voucher.channelId !== ctx.channelId) {
+      throw new Error("voucher.channelId does not match credential channelId");
+    }
+    if (voucher.voucher.expiresAt !== undefined) {
+      const expiresAtMs = Date.parse(voucher.voucher.expiresAt);
+      if (Number.isNaN(expiresAtMs)) {
+        throw new Error(
+          `voucher.expiresAt is not a valid ISO 8601 timestamp: ${voucher.voucher.expiresAt}`,
+        );
+      }
+      const skewMs = clockSkewSeconds * 1000;
+      if (Date.now() - skewMs > expiresAtMs) {
+        throw new Error("voucher has expired");
+      }
+    }
+
+    const specMessage = serializeSpecVoucherMessage({
+      channelId: voucher.voucher.channelId,
+      cumulativeAmount: voucher.voucher.cumulativeAmount,
+      ...(voucher.voucher.expiresAt !== undefined
+        ? { expiresAt: voucher.voucher.expiresAt }
+        : {}),
+    });
+    const signerBytes = addressToBytes(address(voucher.signer));
+    const specSig = bs58.decode(voucher.signature);
+    const specOk = await verifyVoucherSignature({
+      publicKey: signerBytes,
+      message: specMessage,
+      signature: specSig,
+    });
+    if (!specOk) {
+      throw new Error("spec voucher signature verification failed");
+    }
+  };
+
+  /**
+   * Verifies the Flex authorization extension signature: packed
+   * binary over the on-chain authorization layout, base64, signed by
+   * the same session key. This is the signature `submit_authorization`
+   * will verify on chain via the Ed25519 precompile.
+   */
+  const verifyFlexAuthorization = async (
+    voucher: solanaSignedVoucher,
+    flex: flexVoucherExtension,
+    ctx: { channelId: string; programAddress: Address },
+  ): Promise<void> => {
+    const flexMessage = serializeVoucherMessage({
+      programAddress: ctx.programAddress,
+      escrow: address(ctx.channelId),
+      mint: address(flex.mint),
+      maxAmount: BigInt(flex.maxAmount),
+      authorizationId: BigInt(flex.authorizationId),
+      expiresAtSlot: BigInt(flex.expiresAtSlot),
+      splits: flex.splits.map((s) => ({
+        recipient: address(s.recipient),
+        bps: s.bps,
+      })),
+    });
+    const signerBytes = addressToBytes(address(voucher.signer));
+    const flexSig = base64ToBytes(flex.signature);
+    const flexOk = await verifyVoucherSignature({
+      publicKey: signerBytes,
+      message: flexMessage,
+      signature: flexSig,
+    });
+    if (!flexOk) {
+      throw new Error("flex voucher signature verification failed");
+    }
+  };
+
+  const getSessionState = async (
+    channelId: Address,
+  ): Promise<SessionState | undefined> => {
+    return sessionStore.get(channelId);
+  };
+
+  const remainingHold = async (channelId: Address): Promise<bigint> => {
+    const state = await sessionStore.get(channelId);
+    if (!state) {
+      throw new Error(`remainingHold: no session for ${channelId.toString()}`);
+    }
+    return state.acceptedCumulative - state.spent;
+  };
+
+  // Per-channel mutex map. Required by spec §"Concurrency and
+  // Idempotency": voucher acceptance and debit processing MUST be
+  // serialized per `channelId`.
+  const channelLocks = new Map<string, Promise<unknown>>();
+  const withChannelLock = async <T>(
+    channelId: Address,
+    fn: () => Promise<T>,
+  ): Promise<T> => {
+    const key = channelId.toString();
+    const previous = channelLocks.get(key) ?? Promise.resolve();
+    let resolveNext!: () => void;
+    const next = new Promise<void>((resolve) => {
+      resolveNext = resolve;
+    });
+    const ours = previous.then(() => next);
+    channelLocks.set(key, ours);
+    try {
+      await previous;
+      return await fn();
+    } finally {
+      resolveNext();
+      if (channelLocks.get(key) === ours) {
+        channelLocks.delete(key);
+      }
+    }
+  };
+
+  const tryRegisterVoucher = async (
+    registration: VoucherRegistration,
+  ): Promise<TryRegisterResult> =>
+    withChannelLock(registration.channelId, async () => {
+      const state = await sessionStore.get(registration.channelId);
+      if (!state) {
+        // Spec §"Voucher Verification" step 1: channel must exist.
+        return { ok: false, reason: "session-not-found" };
+      }
+      if (state.status !== "open") {
+        // Spec §"Voucher Verification" steps 6 & 7: channel must not
+        // be finalized (ClosedChannel discriminator) or in a
+        // closeRequestedAt-pending state. Flex has no on-chain
+        // equivalent of these fields; we approximate with the
+        // off-chain SessionStatus — see COMPATIBILITY.md "No
+        // closeRequestedAt / ClosedChannel discriminator".
+        return { ok: false, reason: "channel-closed" };
+      }
+      if (state.sessionKey !== address(registration.voucher.signer)) {
+        // Spec §"Voucher Verification" step 3: signer must match the
+        // channel's authorized signer. Caller is responsible for
+        // having verified the Ed25519 signature itself before
+        // reaching this point.
+        return { ok: false, reason: "signer-mismatch" };
+      }
+      const incomingCumulative = BigInt(
+        registration.voucher.voucher.cumulativeAmount,
+      );
+      if (incomingCumulative === state.acceptedCumulative) {
+        // Spec §"Concurrency and Idempotency": equal cumulative is an
+        // idempotent resubmission. Return success with the current
+        // state, without mutating.
+        return { ok: true, state };
+      }
+      if (incomingCumulative < state.acceptedCumulative) {
+        // Spec §"Concurrency and Idempotency": lower cumulative is a
+        // replay; return the current receipt state without reducing
+        // channel state.
+        logger.warning("voucher cumulativeAmount is below current accepted", {
+          incoming: incomingCumulative.toString(),
+          current: state.acceptedCumulative.toString(),
+        });
+        return { ok: true, state };
+      }
+      if (incomingCumulative > state.escrowedAmount) {
+        // Spec §"Voucher Verification" step 8: cumulativeAmount must
+        // not exceed the escrow's deposited balance.
+        return { ok: false, reason: "insufficient-hold" };
+      }
+      if (state.inFlightAuthorizationIds.length >= PENDING_LIMIT_MAX) {
+        // Flex-specific back-pressure (not in the spec); see
+        // COMPATIBILITY.md "MAX_PENDING = 16 ceiling".
+        return { ok: false, reason: "pending-limit" };
+      }
+      const inFlight =
+        registration.flex !== undefined
+          ? [
+              ...state.inFlightAuthorizationIds,
+              BigInt(registration.flex.authorizationId),
+            ]
+          : state.inFlightAuthorizationIds;
+      const updated: SessionState = {
+        ...state,
+        acceptedCumulative: incomingCumulative,
+        inFlightAuthorizationIds: inFlight,
+      };
+      // Spec §"Voucher Verification" step 10: persist the new
+      // acceptedCumulative BEFORE serving the resource. The caller
+      // receives the post-registration state so its receipt reflects
+      // the voucher *this* call accepted, even if a later voucher
+      // advances state between here and the caller's receipt build.
+      await sessionStore.put(updated);
+      return { ok: true, state: updated };
+    });
+
+  const chargeSession = async (
+    channelId: Address,
+    amount: bigint,
+  ): Promise<void> =>
+    withChannelLock(channelId, async () => {
+      const state = await sessionStore.get(channelId);
+      if (!state) {
+        throw new Error(
+          `chargeSession: no session for ${channelId.toString()}`,
+        );
+      }
+      const newSpent = state.spent + amount;
+      if (newSpent > state.acceptedCumulative) {
+        throw new Error(
+          `chargeSession: spent ${newSpent} exceeds acceptedCumulative ${state.acceptedCumulative}`,
+        );
+      }
+      await sessionStore.put({ ...state, spent: newSpent });
+    });
+
+  const buildReceipt = async (channelId: Address): Promise<mppReceipt> => {
+    const state = await sessionStore.get(channelId);
+    if (!state) {
+      // The caller only invokes buildReceipt when they believe a
+      // session exists. A missing state here is a programming error;
+      // per CLAUDE.md we surface it rather than paper over with a
+      // default "0" receipt.
+      throw new Error(
+        `buildReceipt: no session state for channelId ${channelId.toString()}`,
+      );
+    }
+    return {
+      status: "success",
+      method: "solana",
+      intent: SESSION_INTENT,
+      timestamp: new Date().toISOString(),
+      reference: channelId.toString(),
+      acceptedCumulative: state.acceptedCumulative.toString(),
+      spent: state.spent.toString(),
+    };
+  };
+
+  const formatProblemResponse = async (
+    problem:
+      | verificationFailedProblem
+      | flexPendingLimitProblem
+      | Record<string, unknown>,
+    pricing: ResourcePricing,
+    resourceURL: string,
+  ): Promise<ProblemResponse> => {
+    const challenge = await getChallenge(SESSION_INTENT, pricing, resourceURL);
+    return {
+      status: 402,
+      body: problem as Record<string, unknown>,
+      headers: {
+        "Content-Type": "application/problem+json",
+        "WWW-Authenticate": formatWWWAuthenticate([challenge]),
+      },
+    };
+  };
+
+  // Idempotency cache for `(challengeId, idempotencyKey)`. Required by
+  // spec §"Concurrency and Idempotency": servers MUST NOT increment
+  // `spentAmount` twice for a duplicate idempotent request. Entries
+  // are evicted on insert once the map reaches `IDEMPOTENCY_CACHE_MAX`
+  // (FIFO eviction via insertion order). This is a bounded in-memory
+  // cache so a long-running facilitator doesn't leak memory across
+  // an unbounded stream of unique (challengeId, idempotencyKey) pairs.
+  const IDEMPOTENCY_CACHE_MAX = 4096;
+  const idempotencyCache = new Map<string, mppReceipt>();
+  const idemKey = (challengeId: string, key: string) => `${challengeId}:${key}`;
+  const lookupIdempotent = async (
+    challengeId: string,
+    key: string,
+  ): Promise<mppReceipt | undefined> => {
+    return idempotencyCache.get(idemKey(challengeId, key));
+  };
+  const recordIdempotent = async (
+    challengeId: string,
+    key: string,
+    receipt: mppReceipt,
+  ): Promise<void> => {
+    const k = idemKey(challengeId, key);
+    // If the key already exists, delete-then-set refreshes its
+    // insertion-order position (LRU-on-write).
+    if (idempotencyCache.has(k)) {
+      idempotencyCache.delete(k);
+    } else if (idempotencyCache.size >= IDEMPOTENCY_CACHE_MAX) {
+      // Evict the oldest entry (Map preserves insertion order).
+      const oldest = idempotencyCache.keys().next().value;
+      if (oldest !== undefined) {
+        idempotencyCache.delete(oldest);
+      }
+    }
+    idempotencyCache.set(k, receipt);
+  };
+
+  return {
+    method: "solana",
+    capabilities: {
+      networks: [solanaNetwork.caip2],
+      assets: supportedMints.map((m) => m.toString()),
+    },
+    getSupportedIntents: () => [SESSION_INTENT],
+    getChallenge,
+    handleSettle,
+    getSessionState,
+    remainingHold,
+    tryRegisterVoucher,
+    chargeSession,
+    buildReceipt,
+    buildInsufficientHoldProblem,
+    buildPendingLimitProblem,
+    buildSessionNotFoundProblem: (channelId, detail) =>
+      buildSessionNotFoundProblem(channelId.toString(), detail),
+    formatProblemResponse,
+    withChannelLock,
+    lookupIdempotent,
+    recordIdempotent,
+    stop: () => undefined,
+  };
+}

--- a/packages/payment-solana/src/session/state.test.ts
+++ b/packages/payment-solana/src/session/state.test.ts
@@ -1,0 +1,80 @@
+#!/usr/bin/env pnpm tsx
+
+import t from "tap";
+import { address } from "@solana/kit";
+import { createInMemorySessionStore, type SessionState } from "./state";
+
+const CHANNEL = address("9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM");
+const SESSION_KEY = address("DFo9vd1eiRFGQuCkReqvZvRPJVwwYu8NwCiaa9tB5pWZ");
+const MINT = address("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v");
+
+const makeState = (overrides: Partial<SessionState> = {}): SessionState => ({
+  channelId: CHANNEL,
+  sessionKey: SESSION_KEY,
+  mint: MINT,
+  escrowedAmount: 1_000_000n,
+  acceptedCumulative: 0n,
+  spent: 0n,
+  inFlightAuthorizationIds: [],
+  status: "open",
+  ...overrides,
+});
+
+await t.test("in-memory store round-trips a session", async (t) => {
+  const store = createInMemorySessionStore();
+  t.equal(await store.get(CHANNEL), undefined);
+
+  await store.put(makeState({ acceptedCumulative: 100n }));
+  const fetched = await store.get(CHANNEL);
+  t.ok(fetched);
+  t.equal(fetched?.acceptedCumulative, 100n);
+  t.end();
+});
+
+await t.test("in-memory store keys by channelId", async (t) => {
+  const store = createInMemorySessionStore();
+  const otherChannel = address("4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi");
+  await store.put(makeState({ acceptedCumulative: 1n }));
+  await store.put(
+    makeState({ channelId: otherChannel, acceptedCumulative: 2n }),
+  );
+  t.equal((await store.get(CHANNEL))?.acceptedCumulative, 1n);
+  t.equal((await store.get(otherChannel))?.acceptedCumulative, 2n);
+  t.end();
+});
+
+await t.test("in-memory store delete removes the entry", async (t) => {
+  const store = createInMemorySessionStore();
+  await store.put(makeState());
+  await store.delete(CHANNEL);
+  t.equal(await store.get(CHANNEL), undefined);
+  t.end();
+});
+
+await t.test("iterate yields each live session", async (t) => {
+  const store = createInMemorySessionStore();
+  await store.put(makeState({ acceptedCumulative: 1n }));
+  await store.put(
+    makeState({
+      channelId: address("4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi"),
+      acceptedCumulative: 2n,
+    }),
+  );
+  const collected: bigint[] = [];
+  for await (const state of store.iterate()) {
+    collected.push(state.acceptedCumulative);
+  }
+  collected.sort((a, b) => Number(a - b));
+  t.matchOnly(collected, [1n, 2n]);
+  t.end();
+});
+
+await t.test("put clones state so mutations don't leak", async (t) => {
+  const store = createInMemorySessionStore();
+  const initial = makeState({ inFlightAuthorizationIds: [1n] });
+  await store.put(initial);
+  initial.inFlightAuthorizationIds.push(2n);
+  const fetched = await store.get(CHANNEL);
+  t.equal(fetched?.inFlightAuthorizationIds.length, 1);
+  t.end();
+});

--- a/packages/payment-solana/src/session/state.ts
+++ b/packages/payment-solana/src/session/state.ts
@@ -1,0 +1,61 @@
+import type { Address } from "@solana/kit";
+
+export type SessionStatus = "open" | "closing" | "closed";
+
+export type SessionState = {
+  channelId: Address;
+  sessionKey: Address;
+  mint: Address;
+  /**
+   * Total amount deposited into the channel (initial `depositAmount`
+   * at open time plus any `topUp` amounts). The spec §"Voucher
+   * Verification" step 8 requires the server to reject any voucher
+   * whose `cumulativeAmount` exceeds this value.
+   */
+  escrowedAmount: bigint;
+  acceptedCumulative: bigint;
+  spent: bigint;
+  inFlightAuthorizationIds: bigint[];
+  status: SessionStatus;
+};
+
+/**
+ * Per-channel session state. The spec model is one session per
+ * channel; the channel's `authorizedSigner` is the only voucher
+ * signer permitted, so the store is keyed by `channelId` alone.
+ * `sessionKey` is recorded as a property of the state for callers
+ * that need it.
+ */
+export interface SessionStore {
+  get(channelId: Address): Promise<SessionState | undefined>;
+  put(state: SessionState): Promise<void>;
+  delete(channelId: Address): Promise<void>;
+  iterate(): AsyncIterable<SessionState>;
+}
+
+export function createInMemorySessionStore(): SessionStore {
+  const entries = new Map<string, SessionState>();
+
+  const clone = (state: SessionState): SessionState => ({
+    ...state,
+    inFlightAuthorizationIds: [...state.inFlightAuthorizationIds],
+  });
+
+  return {
+    async get(channelId) {
+      const found = entries.get(channelId.toString());
+      return found ? clone(found) : undefined;
+    },
+    async put(state) {
+      entries.set(state.channelId.toString(), clone(state));
+    },
+    async delete(channelId) {
+      entries.delete(channelId.toString());
+    },
+    async *iterate() {
+      for (const state of entries.values()) {
+        yield clone(state);
+      }
+    },
+  };
+}

--- a/packages/payment-solana/src/session/verify-open.ts
+++ b/packages/payment-solana/src/session/verify-open.ts
@@ -1,0 +1,486 @@
+import {
+  decompileTransactionMessage,
+  getBase64Encoder,
+  getCompiledTransactionMessageDecoder,
+  type Address,
+  type Instruction,
+} from "@solana/kit";
+import { getTransactionDecoder } from "@solana/transactions";
+
+import {
+  CREATE_ESCROW_DISCRIMINATOR,
+  DEPOSIT_DISCRIMINATOR,
+  FLEX_PROGRAM_ADDRESS,
+  REGISTER_SESSION_KEY_DISCRIMINATOR,
+  findEscrowPda,
+  findRegisterSessionKeySessionKeyAccountPda,
+  findVaultPda,
+} from "@faremeter/flex-solana";
+
+const deriveEscrowAddress = async (args: {
+  owner: Address;
+  index: bigint;
+  programAddress?: Address;
+}): Promise<Address> => {
+  const [pda] = await findEscrowPda(
+    { owner: args.owner, index: args.index },
+    args.programAddress !== undefined
+      ? { programAddress: args.programAddress }
+      : {},
+  );
+  return pda;
+};
+
+const deriveVaultAddress = async (args: {
+  escrow: Address;
+  mint: Address;
+  programAddress?: Address;
+}): Promise<Address> => {
+  const [pda] = await findVaultPda(
+    { escrow: args.escrow, mint: args.mint },
+    args.programAddress !== undefined
+      ? { programAddress: args.programAddress }
+      : {},
+  );
+  return pda;
+};
+
+const deriveSessionKeyAccountAddress = async (args: {
+  escrow: Address;
+  sessionKey: Address;
+  programAddress?: Address;
+}): Promise<Address> => {
+  const [pda] = await findRegisterSessionKeySessionKeyAccountPda(
+    { escrow: args.escrow, sessionKey: args.sessionKey },
+    args.programAddress !== undefined
+      ? { programAddress: args.programAddress }
+      : {},
+  );
+  return pda;
+};
+
+function discriminatorMatches(
+  data: Uint8Array | undefined,
+  expected: Uint8Array,
+): boolean {
+  if (!data || data.length < 8) return false;
+  for (let i = 0; i < 8; i++) {
+    if (data[i] !== expected[i]) return false;
+  }
+  return true;
+}
+
+function readU64LE(data: Uint8Array, offset: number): bigint {
+  const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
+  return view.getBigUint64(offset, true);
+}
+
+export type DecodedFlexOpen = {
+  owner: Address;
+  index: bigint;
+  facilitator: Address;
+  refundTimeoutSlots: bigint;
+  deadmanTimeoutSlots: bigint;
+  maxSessionKeys: number;
+  escrow: Address;
+  mint: Address;
+  vault: Address;
+  source: Address;
+  depositAmount: bigint;
+  sessionKey: Address;
+  sessionKeyAccount: Address;
+  sessionKeyExpiresAtSlot: bigint | null;
+  revocationGracePeriodSlots: bigint;
+};
+
+export type VerifyFlexOpenTransactionArgs = {
+  /** Base64-encoded wire transaction the client supplied. */
+  transaction: string;
+  /** Channel id the credential claims (escrow PDA, base58). */
+  expectedChannelId: Address;
+  /** Session key the credential claims (base58 pubkey). */
+  expectedSessionKey: Address;
+  /** Flex program address. Defaults to the canonical address. */
+  programAddress?: Address;
+  /**
+   * Required fee-payer address per spec §"Settlement Procedure /
+   * Open" step 3's sponsored-fees branch. When set, the decoded
+   * transaction's fee payer MUST equal this address.
+   */
+  expectedFeePayer?: Address;
+  /**
+   * Required payer address per spec §"Settlement Procedure / Open"
+   * step 3's non-sponsored branch ("the payer funds the
+   * transaction"). When set, the decoded transaction's fee payer
+   * MUST equal this address. Mutually exclusive with
+   * `expectedFeePayer`.
+   */
+  expectedPayer?: Address;
+  /**
+   * Required Flex facilitator key per the challenge's
+   * `methodDetails.flex.facilitator`. When set, the `create_escrow`
+   * instruction's encoded facilitator MUST equal this address or
+   * later Flex settlement will be impossible.
+   */
+  expectedFacilitator?: Address;
+  /**
+   * Required refund timeout slots per the challenge's
+   * `methodDetails.flex.refundTimeoutSlots`. When set, the decoded
+   * `create_escrow` instruction's encoded value MUST equal this.
+   */
+  expectedRefundTimeoutSlots?: bigint;
+  /**
+   * Required deadman timeout slots per the challenge's
+   * `methodDetails.flex.deadmanTimeoutSlots`. When set, the decoded
+   * `create_escrow` instruction's encoded value MUST equal this.
+   */
+  expectedDeadmanTimeoutSlots?: bigint;
+};
+
+export type VerifyFlexOpenResult = {
+  decoded: DecodedFlexOpen;
+};
+
+/**
+ * Decodes a base64-encoded wire transaction and verifies that it
+ * contains the three Flex instructions a session-open requires
+ * (create_escrow, deposit, register_session_key) targeting the
+ * declared channelId and session key. Recomputes the escrow,
+ * vault, and session-key-account PDAs from the create_escrow args
+ * and verifies the transaction's accounts match.
+ *
+ * **What this does NOT verify**, per the COMPATIBILITY.md gap list:
+ *
+ * - The spec PDA seed binding `(payer, payee, asset, signer, salt)`.
+ *   Flex's escrow PDA is derived from `(owner, index)` only and does
+ *   not bind payee, asset, or signer. We re-derive the Flex PDA and
+ *   verify it matches the credential, but the spec MUST that the
+ *   PDA bind payee/asset/signer cannot be satisfied without changing
+ *   Flex's seed set.
+ *
+ * - On-chain confirmation. The handler does not currently broadcast
+ *   the open transaction or read the channel state back from RPC.
+ *   The spec's nine-step open verification (§"Settlement Procedure /
+ *   Open") expects post-confirmation reads; this only does the
+ *   off-chain pre-broadcast portion.
+ */
+export async function verifyFlexOpenTransaction(
+  args: VerifyFlexOpenTransactionArgs,
+): Promise<VerifyFlexOpenResult> {
+  const programAddress = args.programAddress ?? FLEX_PROGRAM_ADDRESS;
+
+  if (args.expectedFeePayer !== undefined && args.expectedPayer !== undefined) {
+    throw new Error(
+      "verifyFlexOpenTransaction: expectedFeePayer and expectedPayer are mutually exclusive",
+    );
+  }
+
+  const txBytes = getBase64Encoder().encode(args.transaction);
+  const decodedTx = getTransactionDecoder().decode(txBytes);
+  const compiledMessage = getCompiledTransactionMessageDecoder().decode(
+    decodedTx.messageBytes,
+  );
+  const transactionMessage = decompileTransactionMessage(compiledMessage);
+
+  // Verify the transaction is actually signed by its fee payer.
+  // Without this check, an attacker can submit an unsigned open
+  // transaction that the handler decodes and persists state from,
+  // even though no on-chain program will ever accept it.
+  const feePayerAddress = transactionMessage.feePayer?.address;
+  if (feePayerAddress === undefined) {
+    throw new Error("open transaction has no fee payer set");
+  }
+  const feePayerSignature = decodedTx.signatures[feePayerAddress];
+  if (feePayerSignature === undefined || feePayerSignature === null) {
+    throw new Error(
+      `open transaction is not signed by its fee payer ${feePayerAddress}`,
+    );
+  }
+
+  // Spec §"Settlement Procedure / Open" step 3: fee-payer policy.
+  // Sponsored-fees branch: fee payer MUST equal facilitatorKey.
+  // Non-sponsored branch: fee payer MUST equal the credential's
+  // `payer` (the channel owner funds their own open transaction).
+  if (args.expectedFeePayer !== undefined) {
+    if (feePayerAddress !== args.expectedFeePayer) {
+      throw new Error(
+        `open transaction fee payer ${feePayerAddress} does not match expected sponsored feePayerKey ${args.expectedFeePayer}`,
+      );
+    }
+  } else if (args.expectedPayer !== undefined) {
+    if (feePayerAddress !== args.expectedPayer) {
+      throw new Error(
+        `open transaction fee payer ${feePayerAddress} does not match expected payer ${args.expectedPayer}`,
+      );
+    }
+  }
+
+  // Spec §"Settlement Procedure / Open" step 4: reject open
+  // transactions that carry instructions unrelated to the three
+  // Flex instructions a session-open requires. Any other program
+  // invocation — including system transfers, memo, compute-budget,
+  // or anything else — could redirect funds or change channel state
+  // in ways the session handler can't reason about.
+  for (const ix of transactionMessage.instructions) {
+    if (ix.programAddress !== programAddress) {
+      throw new Error(
+        `open transaction carries an instruction from unexpected program ${ix.programAddress}; only the Flex program is permitted`,
+      );
+    }
+  }
+
+  const flexInstructions = transactionMessage.instructions.filter(
+    (ix): ix is Instruction => ix.programAddress === programAddress,
+  );
+
+  const hasDiscriminator = (ix: Instruction, disc: Uint8Array): boolean =>
+    discriminatorMatches(ix.data ? new Uint8Array(ix.data) : undefined, disc);
+
+  // Also reject duplicate Flex instructions — per spec step 4, the
+  // open transaction MUST contain exactly one create_escrow, one
+  // deposit, and one register_session_key. Extras could mutate
+  // channel parameters or spawn sibling escrows in the same tx.
+  const exactlyOne = (
+    discriminator: Uint8Array,
+    label: string,
+  ): Instruction => {
+    const matches = flexInstructions.filter((ix) =>
+      hasDiscriminator(ix, discriminator),
+    );
+    if (matches.length === 0) {
+      throw new Error(`open transaction missing ${label} instruction`);
+    }
+    if (matches.length > 1) {
+      throw new Error(
+        `open transaction has ${matches.length} ${label} instructions; expected exactly one`,
+      );
+    }
+    const found = matches[0];
+    if (!found) {
+      throw new Error(`open transaction has unexpected empty ${label} match`);
+    }
+    return found;
+  };
+
+  const createEscrowIx = exactlyOne(
+    CREATE_ESCROW_DISCRIMINATOR,
+    "create_escrow",
+  );
+  const depositIx = exactlyOne(DEPOSIT_DISCRIMINATOR, "deposit");
+  const registerSessionKeyIx = exactlyOne(
+    REGISTER_SESSION_KEY_DISCRIMINATOR,
+    "register_session_key",
+  );
+
+  // Guard against duplicate instances of ANY Flex discriminator
+  // beyond the three recognised ones — a future instruction could
+  // bypass these checks if we only filtered by known discriminators.
+  if (flexInstructions.length !== 3) {
+    throw new Error(
+      `open transaction has ${flexInstructions.length} Flex instructions; expected exactly 3 (create_escrow, deposit, register_session_key)`,
+    );
+  }
+
+  // create_escrow account layout (owner, escrow, systemProgram)
+  if (!createEscrowIx.accounts || createEscrowIx.accounts.length < 3) {
+    throw new Error("create_escrow has unexpected account count");
+  }
+  const ownerAccount = createEscrowIx.accounts[0];
+  const escrowAccount = createEscrowIx.accounts[1];
+  if (!ownerAccount || !escrowAccount) {
+    throw new Error("create_escrow accounts missing");
+  }
+  const owner = ownerAccount.address;
+  const escrow = escrowAccount.address;
+
+  // create_escrow data layout: 8(disc) + 8(index) + 32(facilitator) +
+  // 8(refund) + 8(deadman) + 1(maxSessionKeys)
+  const createData = new Uint8Array(createEscrowIx.data ?? new Uint8Array());
+  if (createData.length < 8 + 8 + 32 + 8 + 8 + 1) {
+    throw new Error("create_escrow data is too short");
+  }
+  let off = 8;
+  const index = readU64LE(createData, off);
+  off += 8;
+  const facilitatorBytes = createData.slice(off, off + 32);
+  off += 32;
+  const refundTimeoutSlots = readU64LE(createData, off);
+  off += 8;
+  const deadmanTimeoutSlots = readU64LE(createData, off);
+  off += 8;
+  const maxSessionKeysByte = createData[off];
+  if (maxSessionKeysByte === undefined) {
+    throw new Error("create_escrow data missing maxSessionKeys");
+  }
+  const maxSessionKeys = maxSessionKeysByte;
+
+  const decodedFacilitator = bytesToBase58Address(facilitatorBytes);
+  if (
+    args.expectedFacilitator !== undefined &&
+    decodedFacilitator !== args.expectedFacilitator
+  ) {
+    throw new Error(
+      `create_escrow facilitator ${decodedFacilitator} does not match expected ${args.expectedFacilitator}`,
+    );
+  }
+  if (
+    args.expectedRefundTimeoutSlots !== undefined &&
+    refundTimeoutSlots !== args.expectedRefundTimeoutSlots
+  ) {
+    throw new Error(
+      `create_escrow refundTimeoutSlots ${refundTimeoutSlots} does not match expected ${args.expectedRefundTimeoutSlots}`,
+    );
+  }
+  if (
+    args.expectedDeadmanTimeoutSlots !== undefined &&
+    deadmanTimeoutSlots !== args.expectedDeadmanTimeoutSlots
+  ) {
+    throw new Error(
+      `create_escrow deadmanTimeoutSlots ${deadmanTimeoutSlots} does not match expected ${args.expectedDeadmanTimeoutSlots}`,
+    );
+  }
+
+  // Re-derive the escrow PDA from (owner, index) and verify the
+  // create_escrow instruction is creating the escrow the credential
+  // claims.
+  const expectedEscrow = await deriveEscrowAddress({
+    owner,
+    index,
+    programAddress,
+  });
+  if (expectedEscrow !== escrow) {
+    throw new Error(
+      `create_escrow account ${escrow} does not match PDA derived from (owner=${owner}, index=${index})`,
+    );
+  }
+  if (escrow !== args.expectedChannelId) {
+    throw new Error(
+      `create_escrow PDA ${escrow} does not match credential channelId ${args.expectedChannelId}`,
+    );
+  }
+
+  // deposit account layout (depositor, escrow, mint, vault, source,
+  // tokenProgram, systemProgram)
+  if (!depositIx.accounts || depositIx.accounts.length < 7) {
+    throw new Error("deposit has unexpected account count");
+  }
+  const depositEscrow = depositIx.accounts[1];
+  const mintAccount = depositIx.accounts[2];
+  const vaultAccount = depositIx.accounts[3];
+  const sourceAccount = depositIx.accounts[4];
+  if (!depositEscrow || !mintAccount || !vaultAccount || !sourceAccount) {
+    throw new Error("deposit accounts missing");
+  }
+  const depositEscrowAddress = depositEscrow.address;
+  const mint = mintAccount.address;
+  const vault = vaultAccount.address;
+  const source = sourceAccount.address;
+
+  if (depositEscrowAddress !== escrow) {
+    throw new Error(
+      `deposit escrow ${depositEscrowAddress} does not match create_escrow ${escrow}`,
+    );
+  }
+  const expectedVault = await deriveVaultAddress({
+    escrow,
+    mint,
+    programAddress,
+  });
+  if (vault !== expectedVault) {
+    throw new Error(
+      `deposit vault ${vault} does not match PDA derived from (escrow, mint)`,
+    );
+  }
+
+  const depositData = new Uint8Array(depositIx.data ?? new Uint8Array());
+  if (depositData.length < 8 + 8) {
+    throw new Error("deposit data is too short");
+  }
+  const depositAmount = readU64LE(depositData, 8);
+
+  // register_session_key account layout
+  // (owner, escrow, sessionKeyAccount, systemProgram)
+  if (
+    !registerSessionKeyIx.accounts ||
+    registerSessionKeyIx.accounts.length < 4
+  ) {
+    throw new Error("register_session_key has unexpected account count");
+  }
+  const rskEscrowAccount = registerSessionKeyIx.accounts[1];
+  const sessionKeyAccountMeta = registerSessionKeyIx.accounts[2];
+  if (!rskEscrowAccount || !sessionKeyAccountMeta) {
+    throw new Error("register_session_key accounts missing");
+  }
+  const rskEscrow = rskEscrowAccount.address;
+  const sessionKeyAccount = sessionKeyAccountMeta.address;
+  if (rskEscrow !== escrow) {
+    throw new Error(
+      `register_session_key escrow ${rskEscrow} does not match create_escrow ${escrow}`,
+    );
+  }
+
+  // register_session_key data: 8(disc) + 32(sessionKey) +
+  // 1+optional 8(expiresAtSlot Option<u64>) + 8(graceSlots)
+  const rskData = new Uint8Array(registerSessionKeyIx.data ?? new Uint8Array());
+  if (rskData.length < 8 + 32 + 1 + 8) {
+    throw new Error("register_session_key data is too short");
+  }
+  const sessionKeyBytes = rskData.slice(8, 8 + 32);
+  let rOff = 8 + 32;
+  const expiresPresent = rskData[rOff] === 1;
+  rOff += 1;
+  let sessionKeyExpiresAtSlot: bigint | null = null;
+  if (expiresPresent) {
+    if (rskData.length < rOff + 8 + 8) {
+      throw new Error(
+        "register_session_key data missing expiresAtSlot payload",
+      );
+    }
+    sessionKeyExpiresAtSlot = readU64LE(rskData, rOff);
+    rOff += 8;
+  }
+  if (rskData.length < rOff + 8) {
+    throw new Error(
+      "register_session_key data missing revocation grace period",
+    );
+  }
+  const revocationGracePeriodSlots = readU64LE(rskData, rOff);
+
+  // Verify the session key bytes match the credential's expectedSessionKey.
+  // We compare against the address by re-deriving the PDA.
+  const expectedSessionKeyAccount = await deriveSessionKeyAccountAddress({
+    escrow,
+    sessionKey: args.expectedSessionKey,
+    programAddress,
+  });
+  if (sessionKeyAccount !== expectedSessionKeyAccount) {
+    throw new Error(
+      `register_session_key account ${sessionKeyAccount} does not match PDA derived from (escrow, expected sessionKey)`,
+    );
+  }
+
+  return {
+    decoded: {
+      owner,
+      index,
+      facilitator: decodedFacilitator,
+      refundTimeoutSlots,
+      deadmanTimeoutSlots,
+      maxSessionKeys,
+      escrow,
+      mint,
+      vault,
+      source,
+      depositAmount,
+      sessionKey: bytesToBase58Address(sessionKeyBytes),
+      sessionKeyAccount,
+      sessionKeyExpiresAtSlot,
+      revocationGracePeriodSlots,
+    },
+  };
+}
+
+import bs58 from "bs58";
+function bytesToBase58Address(bytes: Uint8Array): Address {
+  return bs58.encode(bytes) as Address;
+}

--- a/packages/payment-solana/src/session/verify.ts
+++ b/packages/payment-solana/src/session/verify.ts
@@ -1,0 +1,127 @@
+import type { Address } from "@solana/kit";
+import { canonicalizeSortedJSON } from "@faremeter/types/mpp";
+import {
+  serializePaymentAuthorization,
+  type SplitInput,
+} from "@faremeter/flex-solana";
+
+/**
+ * Serializes spec-shaped voucher data per draft-solana-session-00
+ * §"Voucher Signing": JCS canonicalization of the voucher data object,
+ * UTF-8 encoded.
+ */
+export function serializeSpecVoucherMessage(args: {
+  channelId: string;
+  cumulativeAmount: string;
+  expiresAt?: string;
+}): Uint8Array<ArrayBuffer> {
+  const data: Record<string, unknown> = {
+    channelId: args.channelId,
+    cumulativeAmount: args.cumulativeAmount,
+  };
+  if (args.expiresAt !== undefined) data.expiresAt = args.expiresAt;
+  const json = canonicalizeSortedJSON(data);
+  const encoded = new TextEncoder().encode(json);
+  const out = new Uint8Array(new ArrayBuffer(encoded.length));
+  out.set(encoded);
+  return out;
+}
+
+export type VoucherSplit = SplitInput;
+
+export type SerializeVoucherArgs = {
+  programAddress: Address;
+  escrow: Address;
+  mint: Address;
+  maxAmount: bigint;
+  authorizationId: bigint;
+  expiresAtSlot: bigint;
+  splits: VoucherSplit[];
+};
+
+/**
+ * Serializes a Flex payment authorization into the binary format the
+ * on-chain program's Ed25519 precompile verifies. This is a thin
+ * adapter over `@faremeter/flex-solana`'s
+ * `serializePaymentAuthorization` so the session handler can keep its
+ * own argument shape (`programAddress` rather than `programId`).
+ */
+export function serializeVoucherMessage(
+  args: SerializeVoucherArgs,
+): Uint8Array<ArrayBuffer> {
+  return serializePaymentAuthorization({
+    programId: args.programAddress,
+    escrow: args.escrow,
+    mint: args.mint,
+    maxAmount: args.maxAmount,
+    authorizationId: args.authorizationId,
+    expiresAtSlot: args.expiresAtSlot,
+    splits: args.splits,
+  });
+}
+
+function base64ToBytes(b64: string): Uint8Array<ArrayBuffer> {
+  const binary = atob(b64);
+  const bytes = new Uint8Array(new ArrayBuffer(binary.length));
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+/**
+ * Verifies an Ed25519 signature over a voucher message using the
+ * Web Crypto API. Returns true on a valid signature, false otherwise.
+ * Raw key is imported as SPKI after wrapping with the Ed25519 OID
+ * header.
+ */
+function toArrayBufferUint8(input: Uint8Array): Uint8Array<ArrayBuffer> {
+  if (input.buffer instanceof ArrayBuffer && input.byteOffset === 0) {
+    return input as Uint8Array<ArrayBuffer>;
+  }
+  const out = new Uint8Array(new ArrayBuffer(input.length));
+  out.set(input);
+  return out;
+}
+
+export async function verifyVoucherSignature(args: {
+  publicKey: Uint8Array;
+  message: Uint8Array;
+  signature: Uint8Array;
+}): Promise<boolean> {
+  const publicKey = toArrayBufferUint8(args.publicKey);
+  const message = toArrayBufferUint8(args.message);
+  const signature = toArrayBufferUint8(args.signature);
+  const spki = wrapEd25519SPKI(publicKey);
+  const key = await crypto.subtle.importKey(
+    "spki",
+    spki,
+    { name: "Ed25519" },
+    false,
+    ["verify"],
+  );
+  return crypto.subtle.verify("Ed25519", key, signature, message);
+}
+
+// Ed25519 SPKI header (DER): SEQUENCE { SEQUENCE { OID 1.3.101.112 } BIT STRING }
+const ED25519_SPKI_HEADER = new Uint8Array([
+  0x30, 0x2a, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70, 0x03, 0x21, 0x00,
+]);
+
+function wrapEd25519SPKI(
+  rawPublicKey: Uint8Array<ArrayBuffer>,
+): Uint8Array<ArrayBuffer> {
+  if (rawPublicKey.length !== 32) {
+    throw new Error(
+      `ed25519 public key must be 32 bytes, got ${rawPublicKey.length}`,
+    );
+  }
+  const out = new Uint8Array(new ArrayBuffer(ED25519_SPKI_HEADER.length + 32));
+  out.set(ED25519_SPKI_HEADER, 0);
+  out.set(rawPublicKey, ED25519_SPKI_HEADER.length);
+  return out;
+}
+
+export function base64ToVoucherParts(b64: string): Uint8Array<ArrayBuffer> {
+  return base64ToBytes(b64);
+}

--- a/packages/test-harness/src/scheme/mpp.ts
+++ b/packages/test-harness/src/scheme/mpp.ts
@@ -111,6 +111,7 @@ export function createTestMPPHandler(
       return {
         status: "success" as const,
         method,
+        intent: credential.challenge.intent,
         timestamp: new Date().toISOString(),
         reference: `test-tx-${Date.now()}`,
       };

--- a/packages/types/src/mpp/challenge.test.ts
+++ b/packages/types/src/mpp/challenge.test.ts
@@ -1,0 +1,84 @@
+#!/usr/bin/env pnpm tsx
+
+import t from "tap";
+import { generateChallengeID, verifyChallengeID } from "./challenge";
+import type { mppChallengeParams } from "./types";
+
+const secret = new TextEncoder().encode("test-secret-abcdefghijklmno");
+
+const baseParams: Omit<mppChallengeParams, "id"> = {
+  realm: "example",
+  method: "solana",
+  intent: "charge",
+  request: "dGVzdA",
+  expires: "1700000000",
+};
+
+await t.test("generateChallengeID is deterministic", async (t) => {
+  const a = await generateChallengeID(secret, baseParams);
+  const b = await generateChallengeID(secret, baseParams);
+  t.equal(a, b);
+  t.end();
+});
+
+await t.test("generateChallengeID differs by input", async (t) => {
+  const a = await generateChallengeID(secret, baseParams);
+  const b = await generateChallengeID(secret, {
+    ...baseParams,
+    intent: "session",
+  });
+  t.not(a, b);
+  t.end();
+});
+
+await t.test("verifyChallengeID round trip", async (t) => {
+  const id = await generateChallengeID(secret, baseParams);
+  const ok = await verifyChallengeID(secret, { id, ...baseParams });
+  t.ok(ok);
+  t.end();
+});
+
+await t.test("verifyChallengeID rejects tampered ID", async (t) => {
+  const id = await generateChallengeID(secret, baseParams);
+  const tampered = id.slice(0, -1) + (id.endsWith("A") ? "B" : "A");
+  const ok = await verifyChallengeID(secret, { id: tampered, ...baseParams });
+  t.notOk(ok);
+  t.end();
+});
+
+await t.test("verifyChallengeID rejects wrong secret", async (t) => {
+  const id = await generateChallengeID(secret, baseParams);
+  const otherSecret = new TextEncoder().encode("different-secret-xxxxxxxxxx");
+  const ok = await verifyChallengeID(otherSecret, { id, ...baseParams });
+  t.notOk(ok);
+  t.end();
+});
+
+await t.test("verifyChallengeID rejects mismatched params", async (t) => {
+  const id = await generateChallengeID(secret, baseParams);
+  const ok = await verifyChallengeID(secret, {
+    id,
+    ...baseParams,
+    request: "b3RoZXI",
+  });
+  t.notOk(ok);
+  t.end();
+});
+
+await t.test("optional fields round-trip", async (t) => {
+  const params: Omit<mppChallengeParams, "id"> = {
+    ...baseParams,
+    digest: "sha-256=:abc:",
+    opaque: "opq",
+  };
+  const id = await generateChallengeID(secret, params);
+  const ok = await verifyChallengeID(secret, { id, ...params });
+  t.ok(ok);
+  const okWithoutDigest = await verifyChallengeID(secret, {
+    id,
+    ...baseParams,
+    opaque: "opq",
+  });
+  t.notOk(okWithoutDigest);
+  t.end();
+});

--- a/packages/types/src/mpp/challenge.ts
+++ b/packages/types/src/mpp/challenge.ts
@@ -1,0 +1,67 @@
+import { encodeBase64URL } from "./encoding";
+import type { mppChallengeParams } from "./types";
+
+/**
+ * Computes the HMAC-SHA256 challenge ID for a set of challenge
+ * parameters. The ID commits the server's realm, method, intent,
+ * request, and optional expires/digest/opaque fields under a shared
+ * secret. Used by method handlers to verify that a presented challenge
+ * was minted by the same server without any out-of-band state.
+ *
+ * Slot values are either server-controlled constants or base64url
+ * strings, so the pipe delimiter is safe.
+ */
+export async function generateChallengeID(
+  secret: Uint8Array,
+  params: Omit<mppChallengeParams, "id">,
+): Promise<string> {
+  const slots = [
+    params.realm,
+    params.method,
+    params.intent,
+    params.request,
+    params.expires ?? "",
+    params.digest ?? "",
+    params.opaque ?? "",
+  ];
+  const message = new TextEncoder().encode(slots.join("|"));
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new Uint8Array(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const sig = await crypto.subtle.sign("HMAC", key, message);
+  return encodeBase64URL(String.fromCharCode(...new Uint8Array(sig)));
+}
+
+/**
+ * Constant-time comparison of two byte arrays. Avoids the node:crypto
+ * dependency so this module works in any runtime with Web Crypto.
+ */
+function constantTimeEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.byteLength !== b.byteLength) return false;
+  let diff = 0;
+  for (let i = 0; i < a.byteLength; i++) {
+    const av = a[i];
+    const bv = b[i];
+    if (av === undefined || bv === undefined) return false;
+    diff |= av ^ bv;
+  }
+  return diff === 0;
+}
+
+/**
+ * Recomputes the challenge ID from the other parameters and compares
+ * it to the presented ID in constant time.
+ */
+export async function verifyChallengeID(
+  secret: Uint8Array,
+  params: mppChallengeParams,
+): Promise<boolean> {
+  const { id, ...rest } = params;
+  const computed = await generateChallengeID(secret, rest);
+  const encoder = new TextEncoder();
+  return constantTimeEqual(encoder.encode(computed), encoder.encode(id));
+}

--- a/packages/types/src/mpp/index.ts
+++ b/packages/types/src/mpp/index.ts
@@ -1,3 +1,4 @@
 export * from "./types";
 export * from "./encoding";
 export * from "./handler";
+export * from "./challenge";

--- a/packages/types/src/mpp/index.ts
+++ b/packages/types/src/mpp/index.ts
@@ -2,3 +2,4 @@ export * from "./types";
 export * from "./encoding";
 export * from "./handler";
 export * from "./challenge";
+export * from "./session";

--- a/packages/types/src/mpp/receipt.test.ts
+++ b/packages/types/src/mpp/receipt.test.ts
@@ -1,0 +1,85 @@
+#!/usr/bin/env pnpm tsx
+
+import t from "tap";
+import { mppReceipt } from "./types";
+import { serializeReceipt, parseReceipt } from "./encoding";
+import { isValidationError } from "../validation";
+
+await t.test("mppReceipt round-trips without extras", async (t) => {
+  const receipt: mppReceipt = {
+    status: "success",
+    method: "solana",
+    intent: "charge",
+    timestamp: "2024-01-01T00:00:00.000Z",
+    reference: "tx-abc",
+  };
+  const parsed = parseReceipt(serializeReceipt(receipt));
+  t.matchOnly(parsed, receipt);
+  t.end();
+});
+
+await t.test("mppReceipt round-trips with extras", async (t) => {
+  const receipt: mppReceipt = {
+    status: "success",
+    method: "solana",
+    intent: "session",
+    timestamp: "2024-01-01T00:00:00.000Z",
+    reference: "tx-abc",
+    extra: {
+      channelId: "escrow-pda",
+      acceptedCumulative: "100",
+      spent: "40",
+    },
+  };
+  const parsed = parseReceipt(serializeReceipt(receipt));
+  t.matchOnly(parsed, receipt);
+  t.end();
+});
+
+await t.test("mppReceipt rejects a receipt without intent", async (t) => {
+  const receipt = {
+    status: "success",
+    method: "solana",
+    timestamp: "2024-01-01T00:00:00.000Z",
+    reference: "tx-abc",
+  };
+  const validated = mppReceipt(receipt);
+  t.ok(
+    isValidationError(validated),
+    "intent is REQUIRED per draft-solana-session-00 §Receipt Format",
+  );
+  t.end();
+});
+
+await t.test("mppReceipt rejects unknown top-level keys", async (t) => {
+  const receipt = {
+    status: "success",
+    method: "solana",
+    timestamp: "2024-01-01T00:00:00.000Z",
+    reference: "tx-abc",
+    channelId: "escrow-pda",
+  };
+  const validated = mppReceipt(receipt);
+  t.ok(isValidationError(validated), "top-level extras must live under extra");
+  t.end();
+});
+
+await t.test(
+  "parseReceipt returns undefined for unknown top-level keys",
+  (t) => {
+    const junk = btoa(
+      JSON.stringify({
+        status: "success",
+        method: "solana",
+        timestamp: "2024-01-01T00:00:00.000Z",
+        reference: "tx-abc",
+        stray: "value",
+      }),
+    )
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+    t.equal(parseReceipt(junk), undefined);
+    t.end();
+  },
+);

--- a/packages/types/src/mpp/session.test.ts
+++ b/packages/types/src/mpp/session.test.ts
@@ -1,0 +1,160 @@
+#!/usr/bin/env pnpm tsx
+
+import t from "tap";
+import {
+  SessionAction,
+  sessionOpenBase,
+  sessionTopUpBase,
+  sessionVoucherBase,
+  sessionCloseBase,
+  sessionRequestBase,
+  invalidChallengeProblem,
+  malformedCredentialProblem,
+  verificationFailedProblem,
+  buildInvalidChallengeProblem,
+  buildMalformedCredentialProblem,
+  buildVerificationFailedProblem,
+  PROBLEM_INVALID_CHALLENGE,
+  PROBLEM_MALFORMED_CREDENTIAL,
+  PROBLEM_VERIFICATION_FAILED,
+} from "./session";
+import { isValidationError } from "../validation";
+
+await t.test("SessionAction enumerates all actions", (t) => {
+  for (const action of ["open", "topUp", "voucher", "close"]) {
+    t.notOk(isValidationError(SessionAction(action)), action);
+  }
+  t.ok(isValidationError(SessionAction("refund")));
+  t.end();
+});
+
+await t.test("per-action base validators", (t) => {
+  t.notOk(
+    isValidationError(
+      sessionOpenBase({
+        action: "open",
+        channelId: "escrow",
+        payer: "owner",
+        depositAmount: "1000000",
+      }),
+    ),
+  );
+  t.notOk(
+    isValidationError(
+      sessionTopUpBase({
+        action: "topUp",
+        channelId: "escrow",
+        additionalAmount: "1000",
+      }),
+    ),
+  );
+  t.notOk(
+    isValidationError(
+      sessionVoucherBase({
+        action: "voucher",
+        channelId: "escrow",
+      }),
+    ),
+  );
+  t.notOk(
+    isValidationError(
+      sessionCloseBase({
+        action: "close",
+        channelId: "escrow",
+      }),
+    ),
+  );
+  t.ok(
+    isValidationError(
+      sessionTopUpBase({
+        action: "topUp",
+        channelId: "escrow",
+        additionalAmount: "not-numeric",
+      }),
+    ),
+  );
+  t.end();
+});
+
+await t.test(
+  "sessionRequestBase requires amount, currency, and recipient",
+  (t) => {
+    // draft-solana-session-00 §"Request Schema / Shared Fields" makes
+    // amount REQUIRED for the session intent ("Price per unit of
+    // service in the token's smallest unit").
+    t.notOk(
+      isValidationError(
+        sessionRequestBase({
+          amount: "25",
+          currency: "mint",
+          recipient: "pubkey",
+        }),
+      ),
+    );
+    t.notOk(
+      isValidationError(
+        sessionRequestBase({
+          amount: "25",
+          unitType: "token",
+          suggestedDeposit: "10000",
+          currency: "mint",
+          recipient: "pubkey",
+        }),
+      ),
+    );
+    t.ok(
+      isValidationError(
+        sessionRequestBase({
+          currency: "mint",
+          recipient: "pubkey",
+        }),
+      ),
+      "sessionRequestBase must reject a request missing the spec-required amount",
+    );
+    t.ok(
+      isValidationError(
+        sessionRequestBase({ amount: "25", recipient: "pubkey" }),
+      ),
+      "sessionRequestBase must reject a request missing currency",
+    );
+    t.ok(
+      isValidationError(sessionRequestBase({ amount: "25", currency: "mint" })),
+      "sessionRequestBase must reject a request missing recipient",
+    );
+    t.end();
+  },
+);
+
+await t.test("buildVerificationFailedProblem emits a valid problem", (t) => {
+  const problem = buildVerificationFailedProblem({
+    title: "Insufficient hold",
+    detail: "Amount exceeds deposit",
+  });
+  t.equal(problem.type, PROBLEM_VERIFICATION_FAILED);
+  t.equal(problem.status, 402);
+  t.equal(problem.title, "Insufficient hold");
+  t.equal(problem.detail, "Amount exceeds deposit");
+  t.notOk(isValidationError(verificationFailedProblem(problem)));
+
+  const bare = buildVerificationFailedProblem({});
+  t.equal(bare.title, "Verification failed");
+  t.equal(bare.detail, undefined);
+  t.notOk(isValidationError(verificationFailedProblem(bare)));
+  t.end();
+});
+
+await t.test("buildMalformedCredentialProblem emits a valid problem", (t) => {
+  const problem = buildMalformedCredentialProblem({
+    detail: "missing voucher.signature",
+  });
+  t.equal(problem.type, PROBLEM_MALFORMED_CREDENTIAL);
+  t.notOk(isValidationError(malformedCredentialProblem(problem)));
+  t.end();
+});
+
+await t.test("buildInvalidChallengeProblem emits a valid problem", (t) => {
+  const problem = buildInvalidChallengeProblem({ detail: "challenge expired" });
+  t.equal(problem.type, PROBLEM_INVALID_CHALLENGE);
+  t.notOk(isValidationError(invalidChallengeProblem(problem)));
+  t.end();
+});

--- a/packages/types/src/mpp/session.ts
+++ b/packages/types/src/mpp/session.ts
@@ -1,0 +1,160 @@
+import { type } from "arktype";
+
+/**
+ * Intent name that identifies a session-style handler. Register
+ * handlers with `getSupportedIntents()` returning this constant.
+ */
+export const SESSION_INTENT = "session";
+
+/**
+ * Action discriminator for session credential payloads. Shared across
+ * all chains; chain-specific handlers intersect their per-action
+ * shapes with the corresponding base below.
+ */
+export const SessionAction = type("'open'|'topUp'|'voucher'|'close'");
+export type SessionAction = typeof SessionAction.infer;
+
+// Per draft-solana-session-00 §"Action: open". `payer`, `depositAmount`,
+// and `transaction` are REQUIRED at the spec layer; the initial signed
+// `voucher` is REQUIRED here too but lives in the chain-specific
+// extension because the voucher format is method-specific.
+export const sessionOpenBase = type({
+  action: "'open'",
+  channelId: "string",
+  payer: "string",
+  depositAmount: "string.numeric",
+  "authorizationPolicy?": "Record<string, unknown>",
+  "expiresAt?": "string",
+  "capabilities?": "Record<string, unknown>",
+});
+export type sessionOpenBase = typeof sessionOpenBase.infer;
+
+// Per spec §"Action: topUp". The spec carries channelId,
+// additionalAmount, and transaction; there is no top-level signer.
+export const sessionTopUpBase = type({
+  action: "'topUp'",
+  channelId: "string",
+  additionalAmount: "string.numeric",
+});
+export type sessionTopUpBase = typeof sessionTopUpBase.infer;
+
+// Per spec §"Action: voucher". The voucher data + signature live in
+// the chain-specific extension; the base only carries the action and
+// channelId.
+export const sessionVoucherBase = type({
+  action: "'voucher'",
+  channelId: "string",
+});
+export type sessionVoucherBase = typeof sessionVoucherBase.infer;
+
+// Per spec §"Action: close". The optional final voucher lives in the
+// chain-specific extension.
+export const sessionCloseBase = type({
+  action: "'close'",
+  channelId: "string",
+});
+export type sessionCloseBase = typeof sessionCloseBase.infer;
+
+/**
+ * Generic session challenge `request` body. Method-specific handlers
+ * extend this with their own `methodDetails` shape via arktype's
+ * intersection operators. `amount` is REQUIRED per
+ * draft-solana-session-00 §"Request Schema / Shared Fields" — it
+ * carries the price per unit of service. `description` and
+ * `externalId` are OPTIONAL per the same section: human-readable
+ * service description and merchant reconciliation id respectively.
+ */
+export const sessionRequestBase = type({
+  amount: "string.numeric",
+  "unitType?": "string",
+  "suggestedDeposit?": "string.numeric",
+  currency: "string",
+  recipient: "string",
+  "description?": "string",
+  "externalId?": "string",
+});
+export type sessionRequestBase = typeof sessionRequestBase.infer;
+
+/**
+ * Standard Problem Details type URIs from draft-ietf-httpauth-payment.
+ * draft-solana-session-00 §"Error Responses" requires servers to use
+ * these three types and to attach a fresh `WWW-Authenticate` challenge
+ * to every error response.
+ */
+export const PROBLEM_MALFORMED_CREDENTIAL =
+  "https://paymentauth.org/problems/malformed-credential";
+export const PROBLEM_INVALID_CHALLENGE =
+  "https://paymentauth.org/problems/invalid-challenge";
+export const PROBLEM_VERIFICATION_FAILED =
+  "https://paymentauth.org/problems/verification-failed";
+
+const baseProblemFields = {
+  title: "string",
+  status: "402",
+  "detail?": "string",
+  "instance?": "string",
+} as const;
+
+export const malformedCredentialProblem = type({
+  type: `"${PROBLEM_MALFORMED_CREDENTIAL}"`,
+  ...baseProblemFields,
+});
+export type malformedCredentialProblem =
+  typeof malformedCredentialProblem.infer;
+
+export const invalidChallengeProblem = type({
+  type: `"${PROBLEM_INVALID_CHALLENGE}"`,
+  ...baseProblemFields,
+});
+export type invalidChallengeProblem = typeof invalidChallengeProblem.infer;
+
+export const verificationFailedProblem = type({
+  type: `"${PROBLEM_VERIFICATION_FAILED}"`,
+  ...baseProblemFields,
+});
+export type verificationFailedProblem = typeof verificationFailedProblem.infer;
+
+export function buildVerificationFailedProblem(args: {
+  title?: string;
+  detail?: string;
+  instance?: string;
+}): verificationFailedProblem {
+  const out: verificationFailedProblem = {
+    type: PROBLEM_VERIFICATION_FAILED,
+    title: args.title ?? "Verification failed",
+    status: 402,
+  };
+  if (args.detail !== undefined) out.detail = args.detail;
+  if (args.instance !== undefined) out.instance = args.instance;
+  return out;
+}
+
+export function buildMalformedCredentialProblem(args: {
+  title?: string;
+  detail?: string;
+  instance?: string;
+}): malformedCredentialProblem {
+  const out: malformedCredentialProblem = {
+    type: PROBLEM_MALFORMED_CREDENTIAL,
+    title: args.title ?? "Malformed credential",
+    status: 402,
+  };
+  if (args.detail !== undefined) out.detail = args.detail;
+  if (args.instance !== undefined) out.instance = args.instance;
+  return out;
+}
+
+export function buildInvalidChallengeProblem(args: {
+  title?: string;
+  detail?: string;
+  instance?: string;
+}): invalidChallengeProblem {
+  const out: invalidChallengeProblem = {
+    type: PROBLEM_INVALID_CHALLENGE,
+    title: args.title ?? "Invalid challenge",
+    status: 402,
+  };
+  if (args.detail !== undefined) out.detail = args.detail;
+  if (args.instance !== undefined) out.instance = args.instance;
+  return out;
+}

--- a/packages/types/src/mpp/types.ts
+++ b/packages/types/src/mpp/types.ts
@@ -30,8 +30,16 @@ export type mppCredential = typeof mppCredential.infer;
 export const mppReceipt = type({
   status: "'success'|'failed'",
   method: "string",
+  // draft-solana-session-00 §"Receipt Format" lists `intent` as
+  // REQUIRED; the charge-intent receipt also carries it. Clients
+  // use this to route receipts to the right per-intent handler.
+  intent: "string",
   timestamp: "string",
   reference: "string",
-});
+  "challengeId?": "string",
+  "acceptedCumulative?": "string.numeric",
+  "spent?": "string.numeric",
+  "extra?": "Record<string, unknown>",
+}).onUndeclaredKey("reject");
 
 export type mppReceipt = typeof mppReceipt.infer;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -594,6 +594,9 @@ importers:
       arktype:
         specifier: 'catalog:'
         version: 2.1.21
+      bs58:
+        specifier: 'catalog:'
+        version: 6.0.0
     devDependencies:
       '@eslint/js':
         specifier: 'catalog:'
@@ -1178,9 +1181,15 @@ importers:
       '@faremeter/facilitator':
         specifier: workspace:^
         version: link:../packages/facilitator
+      '@faremeter/info':
+        specifier: workspace:^
+        version: link:../packages/info
       '@faremeter/middleware':
         specifier: workspace:^
         version: link:../packages/middleware
+      '@faremeter/payment-solana':
+        specifier: workspace:^
+        version: link:../packages/payment-solana
       '@faremeter/rides':
         specifier: workspace:^
         version: link:../packages/rides
@@ -1190,6 +1199,12 @@ importers:
       '@faremeter/types':
         specifier: workspace:^
         version: link:../packages/types
+      '@solana/kit':
+        specifier: 'catalog:'
+        version: 6.7.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      bs58:
+        specifier: 'catalog:'
+        version: 6.0.0
     devDependencies:
       '@tapjs/tsx':
         specifier: 'catalog:'
@@ -2981,10 +2996,6 @@ packages:
     resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
     engines: {node: '>=18'}
 
-  commander@14.0.1:
-    resolution: {integrity: sha512-2JkV3gUZUVrbNA+1sjBOYLsMZ5cEEl8GTFP2a4AVz5hvasAMCQ1D2l2le/cX+pV4N6ZU17zjUahLpIXRrnWL8A==}
-    engines: {node: '>=20'}
-
   commander@14.0.3:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
     engines: {node: '>=20'}
@@ -3458,11 +3469,13 @@ packages:
 
   glob@10.4.5:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@11.0.3:
     resolution: {integrity: sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==}
     engines: {node: 20 || >=22}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   globals@14.0.0:
@@ -4591,6 +4604,7 @@ packages:
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   tcompare@9.0.0:
     resolution: {integrity: sha512-qOliew2xDAqIUbIamIFZ+pz80s9T+8IywzQPIt7YX30ojsBqk86jcD6ouygqt5lHURTxFxWjzbUmIe7Cts4bsA==}
@@ -6006,7 +6020,7 @@ snapshots:
   '@solana/errors@2.3.0(typescript@5.9.3)':
     dependencies:
       chalk: 5.6.2
-      commander: 14.0.1
+      commander: 14.0.3
       typescript: 5.9.3
 
   '@solana/errors@6.7.0(typescript@5.9.3)':
@@ -7789,8 +7803,6 @@ snapshots:
       delayed-stream: 1.0.0
 
   commander@12.1.0: {}
-
-  commander@14.0.1: {}
 
   commander@14.0.3: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,6 +7,7 @@ packages:
 catalog:
   "@crossmint/wallets-sdk": 1.0.7
   "@eslint/js": 9.34.0
+  "@faremeter/flex-solana": 0.1.0
   "@faremeter/x-solana-settlement": 0.4.0
   "@hono/node-server": 1.19.1
   "@logtape/logtape": 1.0.4

--- a/tests/mpp/session-end-to-end.test.ts
+++ b/tests/mpp/session-end-to-end.test.ts
@@ -1,0 +1,265 @@
+#!/usr/bin/env pnpm tsx
+
+import t from "tap";
+import {
+  address,
+  generateKeyPairSigner,
+  type Rpc,
+  type SolanaRpcApi,
+} from "@solana/kit";
+import type { webcrypto } from "node:crypto";
+
+type SessionKeyPair = webcrypto.CryptoKeyPair;
+import {
+  createMPPSolanaSessionHandler,
+  serializeVoucherMessage,
+  serializeSpecVoucherMessage,
+  FLEX_PROGRAM_ADDRESS,
+  createInMemorySessionStore,
+} from "@faremeter/payment-solana/session";
+import {
+  SESSION_INTENT,
+  PROBLEM_VERIFICATION_FAILED,
+  type mppCredential,
+} from "@faremeter/types/mpp";
+import { FLEX_PROBLEM_PENDING_LIMIT } from "@faremeter/payment-solana/session";
+import bs58 from "bs58";
+
+const MINT = address("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v");
+const RECIPIENT = address("3QFU3r76XiQVdqkaX5K6FWkDyiBKN7EK3UjRSWxMXHt3");
+const ESCROW = address("9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM");
+
+const stubRpc = {} as unknown as Rpc<SolanaRpcApi>;
+
+async function makeSessionEnv() {
+  const facilitatorSigner = await generateKeyPairSigner();
+  const sessionKeyPair = (await crypto.subtle.generateKey("Ed25519", true, [
+    "sign",
+    "verify",
+  ])) as SessionKeyPair;
+  const exported = await crypto.subtle.exportKey(
+    "raw",
+    sessionKeyPair.publicKey,
+  );
+  const sessionKeyBytes = new Uint8Array(exported);
+  const sessionKeyAddress = address(bs58.encode(sessionKeyBytes));
+
+  const store = createInMemorySessionStore();
+  const handler = await createMPPSolanaSessionHandler({
+    network: "solana-devnet",
+    rpc: stubRpc,
+    facilitatorSigner,
+    supportedMints: [MINT],
+    mintDecimals: 6,
+    defaultSplits: [{ recipient: RECIPIENT.toString(), bps: 10000 }],
+    realm: "test",
+    secretKey: new TextEncoder().encode("session-end-to-end-secret"),
+    sessionStore: store,
+    refundTimeoutSlots: 150n,
+    deadmanTimeoutSlots: 1000n,
+    minGracePeriodSlots: 150n,
+    challengeExpiresSeconds: 3600,
+    maxRetries: 1,
+    retryDelayMs: 1,
+    flushIntervalMs: 1000,
+    programAddress: FLEX_PROGRAM_ADDRESS,
+  });
+
+  return { handler, sessionKeyPair, sessionKeyAddress, store };
+}
+
+async function buildSignedVoucherCredential(args: {
+  challenge: mppCredential["challenge"];
+  sessionKeyPair: SessionKeyPair;
+  sessionKeyAddress: string;
+  cumulativeAmount: bigint;
+  delta: bigint;
+  authorizationId: bigint;
+}): Promise<mppCredential> {
+  // Sign the spec-shaped voucher (JCS over voucher data, base58).
+  const specMessage = serializeSpecVoucherMessage({
+    channelId: ESCROW.toString(),
+    cumulativeAmount: args.cumulativeAmount.toString(),
+  });
+  const specSig = new Uint8Array(
+    await crypto.subtle.sign(
+      "Ed25519",
+      args.sessionKeyPair.privateKey,
+      specMessage,
+    ),
+  );
+
+  // Sign the Flex authorization (packed binary, base64). Carried as a
+  // Faremeter extension because Flex's submit_authorization expects
+  // these bytes on chain. The splits must match the challenge's
+  // defaultSplits or the handler will reject the voucher.
+  const splits = [{ recipient: RECIPIENT.toString(), bps: 10000 }];
+  const flexMessage = serializeVoucherMessage({
+    programAddress: FLEX_PROGRAM_ADDRESS,
+    escrow: ESCROW,
+    mint: MINT,
+    maxAmount: args.delta,
+    authorizationId: args.authorizationId,
+    expiresAtSlot: 0n,
+    splits: splits.map((s) => ({
+      recipient: address(s.recipient),
+      bps: s.bps,
+    })),
+  });
+  const flexSig = new Uint8Array(
+    await crypto.subtle.sign(
+      "Ed25519",
+      args.sessionKeyPair.privateKey,
+      flexMessage,
+    ),
+  );
+  let binary = "";
+  for (const b of flexSig) binary += String.fromCharCode(b);
+  const flexSignature = btoa(binary);
+
+  return {
+    challenge: args.challenge,
+    payload: {
+      action: "voucher",
+      channelId: ESCROW.toString(),
+      voucher: {
+        voucher: {
+          channelId: ESCROW.toString(),
+          cumulativeAmount: args.cumulativeAmount.toString(),
+        },
+        signer: args.sessionKeyAddress,
+        signature: bs58.encode(specSig),
+        signatureType: "ed25519",
+      },
+      flex: {
+        mint: MINT.toString(),
+        authorizationId: args.authorizationId.toString(),
+        maxAmount: args.delta.toString(),
+        expiresAtSlot: "0",
+        splits,
+        signature: flexSignature,
+      },
+    },
+  };
+}
+
+await t.test("session: open then voucher updates state", async (t) => {
+  const env = await makeSessionEnv();
+
+  // Seed the session as if open had succeeded.
+  await env.store.put({
+    channelId: ESCROW,
+    sessionKey: env.sessionKeyAddress,
+    mint: MINT,
+    escrowedAmount: 1_000_000n,
+    acceptedCumulative: 0n,
+    spent: 0n,
+    inFlightAuthorizationIds: [],
+    status: "open",
+  });
+
+  const challenge = await env.handler.getChallenge(
+    SESSION_INTENT,
+    {
+      amount: "25",
+      asset: MINT.toString(),
+      recipient: RECIPIENT.toString(),
+      network: "solana-devnet",
+    },
+    "http://test/api",
+  );
+
+  const credential = await buildSignedVoucherCredential({
+    challenge,
+    sessionKeyPair: env.sessionKeyPair,
+    sessionKeyAddress: env.sessionKeyAddress.toString(),
+    cumulativeAmount: 100n,
+    delta: 100n,
+    authorizationId: 1n,
+  });
+
+  // handleSettle is the spec's voucher-submission path; it calls
+  // tryRegisterVoucher internally so the receipt reflects the
+  // persisted state by the time we return.
+  const receipt = await env.handler.handleSettle(credential);
+  t.ok(receipt);
+  t.equal(receipt?.acceptedCumulative, "100");
+
+  await env.handler.chargeSession(ESCROW, 25n);
+  const remaining = await env.handler.remainingHold(ESCROW);
+  t.equal(remaining, 75n);
+
+  const post = await env.handler.buildReceipt(ESCROW);
+  t.equal(post.acceptedCumulative, "100");
+  t.equal(post.spent, "25");
+  t.equal(post.intent, SESSION_INTENT);
+
+  t.end();
+});
+
+await t.test("session: insufficient hold yields a problem", async (t) => {
+  const env = await makeSessionEnv();
+  await env.store.put({
+    channelId: ESCROW,
+    sessionKey: env.sessionKeyAddress,
+    mint: MINT,
+    escrowedAmount: 100n,
+    acceptedCumulative: 100n,
+    spent: 100n,
+    inFlightAuthorizationIds: [],
+    status: "open",
+  });
+  const remaining = await env.handler.remainingHold(ESCROW);
+  t.equal(remaining, 0n);
+
+  const state = await env.handler.getSessionState(ESCROW);
+  if (!state) throw new Error("missing state");
+  const problem = env.handler.buildInsufficientHoldProblem(state, 30n);
+  t.equal(problem.type, PROBLEM_VERIFICATION_FAILED);
+  t.equal(problem.title, "Insufficient hold");
+  t.match(problem.detail, /requiredTopUp=30/);
+  t.match(problem.detail, /acceptedCumulative=100/);
+  t.match(problem.detail, /spent=100/);
+  t.end();
+});
+
+await t.test(
+  "session: pending-limit problem builder reports counts",
+  async (t) => {
+    const env = await makeSessionEnv();
+    const inFlightAuthorizationIds = Array.from({ length: 16 }, (_, i) =>
+      BigInt(i + 1),
+    );
+    await env.store.put({
+      channelId: ESCROW,
+      sessionKey: env.sessionKeyAddress,
+      mint: MINT,
+      escrowedAmount: 1_000_000n,
+      acceptedCumulative: 0n,
+      spent: 0n,
+      inFlightAuthorizationIds,
+      status: "open",
+    });
+
+    const state = await env.handler.getSessionState(ESCROW);
+    if (!state) throw new Error("missing state");
+    const problem = env.handler.buildPendingLimitProblem(state);
+    t.equal(problem.type, FLEX_PROBLEM_PENDING_LIMIT);
+    t.equal(problem.pendingCount, 16);
+    t.equal(problem.maxPending, 16);
+    t.equal(problem.channelId, ESCROW.toString());
+    t.end();
+  },
+);
+
+await t.test(
+  "session: session-not-found builder for unknown sessions",
+  async (t) => {
+    const env = await makeSessionEnv();
+    const problem = env.handler.buildSessionNotFoundProblem(ESCROW);
+    t.equal(problem.type, PROBLEM_VERIFICATION_FAILED);
+    t.equal(problem.title, "Channel not found");
+    t.match(problem.detail, new RegExp(`channelId=${ESCROW.toString()}`));
+    t.end();
+  },
+);

--- a/tests/mpp/session-middleware.test.ts
+++ b/tests/mpp/session-middleware.test.ts
@@ -1,0 +1,848 @@
+#!/usr/bin/env pnpm tsx
+
+// Integration tests for the MPP solana/session lifecycle through the
+// public test harness. These exercise the full request/response
+// stack: client credential construction, JCS-canonical serialization,
+// HTTP `Authorization: Payment ...` round-trip, the middleware's MPP
+// dispatcher, the session handler, and the receipt header that comes
+// back. Each test builds a real Flex session-open transaction (signed
+// by the owner) so the handler's verify-open path runs end-to-end.
+// On-chain broadcast is out of scope; the handler verifies the wire
+// format and persists state without touching RPC.
+
+import t from "tap";
+import {
+  address,
+  appendTransactionMessageInstructions,
+  createTransactionMessage,
+  generateKeyPairSigner,
+  getBase64EncodedWireTransaction,
+  pipe,
+  setTransactionMessageFeePayerSigner,
+  setTransactionMessageLifetimeUsingBlockhash,
+  signTransactionMessageWithSigners,
+  type Address,
+  type Blockhash,
+  type Rpc,
+  type SolanaRpcApi,
+  type TransactionSigner,
+} from "@solana/kit";
+import type { webcrypto } from "node:crypto";
+import bs58 from "bs58";
+
+import { TestHarness, isResourceContextMPP } from "@faremeter/test-harness";
+import {
+  createMPPSolanaSessionHandler,
+  createMPPSolanaSessionClient,
+  buildSessionOpenInstructions,
+  serializeSpecVoucherMessage,
+  FLEX_PROGRAM_ADDRESS,
+  type MPPSolanaSessionClient,
+  type FlexSessionHandler,
+} from "@faremeter/payment-solana/session";
+import { SOLANA_DEVNET } from "@faremeter/info/solana";
+import {
+  AUTHORIZATION_HEADER,
+  PAYMENT_RECEIPT_HEADER,
+  parseWWWAuthenticate,
+  parseReceipt,
+  serializeCredential,
+  SESSION_INTENT,
+  PROBLEM_VERIFICATION_FAILED,
+  type mppCredential,
+} from "@faremeter/types/mpp";
+import type { ResourcePricing } from "@faremeter/types/pricing";
+
+type SessionKeyPair = webcrypto.CryptoKeyPair;
+
+const MINT = address("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v");
+const RECIPIENT = address("3QFU3r76XiQVdqkaX5K6FWkDyiBKN7EK3UjRSWxMXHt3");
+const FAKE_BLOCKHASH =
+  "EETubP46DHLkT9hAFKy4x2BoFUqUFvKjiiNVY3CaYRi3" as Blockhash;
+
+const stubRpc = {} as unknown as Rpc<SolanaRpcApi>;
+
+async function buildSessionKeyPair(): Promise<{
+  keypair: SessionKeyPair;
+  address: Address;
+}> {
+  const keypair = (await crypto.subtle.generateKey("Ed25519", true, [
+    "sign",
+    "verify",
+  ])) as SessionKeyPair;
+  const raw = new Uint8Array(
+    await crypto.subtle.exportKey("raw", keypair.publicKey),
+  );
+  return { keypair, address: address(bs58.encode(raw)) };
+}
+
+type SessionEnv = {
+  harness: TestHarness;
+  handler: FlexSessionHandler;
+  client: MPPSolanaSessionClient;
+  facilitatorSigner: TransactionSigner;
+  ownerSigner: TransactionSigner;
+  session: { keypair: SessionKeyPair; address: Address };
+  depositAmount: bigint;
+  pricing: ResourcePricing[];
+};
+
+// Builds a fully-wired session env: a handler with `sponsorFees: false`
+// (the test client signs the open as the escrow owner, not as the
+// facilitator), a session client with a `buildOpenTransaction` callback
+// that produces a real Flex three-instruction batch, and a TestHarness
+// stitching them together.
+async function makeSessionEnv(): Promise<SessionEnv> {
+  const facilitatorSigner = await generateKeyPairSigner();
+  const handler = await createMPPSolanaSessionHandler({
+    network: SOLANA_DEVNET.caip2,
+    rpc: stubRpc,
+    facilitatorSigner,
+    sponsorFees: false,
+    supportedMints: [MINT],
+    mintDecimals: 6,
+    defaultSplits: [{ recipient: RECIPIENT.toString(), bps: 10000 }],
+    realm: "session-integration",
+    secretKey: new TextEncoder().encode("session-integration-secret"),
+    refundTimeoutSlots: 150n,
+    deadmanTimeoutSlots: 1000n,
+    minGracePeriodSlots: 150n,
+    challengeExpiresSeconds: 3600,
+    maxRetries: 1,
+    retryDelayMs: 1,
+    flushIntervalMs: 1000,
+    programAddress: FLEX_PROGRAM_ADDRESS,
+  });
+
+  const ownerSigner = await generateKeyPairSigner();
+  const sourceTokenAccount = await generateKeyPairSigner();
+  const session = await buildSessionKeyPair();
+  const depositAmount = 1_000_000n;
+
+  const client = createMPPSolanaSessionClient({
+    wallet: { address: ownerSigner.address },
+    sessionKeyPair: session.keypair,
+    sessionKeyAddress: session.address,
+    programAddress: FLEX_PROGRAM_ADDRESS,
+    buildOpenTransaction: async () => {
+      const built = await buildSessionOpenInstructions({
+        owner: ownerSigner,
+        facilitator: facilitatorSigner.address,
+        sessionKey: session.address,
+        mint: MINT,
+        source: sourceTokenAccount.address,
+        index: 0n,
+        depositAmount,
+        refundTimeoutSlots: 150n,
+        deadmanTimeoutSlots: 1000n,
+        maxSessionKeys: 1,
+        sessionKeyExpiresAtSlot: null,
+        sessionKeyGracePeriodSlots: 150n,
+        programAddress: FLEX_PROGRAM_ADDRESS,
+      });
+      const message = pipe(
+        createTransactionMessage({ version: 0 }),
+        (m) => setTransactionMessageFeePayerSigner(ownerSigner, m),
+        (m) =>
+          setTransactionMessageLifetimeUsingBlockhash(
+            { blockhash: FAKE_BLOCKHASH, lastValidBlockHeight: 1000n },
+            m,
+          ),
+        (m) => appendTransactionMessageInstructions(built.instructions, m),
+      );
+      const signed = await signTransactionMessageWithSigners(message);
+      const wire = getBase64EncodedWireTransaction(signed);
+      return {
+        transaction: wire,
+        escrow: built.escrow,
+        mint: MINT,
+        payer: ownerSigner.address,
+        depositAmount,
+      };
+    },
+  });
+
+  const pricing: ResourcePricing[] = [
+    {
+      amount: "25",
+      asset: MINT.toString(),
+      recipient: RECIPIENT.toString(),
+      network: SOLANA_DEVNET.caip2,
+    },
+  ];
+
+  const harness = new TestHarness({
+    mppMethodHandlers: [handler],
+    mppClientHandlers: [client],
+    pricing,
+    clientHandlers: [],
+    settleMode: "settle-only",
+  });
+
+  return {
+    harness,
+    handler,
+    client,
+    facilitatorSigner,
+    ownerSigner,
+    session,
+    depositAmount,
+    pricing,
+  };
+}
+
+// Drives the spec's open path through `harness.createClientFetch()`
+// directly so the test can inspect the 402 challenge before submitting
+// the credential. Returns the open response (200) and the channelId
+// the server bound on the credential.
+async function openSession(env: SessionEnv): Promise<{
+  response: Response;
+  channelId: Address;
+}> {
+  const clientFetch = env.harness.createClientFetch();
+  const challengeResponse = await clientFetch("/protected");
+  if (challengeResponse.status !== 402) {
+    throw new Error(
+      `expected 402 to start the open flow, got ${challengeResponse.status}`,
+    );
+  }
+  const wwwAuth = challengeResponse.headers.get("WWW-Authenticate");
+  if (!wwwAuth) throw new Error("no WWW-Authenticate on initial 402");
+  const challenges = parseWWWAuthenticate(wwwAuth);
+  const challenge = challenges.find(
+    (c) => c.method === "solana" && c.intent === SESSION_INTENT,
+  );
+  if (!challenge) throw new Error("no session challenge in WWW-Authenticate");
+
+  const execer = await env.client(challenge);
+  if (!execer) throw new Error("session client did not match the challenge");
+  const credential = await execer.exec();
+  const authHeader = `Payment ${serializeCredential(credential)}`;
+  const response = await clientFetch("/protected", {
+    headers: { [AUTHORIZATION_HEADER]: authHeader },
+  });
+  const channelId = address(
+    (credential.payload as { channelId: string }).channelId,
+  );
+  return { response, channelId };
+}
+
+await t.test(
+  "spec §Challenge — initial GET returns 402 with WWW-Authenticate Payment header carrying the session challenge",
+  async (t) => {
+    const env = await makeSessionEnv();
+    const clientFetch = env.harness.createClientFetch();
+
+    const response = await clientFetch("/protected");
+    t.equal(response.status, 402, "unauthenticated GET must return 402");
+
+    const wwwAuth = response.headers.get("WWW-Authenticate");
+    t.ok(wwwAuth, "402 must carry WWW-Authenticate header");
+
+    const challenges = parseWWWAuthenticate(wwwAuth ?? "");
+    const session = challenges.find(
+      (c) => c.method === "solana" && c.intent === SESSION_INTENT,
+    );
+    t.ok(session, "WWW-Authenticate must include a session-intent challenge");
+    t.equal(session?.realm, "session-integration");
+    t.ok(session?.id, "challenge must carry an HMAC id");
+    t.ok(session?.request, "challenge must carry a request body");
+
+    env.handler.stop();
+    t.end();
+  },
+);
+
+await t.test(
+  "spec §Action: open — happy-path open through createFetch round-trips a valid Payment-Receipt",
+  async (t) => {
+    const env = await makeSessionEnv();
+
+    let resourceCalled = false;
+    let observedReference: string | undefined;
+    env.harness.setResourceHandler((ctx) => {
+      if (!isResourceContextMPP(ctx)) {
+        throw new Error("expected MPP resource context");
+      }
+      resourceCalled = true;
+      observedReference = ctx.receipt.reference;
+      return { status: 200, body: { ok: true } };
+    });
+
+    const fetch = env.harness.createFetch();
+    const response = await fetch("/protected");
+    t.equal(response.status, 200, "middleware must accept the open credential");
+    t.ok(resourceCalled, "resource handler must run after settlement");
+    t.ok(observedReference, "receipt must carry a non-empty channelId");
+
+    // The middleware sets Payment-Receipt on the response. Parse it
+    // back through the shared receipt decoder so we exercise the full
+    // serialize/deserialize round-trip.
+    const receiptHeader = response.headers.get(PAYMENT_RECEIPT_HEADER);
+    t.ok(receiptHeader, "response must include the Payment-Receipt header");
+    if (receiptHeader) {
+      const parsed = parseReceipt(receiptHeader);
+      t.ok(parsed, "Payment-Receipt header must decode as an mppReceipt");
+      t.equal(parsed?.intent, SESSION_INTENT);
+      t.equal(parsed?.method, "solana");
+      t.equal(parsed?.acceptedCumulative, "0");
+      t.equal(parsed?.spent, "0");
+    }
+
+    if (observedReference !== undefined) {
+      const state = await env.handler.getSessionState(
+        address(observedReference),
+      );
+      t.ok(state, "open must persist a session state for the channel");
+      t.equal(state?.sessionKey, env.session.address);
+      t.equal(state?.mint, MINT);
+      t.equal(state?.acceptedCumulative, 0n);
+      t.equal(state?.spent, 0n);
+      t.equal(state?.status, "open");
+    }
+
+    env.handler.stop();
+    t.end();
+  },
+);
+
+await t.test(
+  "spec §Action: voucher — open then multiple voucher submissions advance state monotonically",
+  async (t) => {
+    const env = await makeSessionEnv();
+
+    // Drive the open via createClientFetch + manual credential so we
+    // can capture the channelId.
+    const { response: openResponse, channelId } = await openSession(env);
+    t.equal(openResponse.status, 200, "open must succeed");
+
+    // Now drive two vouchers via the client's helper. handleInsufficientHold
+    // is the public API the session client exposes for advancing
+    // acceptedCumulative by a delta.
+    const clientFetch = env.harness.createClientFetch();
+
+    const auth1 = await env.client.handleInsufficientHold({
+      channelId: channelId.toString(),
+      requiredTopUp: 250n,
+    });
+    const voucher1Resp = await clientFetch("/protected", {
+      headers: { [AUTHORIZATION_HEADER]: auth1 },
+    });
+    t.equal(voucher1Resp.status, 200, "first voucher must be accepted");
+    const receipt1 = parseReceipt(
+      voucher1Resp.headers.get(PAYMENT_RECEIPT_HEADER) ?? "",
+    );
+    t.equal(receipt1?.acceptedCumulative, "250");
+
+    const auth2 = await env.client.handleInsufficientHold({
+      channelId: channelId.toString(),
+      requiredTopUp: 100n,
+    });
+    const voucher2Resp = await clientFetch("/protected", {
+      headers: { [AUTHORIZATION_HEADER]: auth2 },
+    });
+    t.equal(voucher2Resp.status, 200, "second voucher must be accepted");
+    const receipt2 = parseReceipt(
+      voucher2Resp.headers.get(PAYMENT_RECEIPT_HEADER) ?? "",
+    );
+    t.equal(
+      receipt2?.acceptedCumulative,
+      "350",
+      "second voucher must add to the running cumulative",
+    );
+
+    const state = await env.handler.getSessionState(channelId);
+    t.equal(state?.acceptedCumulative, 350n);
+    t.equal(state?.inFlightAuthorizationIds.length, 2);
+
+    env.handler.stop();
+    t.end();
+  },
+);
+
+await t.test(
+  "spec §Concurrency and Idempotency — replaying an open credential is idempotent and returns the live state",
+  async (t) => {
+    const env = await makeSessionEnv();
+
+    // First open: succeeds and persists.
+    const { response: first, channelId } = await openSession(env);
+    t.equal(first.status, 200);
+
+    // Mutate the live state to simulate the channel having advanced.
+    const live = await env.handler.getSessionState(channelId);
+    if (!live) throw new Error("missing state after first open");
+    // We can't mutate the SessionStore from outside; instead drive a
+    // voucher to advance state, then replay the same open credential.
+    const auth = await env.client.handleInsufficientHold({
+      channelId: channelId.toString(),
+      requiredTopUp: 500n,
+    });
+    const clientFetch = env.harness.createClientFetch();
+    await clientFetch("/protected", {
+      headers: { [AUTHORIZATION_HEADER]: auth },
+    });
+
+    // Re-drive open: the client builds a fresh open credential
+    // (deterministic for the same wallet/session/escrow) and submits.
+    // The spec §"Action: open" idempotent re-open path returns the
+    // existing live state without resetting it.
+    const replay = await openSession(env);
+    t.equal(replay.response.status, 200, "re-open must succeed");
+    const replayReceipt = parseReceipt(
+      replay.response.headers.get(PAYMENT_RECEIPT_HEADER) ?? "",
+    );
+    t.equal(
+      replayReceipt?.acceptedCumulative,
+      "500",
+      "re-open must report the live acceptedCumulative, not reset to 0",
+    );
+
+    env.handler.stop();
+    t.end();
+  },
+);
+
+await t.test(
+  "spec §Concurrency and Idempotency — a replayed voucher credential is idempotent",
+  async (t) => {
+    const env = await makeSessionEnv();
+    const { channelId } = await openSession(env);
+
+    const auth = await env.client.handleInsufficientHold({
+      channelId: channelId.toString(),
+      requiredTopUp: 250n,
+    });
+    const clientFetch = env.harness.createClientFetch();
+
+    const first = await clientFetch("/protected", {
+      headers: { [AUTHORIZATION_HEADER]: auth },
+    });
+    t.equal(first.status, 200, "first submission accepted");
+
+    // Re-submit the SAME credential. The credential's voucher carries
+    // the same cumulativeAmount the channel already accepted, which
+    // tryRegisterVoucher treats as an idempotent retry. The middleware
+    // returns 200 with the same receipt.
+    const replay = await clientFetch("/protected", {
+      headers: { [AUTHORIZATION_HEADER]: auth },
+    });
+    t.equal(
+      replay.status,
+      200,
+      "replayed voucher must return 200 (idempotent)",
+    );
+
+    const state = await env.handler.getSessionState(channelId);
+    t.equal(
+      state?.acceptedCumulative,
+      250n,
+      "replay must not double-advance state",
+    );
+    t.equal(
+      state?.inFlightAuthorizationIds.length,
+      1,
+      "replay must not double-add the authorization id",
+    );
+
+    env.handler.stop();
+    t.end();
+  },
+);
+
+await t.test(
+  "spec §Voucher Verification — a voucher signed for a different channel is rejected",
+  async (t) => {
+    const env = await makeSessionEnv();
+    const { channelId } = await openSession(env);
+
+    // Build a voucher whose inner data points at a fake channelId,
+    // signed by the real session key, then submit it under the real
+    // channelId. The handler must reject because verifyVoucher checks
+    // the inner channelId against the credential channelId.
+    const tamperedChannel = address(
+      "4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi",
+    );
+    const tamperedMessage = serializeSpecVoucherMessage({
+      channelId: tamperedChannel.toString(),
+      cumulativeAmount: "100",
+    });
+    const tamperedSig = new Uint8Array(
+      await crypto.subtle.sign(
+        "Ed25519",
+        env.session.keypair.privateKey,
+        tamperedMessage,
+      ),
+    );
+
+    const clientFetch = env.harness.createClientFetch();
+    // Mint a fresh challenge first so we have one to bind to.
+    const challengeResponse = await clientFetch("/protected");
+    const wwwAuth = challengeResponse.headers.get("WWW-Authenticate");
+    if (!wwwAuth) throw new Error("no WWW-Authenticate");
+    const challenges = parseWWWAuthenticate(wwwAuth);
+    const challenge = challenges.find(
+      (c) => c.method === "solana" && c.intent === SESSION_INTENT,
+    );
+    if (!challenge) throw new Error("no session challenge");
+
+    const credential: mppCredential = {
+      challenge,
+      payload: {
+        action: "voucher",
+        channelId: channelId.toString(),
+        voucher: {
+          voucher: {
+            channelId: tamperedChannel.toString(),
+            cumulativeAmount: "100",
+          },
+          signer: env.session.address.toString(),
+          signature: bs58.encode(tamperedSig),
+          signatureType: "ed25519",
+        },
+      },
+    };
+    const authHeader = `Payment ${serializeCredential(credential)}`;
+    const response = await clientFetch("/protected", {
+      headers: { [AUTHORIZATION_HEADER]: authHeader },
+    });
+    t.equal(
+      response.status,
+      402,
+      "cross-channel voucher must be rejected with 402",
+    );
+    t.ok(
+      response.headers.get("WWW-Authenticate"),
+      "rejection must carry a fresh WWW-Authenticate",
+    );
+
+    // The channel's state must be unchanged.
+    const state = await env.handler.getSessionState(channelId);
+    t.equal(state?.acceptedCumulative, 0n);
+
+    env.handler.stop();
+    t.end();
+  },
+);
+
+await t.test(
+  "spec §Voucher Verification step 8 — voucher whose cumulative exceeds escrow is rejected with 402",
+  async (t) => {
+    const env = await makeSessionEnv();
+    const { channelId } = await openSession(env);
+
+    const auth = await env.client.handleInsufficientHold({
+      channelId: channelId.toString(),
+      // depositAmount is 1_000_000; ask for more.
+      requiredTopUp: 9_999_999n,
+    });
+
+    const clientFetch = env.harness.createClientFetch();
+    const response = await clientFetch("/protected", {
+      headers: { [AUTHORIZATION_HEADER]: auth },
+    });
+    t.equal(
+      response.status,
+      402,
+      "voucher exceeding escrowedAmount must yield 402",
+    );
+    t.ok(
+      response.headers.get("WWW-Authenticate"),
+      "402 must carry a fresh challenge for retry",
+    );
+
+    const state = await env.handler.getSessionState(channelId);
+    t.equal(
+      state?.acceptedCumulative,
+      0n,
+      "rejection must not advance acceptedCumulative",
+    );
+
+    env.handler.stop();
+    t.end();
+  },
+);
+
+await t.test(
+  "spec §Voucher Verification step 1 — voucher submitted before any open returns 402",
+  async (t) => {
+    const env = await makeSessionEnv();
+    // No open performed.
+    const fakeChannel = address("9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM");
+
+    const clientFetch = env.harness.createClientFetch();
+    const challengeResponse = await clientFetch("/protected");
+    const wwwAuth = challengeResponse.headers.get("WWW-Authenticate") ?? "";
+    const challenges = parseWWWAuthenticate(wwwAuth);
+    const challenge = challenges.find(
+      (c) => c.method === "solana" && c.intent === SESSION_INTENT,
+    );
+    if (!challenge) throw new Error("no session challenge");
+
+    const message = serializeSpecVoucherMessage({
+      channelId: fakeChannel.toString(),
+      cumulativeAmount: "100",
+    });
+    const sig = new Uint8Array(
+      await crypto.subtle.sign(
+        "Ed25519",
+        env.session.keypair.privateKey,
+        message,
+      ),
+    );
+    const credential: mppCredential = {
+      challenge,
+      payload: {
+        action: "voucher",
+        channelId: fakeChannel.toString(),
+        voucher: {
+          voucher: {
+            channelId: fakeChannel.toString(),
+            cumulativeAmount: "100",
+          },
+          signer: env.session.address.toString(),
+          signature: bs58.encode(sig),
+          signatureType: "ed25519",
+        },
+      },
+    };
+    const authHeader = `Payment ${serializeCredential(credential)}`;
+    const response = await clientFetch("/protected", {
+      headers: { [AUTHORIZATION_HEADER]: authHeader },
+    });
+    t.equal(
+      response.status,
+      402,
+      "voucher on a non-existent channel must be rejected",
+    );
+
+    env.handler.stop();
+    t.end();
+  },
+);
+
+await t.test(
+  "spec §Action: close — bare close credential transitions the channel to closing",
+  async (t) => {
+    const env = await makeSessionEnv();
+    const { channelId } = await openSession(env);
+
+    // Build a close credential by hand — the session client doesn't
+    // expose a close helper.
+    const clientFetch = env.harness.createClientFetch();
+    const challengeResponse = await clientFetch("/protected");
+    const wwwAuth = challengeResponse.headers.get("WWW-Authenticate") ?? "";
+    const challenges = parseWWWAuthenticate(wwwAuth);
+    const challenge = challenges.find(
+      (c) => c.method === "solana" && c.intent === SESSION_INTENT,
+    );
+    if (!challenge) throw new Error("no session challenge");
+
+    const credential: mppCredential = {
+      challenge,
+      payload: {
+        action: "close",
+        channelId: channelId.toString(),
+      },
+    };
+    const authHeader = `Payment ${serializeCredential(credential)}`;
+    const response = await clientFetch("/protected", {
+      headers: { [AUTHORIZATION_HEADER]: authHeader },
+    });
+    t.equal(response.status, 200, "close must be accepted");
+
+    const state = await env.handler.getSessionState(channelId);
+    t.equal(
+      state?.status,
+      "closing",
+      "close must transition status to closing",
+    );
+
+    // A subsequent voucher on the closing channel must be refused.
+    const auth = await env.client.handleInsufficientHold({
+      channelId: channelId.toString(),
+      requiredTopUp: 100n,
+    });
+    const followupResponse = await clientFetch("/protected", {
+      headers: { [AUTHORIZATION_HEADER]: auth },
+    });
+    t.equal(
+      followupResponse.status,
+      402,
+      "voucher on a closing channel must be rejected",
+    );
+
+    env.handler.stop();
+    t.end();
+  },
+);
+
+await t.test(
+  "spec §Concurrency and Idempotency — concurrent voucher submissions on the same channel are serialized correctly",
+  async (t) => {
+    const env = await makeSessionEnv();
+    const { channelId } = await openSession(env);
+    const clientFetch = env.harness.createClientFetch();
+
+    // Build two voucher Authorization headers with non-overlapping
+    // deltas. Submit them in parallel.
+    const auth1 = await env.client.handleInsufficientHold({
+      channelId: channelId.toString(),
+      requiredTopUp: 100n,
+    });
+    const auth2 = await env.client.handleInsufficientHold({
+      channelId: channelId.toString(),
+      requiredTopUp: 200n,
+    });
+
+    const [resp1, resp2] = await Promise.all([
+      clientFetch("/protected", {
+        headers: { [AUTHORIZATION_HEADER]: auth1 },
+      }),
+      clientFetch("/protected", {
+        headers: { [AUTHORIZATION_HEADER]: auth2 },
+      }),
+    ]);
+    t.equal(resp1.status, 200);
+    t.equal(resp2.status, 200);
+
+    // Both must persist. After both have landed the channel's
+    // acceptedCumulative is the larger of the two voucher cumulatives
+    // (100 and 100+200=300). The receipts on each response report the
+    // state at the moment that voucher was registered.
+    const state = await env.handler.getSessionState(channelId);
+    t.equal(state?.acceptedCumulative, 300n);
+    t.equal(state?.inFlightAuthorizationIds.length, 2);
+
+    const r1 = parseReceipt(resp1.headers.get(PAYMENT_RECEIPT_HEADER) ?? "");
+    const r2 = parseReceipt(resp2.headers.get(PAYMENT_RECEIPT_HEADER) ?? "");
+    const receipts = [r1?.acceptedCumulative, r2?.acceptedCumulative].sort();
+    t.matchOnly(
+      receipts,
+      ["100", "300"],
+      "each receipt must reflect the state at the time that voucher landed",
+    );
+
+    env.handler.stop();
+    t.end();
+  },
+);
+
+await t.test(
+  "spec §Error Responses — every error response carries a fresh WWW-Authenticate challenge",
+  async (t) => {
+    const env = await makeSessionEnv();
+    const { channelId } = await openSession(env);
+
+    // Submit a voucher exceeding escrow to trigger an error.
+    const auth = await env.client.handleInsufficientHold({
+      channelId: channelId.toString(),
+      requiredTopUp: 9_999_999n,
+    });
+    const clientFetch = env.harness.createClientFetch();
+    const errorResp = await clientFetch("/protected", {
+      headers: { [AUTHORIZATION_HEADER]: auth },
+    });
+    t.equal(errorResp.status, 402);
+
+    const wwwAuth = errorResp.headers.get("WWW-Authenticate");
+    t.ok(wwwAuth, "error response must carry WWW-Authenticate");
+    const challenges = parseWWWAuthenticate(wwwAuth ?? "");
+    const fresh = challenges.find(
+      (c) => c.method === "solana" && c.intent === SESSION_INTENT,
+    );
+    t.ok(fresh, "fresh challenge must be present");
+    t.ok(fresh?.id, "fresh challenge must have a new id");
+
+    env.handler.stop();
+    t.end();
+  },
+);
+
+await t.test(
+  "spec §Receipt Format — handleSettle receipt is observable in the resource handler context",
+  async (t) => {
+    const env = await makeSessionEnv();
+
+    let capturedCumulative: string | undefined;
+    let capturedIntent: string | undefined;
+    env.harness.setResourceHandler((ctx) => {
+      if (!isResourceContextMPP(ctx)) {
+        throw new Error("expected MPP resource context");
+      }
+      capturedCumulative = ctx.receipt.acceptedCumulative;
+      capturedIntent = ctx.receipt.intent;
+      return { status: 200, body: { ok: true } };
+    });
+
+    const fetch = env.harness.createFetch();
+    const response = await fetch("/protected");
+    t.equal(response.status, 200);
+    t.equal(capturedIntent, SESSION_INTENT);
+    t.equal(capturedCumulative, "0");
+
+    env.handler.stop();
+    t.end();
+  },
+);
+
+await t.test(
+  "spec §Action: voucher — voucher signed by a key that isn't the channel's session key is rejected",
+  async (t) => {
+    const env = await makeSessionEnv();
+    const { channelId } = await openSession(env);
+
+    // Build a voucher signed by an attacker keypair, claiming the
+    // attacker's pubkey as the signer.
+    const attacker = await buildSessionKeyPair();
+    const message = serializeSpecVoucherMessage({
+      channelId: channelId.toString(),
+      cumulativeAmount: "100",
+    });
+    const sig = new Uint8Array(
+      await crypto.subtle.sign("Ed25519", attacker.keypair.privateKey, message),
+    );
+
+    const clientFetch = env.harness.createClientFetch();
+    const challengeResponse = await clientFetch("/protected");
+    const wwwAuth = challengeResponse.headers.get("WWW-Authenticate") ?? "";
+    const challenges = parseWWWAuthenticate(wwwAuth);
+    const challenge = challenges.find(
+      (c) => c.method === "solana" && c.intent === SESSION_INTENT,
+    );
+    if (!challenge) throw new Error("no session challenge");
+
+    const credential: mppCredential = {
+      challenge,
+      payload: {
+        action: "voucher",
+        channelId: channelId.toString(),
+        voucher: {
+          voucher: {
+            channelId: channelId.toString(),
+            cumulativeAmount: "100",
+          },
+          signer: attacker.address.toString(),
+          signature: bs58.encode(sig),
+          signatureType: "ed25519",
+        },
+      },
+    };
+    const authHeader = `Payment ${serializeCredential(credential)}`;
+    const response = await clientFetch("/protected", {
+      headers: { [AUTHORIZATION_HEADER]: authHeader },
+    });
+    t.equal(
+      response.status,
+      402,
+      "voucher signed by an unregistered key must be rejected",
+    );
+
+    env.handler.stop();
+    t.end();
+  },
+);
+
+// Reference an unused import so a future drift renaming
+// PROBLEM_VERIFICATION_FAILED is caught here.
+void PROBLEM_VERIFICATION_FAILED;

--- a/tests/package.json
+++ b/tests/package.json
@@ -5,10 +5,14 @@
   "type": "module",
   "dependencies": {
     "@faremeter/facilitator": "workspace:^",
+    "@faremeter/info": "workspace:^",
     "@faremeter/middleware": "workspace:^",
+    "@faremeter/payment-solana": "workspace:^",
     "@faremeter/rides": "workspace:^",
     "@faremeter/test-harness": "workspace:^",
-    "@faremeter/types": "workspace:^"
+    "@faremeter/types": "workspace:^",
+    "@solana/kit": "catalog:",
+    "bs58": "catalog:"
   },
   "devDependencies": {
     "@tapjs/tsx": "catalog:",

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -9,6 +9,7 @@
     "interop/*.ts",
     "x402-in-process/*.ts",
     "mpp/*.ts",
+    "mpp-session/*.ts",
     "rides/*.ts"
   ]
 }


### PR DESCRIPTION
## Summary

Adds an experimental `solana`/`session` MPP intent handler settled against the [Faremeter Flex](https://github.com/faremeter/flex) escrow program. The handler ships off-chain credential verification, per-channel state, and the wire format aligned with [draft-solana-session-00](https://github.com/solana-foundation/mpp-specs/blob/a64edb477cfcb5e071e4f73f4227cf329dd1c4b5/specs/methods/solana/draft-solana-session-00.md), with documented divergences where the Flex on-chain shape diverges from the spec's assumed payment-channel program.

## Commits

7 commits, in dependency order:

1. **Promote MPP challenge ID helpers to the shared types package** — moves the HMAC challenge-ID helpers from the charge handler into `@faremeter/types/mpp` so the session handler can reuse them.
2. **Enforce MPP digest binding only when the challenge opts in** — makes the body-digest binding a server-side opt-in so long-lived session challenges can be reused across body-bearing requests.
3. **Add optional extras field to the MPP receipt validator** — adds spec-required `acceptedCumulative`/`spent`/`challengeId` and an `extra` map to `mppReceipt`, makes `intent` REQUIRED.
4. **Add generic MPP session types to the shared types package** — chain-agnostic `SessionAction`, per-action base shapes, request shape with optional `description`/`externalId`, and the spec Problem Details types.
5. **Add `@faremeter/flex-solana` as a `payment-solana` dependency** — declares the upstream Flex SDK so the handler can import its instruction encoders, PDA helpers, discriminators, and authorization serializer directly.
6. **Add MPP Solana per-voucher session handler** — the bulk: server, client, common types, verify, verify-open, problem, state, batch builder, plus unit and integration tests. Imports from `@faremeter/flex-solana` from the start (no vendored Flex layer).
7. **Document Flex divergences from `draft-solana-session-00`** — `COMPATIBILITY.md` enumerates the spec gaps that can't be closed off-chain (cumulative on-chain settlement, payee binding, `closeRequestedAt`/`ClosedChannel` observability, etc.) and the spec-aligned wire details the handler matches.

## Status

This is a prototype, not a production handler. Several spec MUSTs are documented as deferred or Flex-constrained in `COMPATIBILITY.md`:

- On-chain confirmation reads after open
- `topUp` settlement (the action is rejected today)
- Background flush/finalize loop for in-flight Flex authorizations
- Crash-safe persistence (the default `SessionStore` is in-memory)
- Streaming-response receipts
- On-chain ed25519 verification of the spec voucher's `cumulativeAmount` (Flex's \`submit_authorization\` verifies a different byte layout)

## Test plan

- [X] \`make\` builds clean (lint + types + tests)
- [X] Unit tests in \`packages/payment-solana/src/session/\` cover spec MUSTs (happy and unhappy paths)
- [X] Integration tests in \`tests/mpp/session-*.test.ts\` drive the full lifecycle through the harness
- [X] \`COMPATIBILITY.md\` reflects current state of off-chain vs Flex-constrained gaps
- [X] Branch builds against the local \`@faremeter/flex-solana\` checkout (publish + lockfile pinning are out of scope)
