### PR TITLE
FMTR-265: Fix Faremeter doc generation for docs.faremeter.xyz

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,14 @@ doc: FORCE
 	bin/generate-readme
 	pnpm prettier -w packages/*/README.md
 	pnpm typedoc
+	bin/strip-link-extensions docs
 	pnpm prettier -w docs/
+
+sync-docs: doc
+	@test -n "$(DEST)" || (echo "Usage: make sync-docs DEST=<dir>" && exit 1)
+	cp docs/*.md "$(DEST)/"
+	@echo "Synced $$(ls docs/*.md | wc -l | tr -d ' ') files to $(DEST)"
+	@echo "Remember to commit in the destination repo."
 
 packages/gateway-nginx: FORCE
 	cd $@ && rm -rf dist && pnpm tsc && pnpm tsc-esm-fix

--- a/bin/strip-link-extensions
+++ b/bin/strip-link-extensions
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+
+/**
+ * Post-processes TypeDoc markdown output to strip .md extensions from
+ * internal links. Mintlify expects extensionless paths for cross-page
+ * references.
+ *
+ * Only rewrites links whose target matches a generated file in the
+ * output directory, so external URLs (e.g. GitHub source links) are
+ * left untouched.
+ *
+ * Usage: bin/strip-link-extensions <docs-dir>
+ */
+
+import { readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const docsDir = process.argv[2];
+if (!docsDir) {
+  console.error("Usage: strip-link-extensions <docs-dir>");
+  process.exit(1);
+}
+
+const mdFiles = readdirSync(docsDir).filter((f) => f.endsWith(".md"));
+const knownBases = new Set(mdFiles.map((f) => f.replace(/\.md$/, "")));
+
+// Match markdown links: ](target.md) or ](target.md#anchor)
+const linkRe = /\]\(([^)]+?)\.md(#[^)]*)?\)/g;
+
+let totalRewrites = 0;
+
+for (const file of mdFiles) {
+  const filePath = join(docsDir, file);
+  const original = readFileSync(filePath, "utf-8");
+
+  const updated = original.replace(linkRe, (match, target, anchor) => {
+    if (!knownBases.has(target)) return match;
+    totalRewrites++;
+    return `](${target}${anchor ?? ""})`;
+  });
+
+  if (updated !== original) {
+    writeFileSync(filePath, updated, "utf-8");
+  }
+}
+
+console.log(
+  `Stripped .md from ${totalRewrites} internal links across ${mdFiles.length} files`,
+);

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "faremeter",
+  "type": "module",
   "license": "GPL-3.0-only",
   "packageManager": "pnpm@10.19.0",
   "private": true,

--- a/packages/payment-solana/src/index.ts
+++ b/packages/payment-solana/src/index.ts
@@ -10,6 +10,11 @@
  * @description SPL token transfer payment handlers for Solana
  */
 export * as exact from "./exact";
+/**
+ * @title Solana Charge Payment Scheme
+ * @sidebarTitle Payment Solana / Charge
+ * @description MPP charge-based payment handlers for Solana
+ */
 export * as charge from "./charge";
 /**
  * @title SPL Token Utilities

--- a/typedoc.config.mjs
+++ b/typedoc.config.mjs
@@ -23,6 +23,8 @@ export default {
   tsconfig: "tsconfig.typedoc.json",
   sanitizeComments: true,
   flattenOutputFiles: true,
+  hideBreadcrumbs: true,
+  hidePageHeader: true,
   blockTags: [
     ...OptionDefaults.blockTags,
     "@title",


### PR DESCRIPTION
## Summary

- Add `hideBreadcrumbs` and `hidePageHeader` to typedoc config to remove the breadcrumb link from all API pages
- Add a post-processing Node script to strip `.md` extensions from internal links (Mintlify expects extensionless paths)
- Add missing JSDoc frontmatter tags for the `payment-solana/charge` namespace
- Wire the strip script into the Makefile `doc` target and add a `sync-docs` convenience target
- Add `"type": "module"` to root `package.json` to align with all workspace packages

## Test plan

- [x] `make build` passes
- [x] `make lint` passes
- [x] `make test` passes (1521/1521)
- [x] `make doc` generates correct output: no breadcrumbs, no `.md` in internal links, frontmatter on every page
- [x] Strip script is idempotent (second run produces zero diff)
- [x] External URLs (GitHub source links) are not rewritten
- [x] Cross-page anchor links are correctly handled (`foo.md#bar` → `foo#bar`)
- [ ] Regenerate docs in `faremeter/docs` repo and validate with Mintlify local preview (follow-up PR)

Closes FMTR-265

🤖 Generated with [Claude Code](https://claude.com/claude-code)