### PR TITLE
Extend payment gateway capture/authorize hooks

### DIFF
--- a/apps/sidecar/src/app.ts
+++ b/apps/sidecar/src/app.ts
@@ -1,34 +1,15 @@
 import { Hono } from "hono";
 import { isValidationError } from "@faremeter/types";
+import type { ContentfulStatusCode } from "hono/utils/http-status";
 import {
   createGatewayHandler,
   requestContext,
   responseContext,
-  type CaptureResponse,
   type GatewayHandlerConfig,
 } from "@faremeter/middleware-openapi";
 import { logger } from "./logger.js";
 
-export type CreateAppOpts = GatewayHandlerConfig & {
-  /**
-   * Called once per successful `/response` with the capture envelope
-   * that will be returned to the Lua gateway. The hook fires for
-   * every matched capture. One-phase (capture-only) rules report
-   * `result.settled === true` when a non-zero amount was charged at
-   * request time; zero-amount captures and unmatched rules report
-   * `result.settled === false`. Consumers that only care about
-   * settled bills should gate on `result.settled`.
-   *
-   * The hook runs post-settlement and is awaited to catch async
-   * rejections. A throw or rejected promise is logged but must not
-   * corrupt the authoritative response: the capture envelope is
-   * returned to the gateway regardless of hook outcome.
-   */
-  onCapture?: (
-    operationKey: string,
-    result: CaptureResponse,
-  ) => void | Promise<void>;
-};
+export type CreateAppOpts = GatewayHandlerConfig;
 
 // The Lua gateway has two mutually incompatible contracts for the
 // sidecar's two endpoints:
@@ -76,8 +57,7 @@ async function parseJSON(request: Request): Promise<ParseJSONResult> {
 }
 
 export function createApp(config: CreateAppOpts) {
-  const { onCapture, ...handlerConfig } = config;
-  const handler = createGatewayHandler(handlerConfig);
+  const handler = createGatewayHandler(config);
   const app = new Hono();
 
   app.post("/request", async (c) => {
@@ -126,9 +106,9 @@ export function createApp(config: CreateAppOpts) {
     logger.debug("gateway /response", {
       operationKey: validated.operationKey,
     });
-    let result: CaptureResponse;
     try {
-      result = await handler.handleResponse(validated);
+      const result = await handler.handleResponse(validated);
+      return c.json(result, result.status as ContentfulStatusCode);
     } catch (cause) {
       logger.error("handleResponse threw", {
         operationKey: validated.operationKey,
@@ -146,23 +126,6 @@ export function createApp(config: CreateAppOpts) {
         422,
       );
     }
-    if (onCapture) {
-      // The hook runs post-settlement. A throw or async rejection must
-      // not corrupt the nginx contract by flipping a settled response
-      // to 5xx — log it and return the authoritative result anyway.
-      // Awaiting the hook (even when the signature is `=> void`) is the
-      // only way to catch async rejections, which would otherwise become
-      // process-level unhandled rejections.
-      try {
-        await onCapture(validated.operationKey, result);
-      } catch (cause) {
-        logger.error("onCapture hook threw", {
-          operationKey: validated.operationKey,
-          cause: cause instanceof Error ? cause.message : String(cause),
-        });
-      }
-    }
-    return c.json(result);
   });
 
   app.onError((err, c) => {

--- a/apps/sidecar/src/index.test.ts
+++ b/apps/sidecar/src/index.test.ts
@@ -128,34 +128,36 @@ await t.test(
   },
 );
 
-await t.test("response evaluates capture and returns amount", async (t) => {
-  const spec = makeSpec([
-    {
-      match: "$",
-      authorize: "5000",
-      capture:
-        "$.response.body.usage.prompt_tokens * 10 + $.response.body.usage.completion_tokens * 30",
-    },
-  ]);
-  const { app } = createApp({ spec, baseURL: BASE_URL });
-
-  const res = await post(app, "/response", {
-    ...requestPayload(),
-    response: {
-      status: 200,
-      headers: {},
-      body: {
-        usage: { prompt_tokens: 100, completion_tokens: 50 },
+await t.test(
+  "response returns 500 for two-phase rule without handlers",
+  async (t) => {
+    const spec = makeSpec([
+      {
+        match: "$",
+        authorize: "5000",
+        capture:
+          "$.response.body.usage.prompt_tokens * 10 + $.response.body.usage.completion_tokens * 30",
       },
-    },
-  });
-  const data = (await res.json()) as Record<string, unknown>;
+    ]);
+    const { app } = createApp({ spec, baseURL: BASE_URL });
 
-  t.equal(data.captured, true);
-  const amount = data.amount as Record<string, unknown>;
-  t.equal(amount["usdc-sol"], "2500");
-  t.end();
-});
+    const res = await post(app, "/response", {
+      ...requestPayload(),
+      response: {
+        status: 200,
+        headers: {},
+        body: {
+          usage: { prompt_tokens: 100, completion_tokens: 50 },
+        },
+      },
+    });
+    t.equal(res.status, 500, "transport status must be non-2xx for Lua retry");
+    const data = (await res.json()) as Record<string, unknown>;
+
+    t.equal(data.status, 500);
+    t.end();
+  },
+);
 
 await t.test("response with no matching operation returns empty", async (t) => {
   const spec = makeSpec([
@@ -182,12 +184,12 @@ await t.test("response with no matching operation returns empty", async (t) => {
   });
   const data = (await res.json()) as Record<string, unknown>;
 
-  t.equal(data.captured, false);
+  t.equal(data.status, 200);
   t.end();
 });
 
 await t.test(
-  "onCapture throw does not corrupt the settled response",
+  "onCapture does not fire when no payment handlers are configured",
   async (t) => {
     const spec = makeSpec([
       {
@@ -202,7 +204,6 @@ await t.test(
       baseURL: BASE_URL,
       onCapture: () => {
         hookFired = true;
-        throw new Error("hook blew up");
       },
     });
 
@@ -214,45 +215,54 @@ await t.test(
         body: { usage: { total_tokens: 50 } },
       },
     });
-    t.equal(res.status, 200, "settled response preserved despite hook throw");
+    t.equal(res.status, 500, "transport status must be non-2xx for Lua retry");
     const data = (await res.json()) as Record<string, unknown>;
-    t.equal(data.captured, true);
-    t.ok(hookFired, "hook was invoked");
+    t.equal(data.status, 500);
+    t.equal(
+      hookFired,
+      false,
+      "hook does not fire when no handlers are configured",
+    );
     t.end();
   },
 );
 
-await t.test("onCapture fires on successful settlement", async (t) => {
-  const spec = makeSpec([
-    {
-      match: "$",
-      authorize: "100",
-      capture: "$.response.body.usage.total_tokens * 2",
-    },
-  ]);
-  const calls: { key: string; amount: unknown }[] = [];
-  const { app } = createApp({
-    spec,
-    baseURL: BASE_URL,
-    onCapture: (operationKey, result) => {
-      calls.push({ key: operationKey, amount: result.amount });
-    },
-  });
+await t.test(
+  "onCapture does not fire for two-phase rule without handlers",
+  async (t) => {
+    const spec = makeSpec([
+      {
+        match: "$",
+        authorize: "100",
+        capture: "$.response.body.usage.total_tokens * 2",
+      },
+    ]);
+    const calls: { key: string; amount: unknown }[] = [];
+    const { app } = createApp({
+      spec,
+      baseURL: BASE_URL,
+      onCapture: (operationKey, result) => {
+        calls.push({ key: operationKey, amount: result.amount });
+      },
+    });
 
-  await post(app, "/response", {
-    ...requestPayload(),
-    response: {
-      status: 200,
-      headers: {},
-      body: { usage: { total_tokens: 50 } },
-    },
-  });
+    await post(app, "/response", {
+      ...requestPayload(),
+      response: {
+        status: 200,
+        headers: {},
+        body: { usage: { total_tokens: 50 } },
+      },
+    });
 
-  t.equal(calls.length, 1);
-  t.equal(calls[0]?.key, OP);
-  t.match(calls[0]?.amount, { "usdc-sol": "100" });
-  t.end();
-});
+    t.equal(
+      calls.length,
+      0,
+      "hook must not fire when no handlers are configured",
+    );
+    t.end();
+  },
+);
 
 await t.test("onCapture does not fire on validation error", async (t) => {
   const spec = makeSpec([{ match: "$", authorize: "100", capture: "1" }]);
@@ -272,6 +282,41 @@ await t.test("onCapture does not fire on validation error", async (t) => {
     "validation failure on /response must return non-2xx (see K2 comment in app.ts)",
   );
   t.equal(fired, false, "hook not called when validation fails");
+  t.end();
+});
+
+await t.test("onCapture does not fire when no operation matches", async (t) => {
+  const spec = makeSpec([
+    {
+      match: "$",
+      authorize: "100",
+      capture: "$.response.body.usage.total_tokens",
+    },
+  ]);
+  let fired = false;
+  const { app } = createApp({
+    spec,
+    baseURL: BASE_URL,
+    onCapture: () => {
+      fired = true;
+    },
+  });
+
+  await post(app, "/response", {
+    operationKey: "GET /nonexistent",
+    method: "GET",
+    path: "/nonexistent",
+    headers: {},
+    query: {},
+    body: {},
+    response: {
+      status: 200,
+      headers: {},
+      body: { usage: { total_tokens: 100 } },
+    },
+  });
+
+  t.equal(fired, false, "hook not called when no operation matches");
   t.end();
 });
 
@@ -396,13 +441,13 @@ await t.test(
     });
     t.equal(
       res.status,
-      200,
-      "multi-value headers must not be rejected by the schema",
+      500,
+      "no handlers configured so settlement fails (non-2xx preserves Lua buffer)",
     );
     const envelope = (await res.json()) as Record<string, unknown>;
     t.equal(
-      envelope.captured,
-      true,
+      envelope.status,
+      500,
       "capture still runs on payloads with multi-value headers",
     );
     t.end();
@@ -443,55 +488,11 @@ await t.test(
   },
 );
 
-await t.test(
-  "async onCapture that rejects does not leak an unhandled rejection",
-  async (t) => {
-    const spec = makeSpec([
-      {
-        match: "$",
-        authorize: "100",
-        capture: "$.response.body.usage.total_tokens",
-      },
-    ]);
-    const rejections: unknown[] = [];
-    const listener = (reason: unknown) => {
-      rejections.push(reason);
-    };
-    process.on("unhandledRejection", listener);
-    try {
-      const { app } = createApp({
-        spec,
-        baseURL: BASE_URL,
-        // onCapture is typed `=> void` but TypeScript will accept a
-        // Promise<void> returning function. A rejected promise must not
-        // become an unhandled rejection because the sidecar's try/catch
-        // only catches synchronous throws.
-        onCapture: (() => {
-          return Promise.reject(new Error("async hook rejection"));
-        }) as (key: string, result: unknown) => void,
-      });
-      const res = await post(app, "/response", {
-        ...requestPayload(),
-        response: {
-          status: 200,
-          headers: {},
-          body: { usage: { total_tokens: 50 } },
-        },
-      });
-      t.equal(res.status, 200, "settled response preserved despite async hook");
-      // Give the event loop time for any unhandled rejection to fire.
-      await new Promise((resolve) => setTimeout(resolve, 10));
-      t.equal(
-        rejections.length,
-        0,
-        "async onCapture must not leak unhandled rejections",
-      );
-    } finally {
-      process.off("unhandledRejection", listener);
-    }
-    t.end();
-  },
-);
+// NOTE: The async onCapture rejection test lives in
+// tests/openapi/pricing-settlement.test.ts, which has access to real
+// payment handlers. A sidecar-level test would need to configure
+// handlers to trigger onCapture, which creates a build-order cycle
+// with @faremeter/test-harness.
 
 await t.test(
   "/response exception must not silently discard the capture event",

--- a/packages/gateway-nginx/src/cli.ts
+++ b/packages/gateway-nginx/src/cli.ts
@@ -16,12 +16,14 @@ nginx.conf via \`include locations.conf;\`. The operator provides
 the server block, http wrapper, lua_shared_dict, and lua_package_path.
 
 Options:
-  --spec         Path to OpenAPI spec file (required)
-  --sidecar      Sidecar URL, e.g. http://127.0.0.1:4002 (required)
-  --upstream     Upstream URL used in proxy_pass (required)
-  --output       Output directory for generated files (required)
-  --site-prefix  Site name for multi-site sidecar routing
-  --help         Show this help message`;
+  --spec              Path to OpenAPI spec file (required)
+  --sidecar           Sidecar URL, e.g. http://127.0.0.1:4002 (required)
+  --upstream          Upstream URL used in proxy_pass (required)
+  --output            Output directory for generated files (required)
+  --site-prefix       Site name for multi-site sidecar routing
+  --extra-directive   Extra nginx directive injected into every generated
+                      location block (repeatable)
+  --help              Show this help message`;
 }
 
 function fatal(message: string): never {
@@ -37,6 +39,7 @@ async function main() {
       upstream: { type: "string" },
       output: { type: "string" },
       "site-prefix": { type: "string" },
+      "extra-directive": { type: "string", multiple: true },
       help: { type: "boolean" },
     },
     strict: true,
@@ -64,6 +67,7 @@ async function main() {
     upstreamURL: upstream,
     specRoot: outputDir,
     sitePrefix: values["site-prefix"],
+    extraDirectives: values["extra-directive"],
   });
 
   for (const warning of result.warnings) {

--- a/packages/gateway-nginx/src/fixtures/expected/locations.conf
+++ b/packages/gateway-nginx/src/fixtures/expected/locations.conf
@@ -400,7 +400,7 @@ location = /v1/chat/completions {
 }
 
 location = /v1/chat/stream {
-  proxy_buffering off;
+    proxy_buffering off;
 
     access_by_lua_block {
       local op_keys = {

--- a/packages/gateway-nginx/src/fixtures/expected/locations.conf
+++ b/packages/gateway-nginx/src/fixtures/expected/locations.conf
@@ -83,6 +83,7 @@ location = /v1/chat/completions {
       end
 
       local headers = array_aware(ngx.req.get_headers())
+      headers["x-request-id"] = ngx.var.request_id
       local query = array_aware(ngx.req.get_uri_args())
 
       -- Each cjson.safe.encode can return nil on failure (NaN, Inf, cycles).
@@ -479,6 +480,7 @@ location = /v1/chat/stream {
       end
 
       local headers = array_aware(ngx.req.get_headers())
+      headers["x-request-id"] = ngx.var.request_id
       local query = array_aware(ngx.req.get_uri_args())
 
       -- Each cjson.safe.encode can return nil on failure (NaN, Inf, cycles).
@@ -873,6 +875,7 @@ location = /v1/images/generations {
       end
 
       local headers = array_aware(ngx.req.get_headers())
+      headers["x-request-id"] = ngx.var.request_id
       local query = array_aware(ngx.req.get_uri_args())
 
       -- Each cjson.safe.encode can return nil on failure (NaN, Inf, cycles).
@@ -1268,6 +1271,7 @@ location = /v1/data {
       end
 
       local headers = array_aware(ngx.req.get_headers())
+      headers["x-request-id"] = ngx.var.request_id
       local query = array_aware(ngx.req.get_uri_args())
 
       -- Each cjson.safe.encode can return nil on failure (NaN, Inf, cycles).
@@ -1662,6 +1666,7 @@ location ~ ^/v1/([^/]+)/completions$ {
       end
 
       local headers = array_aware(ngx.req.get_headers())
+      headers["x-request-id"] = ngx.var.request_id
       local query = array_aware(ngx.req.get_uri_args())
 
       -- Each cjson.safe.encode can return nil on failure (NaN, Inf, cycles).

--- a/packages/gateway-nginx/src/index.ts
+++ b/packages/gateway-nginx/src/index.ts
@@ -22,7 +22,14 @@ import { detectOverlaps } from "./path.js";
  * access. Safe to call in tests.
  */
 export function generateConfig(input: GeneratorInput): GeneratorOutput {
-  const { routes, sidecarURL, upstreamURL, specRoot, sitePrefix } = input;
+  const {
+    routes,
+    sidecarURL,
+    upstreamURL,
+    specRoot,
+    sitePrefix,
+    extraDirectives,
+  } = input;
   const warnings: string[] = [];
 
   const overlapWarnings = detectOverlaps(routes.map((r) => r.path));
@@ -36,6 +43,7 @@ export function generateConfig(input: GeneratorInput): GeneratorOutput {
     upstreamURL,
     specRoot,
     sitePrefix,
+    extraDirectives,
   });
   warnings.push(...nginxWarnings);
 

--- a/packages/gateway-nginx/src/lua/access.lua
+++ b/packages/gateway-nginx/src/lua/access.lua
@@ -70,6 +70,7 @@ local function array_aware(tbl)
 end
 
 local headers = array_aware(ngx.req.get_headers())
+headers["x-request-id"] = ngx.var.request_id
 local query = array_aware(ngx.req.get_uri_args())
 
 -- Each cjson.safe.encode can return nil on failure (NaN, Inf, cycles).

--- a/packages/gateway-nginx/src/nginx/index.ts
+++ b/packages/gateway-nginx/src/nginx/index.ts
@@ -7,6 +7,7 @@ type NginxGeneratorOpts = {
   upstreamURL: string;
   specRoot?: string | undefined;
   sitePrefix?: string | undefined;
+  extraDirectives?: string[] | undefined;
 };
 
 type NginxGeneratorResult = {
@@ -17,7 +18,14 @@ type NginxGeneratorResult = {
 export function generateNginxConf(
   opts: NginxGeneratorOpts,
 ): NginxGeneratorResult {
-  const { routes, sidecarURL, upstreamURL, specRoot, sitePrefix } = opts;
+  const {
+    routes,
+    sidecarURL,
+    upstreamURL,
+    specRoot,
+    sitePrefix,
+    extraDirectives,
+  } = opts;
 
   const effectiveSidecarURL = sitePrefix
     ? `${sidecarURL}/sites/${sitePrefix}`
@@ -27,6 +35,7 @@ export function generateNginxConf(
     sidecarURL: effectiveSidecarURL,
     upstreamURL,
     specRoot,
+    extraDirectives,
   });
 
   return { locationsConf: locationBlocks, warnings };

--- a/packages/gateway-nginx/src/nginx/location.test.ts
+++ b/packages/gateway-nginx/src/nginx/location.test.ts
@@ -255,3 +255,150 @@ await t.test(
     t.end();
   },
 );
+
+await t.test(
+  "extraDirectives are emitted in HTTP location blocks",
+  async (t) => {
+    const routes = [makeRoute({ path: "/v1/chat", method: "POST" })];
+    const result = generateLocationBlocks(routes, {
+      ...defaultOpts,
+      extraDirectives: [
+        "proxy_read_timeout 3600s;",
+        "proxy_send_timeout 3600s;",
+      ],
+    });
+
+    t.match(
+      result.block,
+      /proxy_read_timeout 3600s;/,
+      "first extra directive is present",
+    );
+    t.match(
+      result.block,
+      /proxy_send_timeout 3600s;/,
+      "second extra directive is present",
+    );
+    t.end();
+  },
+);
+
+await t.test(
+  "extraDirectives are emitted in WebSocket location blocks",
+  async (t) => {
+    const routes = [
+      makeRoute({
+        path: "/v1/ws",
+        method: "GET",
+        transportType: "websocket",
+      }),
+    ];
+    const result = generateLocationBlocks(routes, {
+      ...defaultOpts,
+      extraDirectives: ["proxy_read_timeout 3600s;"],
+    });
+
+    t.match(
+      result.block,
+      /proxy_read_timeout 3600s;/,
+      "extra directive is present in WebSocket location",
+    );
+    t.end();
+  },
+);
+
+await t.test("extraDirectives appear before Lua blocks", async (t) => {
+  const routes = [makeRoute({ path: "/v1/chat", method: "POST" })];
+  const result = generateLocationBlocks(routes, {
+    ...defaultOpts,
+    extraDirectives: ["proxy_read_timeout 3600s;"],
+  });
+
+  const directiveIdx = result.block.indexOf("proxy_read_timeout 3600s;");
+  const luaIdx = result.block.indexOf("access_by_lua_block");
+  t.ok(
+    directiveIdx < luaIdx,
+    "extra directive appears before access_by_lua_block",
+  );
+  t.end();
+});
+
+await t.test(
+  "extraDirectives appear before WebSocket upgrade directives in mixed locations",
+  async (t) => {
+    const routes = [
+      makeRoute({ path: "/v1/stream", method: "POST", transportType: "json" }),
+      makeRoute({
+        path: "/v1/stream",
+        method: "GET",
+        transportType: "websocket",
+      }),
+    ];
+    const result = generateLocationBlocks(routes, {
+      ...defaultOpts,
+      extraDirectives: ["proxy_read_timeout 3600s;"],
+    });
+
+    const httpBlock = result.block.slice(
+      result.block.indexOf("location = /v1/stream"),
+    );
+    const directiveIdx = httpBlock.indexOf("proxy_read_timeout 3600s;");
+    const upgradeIdx = httpBlock.indexOf("error_page 418");
+    t.ok(
+      directiveIdx < upgradeIdx,
+      "extra directive appears before upgrade detection",
+    );
+    t.end();
+  },
+);
+
+await t.test(
+  "extraDirectives are emitted in the named WS location of mixed paths",
+  async (t) => {
+    const routes = [
+      makeRoute({ path: "/v1/stream", method: "POST", transportType: "json" }),
+      makeRoute({
+        path: "/v1/stream",
+        method: "GET",
+        transportType: "websocket",
+      }),
+    ];
+    const result = generateLocationBlocks(routes, {
+      ...defaultOpts,
+      extraDirectives: ["proxy_read_timeout 3600s;"],
+    });
+
+    const wsBlock = result.block.slice(
+      result.block.indexOf("location @ws_"),
+      result.block.indexOf("location = /v1/stream"),
+    );
+    t.match(
+      wsBlock,
+      /proxy_read_timeout 3600s;/,
+      "extra directive is present in named WS location",
+    );
+    t.end();
+  },
+);
+
+await t.test(
+  "extraDirectives with embedded newlines are split and indented",
+  async (t) => {
+    const routes = [makeRoute({ path: "/v1/chat", method: "POST" })];
+    const result = generateLocationBlocks(routes, {
+      ...defaultOpts,
+      extraDirectives: ["proxy_read_timeout 3600s;\nproxy_send_timeout 3600s;"],
+    });
+
+    t.match(
+      result.block,
+      /^ {2}proxy_read_timeout 3600s;$/m,
+      "first line is indented",
+    );
+    t.match(
+      result.block,
+      /^ {2}proxy_send_timeout 3600s;$/m,
+      "second line after newline split is indented",
+    );
+    t.end();
+  },
+);

--- a/packages/gateway-nginx/src/nginx/location.test.ts
+++ b/packages/gateway-nginx/src/nginx/location.test.ts
@@ -391,12 +391,12 @@ await t.test(
 
     t.match(
       result.block,
-      /^ {2}proxy_read_timeout 3600s;$/m,
+      /^ {4}proxy_read_timeout 3600s;$/m,
       "first line is indented",
     );
     t.match(
       result.block,
-      /^ {2}proxy_send_timeout 3600s;$/m,
+      /^ {4}proxy_send_timeout 3600s;$/m,
       "second line after newline split is indented",
     );
     t.end();

--- a/packages/gateway-nginx/src/nginx/location.ts
+++ b/packages/gateway-nginx/src/nginx/location.ts
@@ -19,6 +19,7 @@ type LocationOpts = {
   sidecarURL: string;
   upstreamURL: string;
   specRoot?: string | undefined;
+  extraDirectives?: string[] | undefined;
 };
 
 type LocationResult = {
@@ -29,6 +30,7 @@ type LocationResult = {
 function indent(text: string, spaces: number): string {
   const pad = " ".repeat(spaces);
   return text
+    .replace(/\r\n/g, "\n")
     .split("\n")
     .map((line) => (line.trim() === "" ? "" : pad + line))
     .join("\n");
@@ -55,7 +57,7 @@ function generatePaidHTTPLocation(
   pathDirective: string,
   routes: RouteConfig[],
   opts: LocationOpts,
-  extraDirectives?: string,
+  upgradeBlock?: string,
 ): string {
   const { sidecarURL } = opts;
   const accessCode = generateAccessBlock({ routes, sidecarURL });
@@ -72,13 +74,16 @@ function generatePaidHTTPLocation(
     lines.push("  proxy_buffering off;");
   }
 
-  // Caller-supplied extra directives (currently used by the mixed
-  // HTTP+WebSocket path to insert an Upgrade-detection jump into a
-  // named WS location). Placed before the access_by_lua block so the
-  // upgrade redirect short-circuits before any paid-request logic
-  // runs — an upgrade request should never increment billing.
-  if (extraDirectives) {
-    lines.push(extraDirectives);
+  if (opts.extraDirectives?.length) {
+    lines.push(indent(opts.extraDirectives.map((d) => d.trim()).join("\n"), 2));
+  }
+
+  // Upgrade-detection block injected by the mixed HTTP+WebSocket
+  // path. Placed before the access_by_lua block so the upgrade
+  // redirect short-circuits before any paid-request logic runs — an
+  // upgrade request should never increment billing.
+  if (upgradeBlock) {
+    lines.push(upgradeBlock);
   }
 
   lines.push("");
@@ -135,6 +140,11 @@ function generatePaidWebSocketLocation(
   const lines: string[] = [];
 
   lines.push(`location ${pathDirective} {`);
+
+  if (opts.extraDirectives?.length) {
+    lines.push(indent(opts.extraDirectives.map((d) => d.trim()).join("\n"), 2));
+  }
+
   lines.push("");
   lines.push(indent(luaBlock("access_by_lua_block", accessCode), 4));
   lines.push("");
@@ -174,6 +184,11 @@ function generatePaidWebSocketUpgradeLocation(
 
   const wsLines: string[] = [];
   wsLines.push(`location ${wsLocationName} {`);
+
+  if (opts.extraDirectives?.length) {
+    wsLines.push(indent(opts.extraDirectives.map((d) => d.trim()).join("\n"), 2));
+  }
+
   wsLines.push(indent(luaBlock("access_by_lua_block", wsAccessCode), 4));
   wsLines.push("");
   wsLines.push(indent(luaBlock("content_by_lua_block", contentCode), 4));

--- a/packages/gateway-nginx/src/nginx/location.ts
+++ b/packages/gateway-nginx/src/nginx/location.ts
@@ -71,11 +71,11 @@ function generatePaidHTTPLocation(
   const hasSSE = routes.some((r) => r.transportType === "sse");
   lines.push(`location ${pathDirective} {`);
   if (hasSSE) {
-    lines.push("  proxy_buffering off;");
+    lines.push("    proxy_buffering off;");
   }
 
   if (opts.extraDirectives?.length) {
-    lines.push(indent(opts.extraDirectives.map((d) => d.trim()).join("\n"), 2));
+    lines.push(indent(opts.extraDirectives.map((d) => d.trim()).join("\n"), 4));
   }
 
   // Upgrade-detection block injected by the mixed HTTP+WebSocket
@@ -142,7 +142,7 @@ function generatePaidWebSocketLocation(
   lines.push(`location ${pathDirective} {`);
 
   if (opts.extraDirectives?.length) {
-    lines.push(indent(opts.extraDirectives.map((d) => d.trim()).join("\n"), 2));
+    lines.push(indent(opts.extraDirectives.map((d) => d.trim()).join("\n"), 4));
   }
 
   lines.push("");
@@ -186,9 +186,12 @@ function generatePaidWebSocketUpgradeLocation(
   wsLines.push(`location ${wsLocationName} {`);
 
   if (opts.extraDirectives?.length) {
-    wsLines.push(indent(opts.extraDirectives.map((d) => d.trim()).join("\n"), 2));
+    wsLines.push(
+      indent(opts.extraDirectives.map((d) => d.trim()).join("\n"), 4),
+    );
   }
 
+  wsLines.push("");
   wsLines.push(indent(luaBlock("access_by_lua_block", wsAccessCode), 4));
   wsLines.push("");
   wsLines.push(indent(luaBlock("content_by_lua_block", contentCode), 4));
@@ -201,12 +204,15 @@ function generatePaidWebSocketUpgradeLocation(
   // unlikely to collide with any real upstream status) to the named
   // WS location, then `return 418` from the conditional to take
   // that jump.
-  const upgradeRedirect = [
-    `  error_page 418 = ${wsLocationName};`,
-    `  if ($http_upgrade ~* "websocket") {`,
-    "    return 418;",
-    "  }",
-  ].join("\n");
+  const upgradeRedirect = indent(
+    [
+      `error_page 418 = ${wsLocationName};`,
+      `if ($http_upgrade ~* "websocket") {`,
+      "  return 418;",
+      "}",
+    ].join("\n"),
+    4,
+  );
 
   const httpLocation = generatePaidHTTPLocation(
     pathDirective,

--- a/packages/gateway-nginx/src/types.ts
+++ b/packages/gateway-nginx/src/types.ts
@@ -24,6 +24,7 @@ export type GeneratorInput = {
   upstreamURL: string;
   specRoot?: string | undefined;
   sitePrefix?: string | undefined;
+  extraDirectives?: string[] | undefined;
 };
 
 export type GeneratorOutput = {

--- a/packages/middleware-openapi/README.md
+++ b/packages/middleware-openapi/README.md
@@ -125,9 +125,15 @@ Parameters:
 - [EvalErrorHandler](#evalerrorhandler)
 - [PricingEvaluator](#pricingevaluator)
 - [GatewayHandlerConfig](#gatewayhandlerconfig)
+- [AuthorizeResponse](#authorizeresponse)
+- [SettledPayment](#settledpayment)
 - [RequestContext](#requestcontext)
 - [ResponseContext](#responsecontext)
-- [GatewayResponse](#gatewayresponse)
+- [GatewayRequestResult](#gatewayrequestresult)
+- [GatewayResponseResult](#gatewayresponseresult)
+- [CapturePhase](#capturephase)
+- [CaptureError](#captureerror)
+- [CaptureRequestInfo](#capturerequestinfo)
 - [CaptureResponse](#captureresponse)
 - [GatewayHandler](#gatewayhandler)
 
@@ -216,9 +222,21 @@ lose precision to IEEE-754 rounding.
 
 ### GatewayHandlerConfig
 
-| Type                   | Type                                                                                                                                                                  |
-| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `GatewayHandlerConfig` | `{ spec: FaremeterSpec; baseURL: string; x402Handlers?: FacilitatorHandler[]; mppMethodHandlers?: MPPMethodHandler[]; supportedVersions?: SupportedVersionsConfig; }` |
+| Type                   | Type                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `GatewayHandlerConfig` | `{ spec: FaremeterSpec; baseURL: string; x402Handlers?: FacilitatorHandler[]; mppMethodHandlers?: MPPMethodHandler[]; supportedVersions?: SupportedVersionsConfig; /** * Called post-settlement when a pricing rule matched and produced * a non-empty capture amount. `result.phase`indicates whether * settlement happened at`/request`(one-phase) or`/response`* (two-phase). * * For two-phase rules the hook fires at`/response` when settlement * is attempted, regardless of whether it succeeded or failed * (`result.settled`and`result.error`distinguish the outcome). * For one-phase rules the hook fires at`/request` only on * successful settlement -- if the facilitator rejects the payment, * the request gets a 402 and the hook is not invoked. * * The hook does NOT fire when the capture expression evaluates to * zero across all assets. A zero-amount capture produces no * settlement and no hook invocation. * * The hook is awaited -- a slow async hook delays the caller. The * return value is computed before the hook is invoked, so a throw * or rejected promise is caught and logged without affecting it. * * Requires payment handlers (`x402Handlers`or`mppMethodHandlers`) * to be configured. Without them no settlement occurs and this * hook is never invoked. */ onCapture?: ( operationKey: string, result: CaptureResponse, ) => void or Promise<void>; /** * Called when a two-phase rule's payment is successfully verified at * `/request`time. Does not fire for one-phase (capture-only) rules, * which settle immediately and report through`onCapture` instead. * Does not fire when verification fails (the request gets a 402). * * The hook is awaited -- a slow async hook delays the caller. A * throw or rejected promise is caught and logged without affecting * the gateway response, which is already determined at this point. */ onAuthorize?: ( operationKey: string, result: AuthorizeResponse, ) => void or Promise<void>; }` |
+
+### AuthorizeResponse
+
+| Type                | Type |
+| ------------------- | ---- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `AuthorizeResponse` | `    | { protocol: "x402v1"; verification: x402VerifyResponseV1 } or { protocol: "x402v2"; verification: x402VerifyResponseV2 } or { protocol: "mpp"; verification: mppReceipt }` |
+
+### SettledPayment
+
+| Type             | Type |
+| ---------------- | ---- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `SettledPayment` | `    | { protocol: "x402v1"; settlement: x402SettleResponseV1 } or { protocol: "x402v2"; settlement: x402SettleResponseV2 } or { protocol: "mpp"; settlement: mppReceipt }` |
 
 ### RequestContext
 
@@ -232,22 +250,46 @@ lose precision to IEEE-754 rounding.
 | ----------------- | ------------------------------ |
 | `ResponseContext` | `typeof responseContext.infer` |
 
-### GatewayResponse
+### GatewayRequestResult
 
-| Type              | Type                                                                    |
-| ----------------- | ----------------------------------------------------------------------- |
-| `GatewayResponse` | `{ status: number; headers?: Record<string, string>; body?: unknown; }` |
+| Type                   | Type                                                                    |
+| ---------------------- | ----------------------------------------------------------------------- |
+| `GatewayRequestResult` | `{ status: number; headers?: Record<string, string>; body?: unknown; }` |
+
+### GatewayResponseResult
+
+| Type                    | Type                  |
+| ----------------------- | --------------------- |
+| `GatewayResponseResult` | `{ status: number; }` |
+
+### CapturePhase
+
+| Type           | Type                    |
+| -------------- | ----------------------- |
+| `CapturePhase` | `request" or "response` |
+
+### CaptureError
+
+| Type           | Type                                    |
+| -------------- | --------------------------------------- |
+| `CaptureError` | `{ status: number; message?: string; }` |
+
+### CaptureRequestInfo
+
+| Type                 | Type                                                                 |
+| -------------------- | -------------------------------------------------------------------- |
+| `CaptureRequestInfo` | `{ method: string; path: string; headers: Record<string, string>; }` |
 
 ### CaptureResponse
 
-| Type              | Type                                                                                                                                                                                                                                                                                                                                                   |
-| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `CaptureResponse` | `{ captured: boolean; settled: boolean; amount: Record<string, string>; // When settlement is attempted and fails, the facilitator's // machine-readable error payload is propagated here. Absent for // successful settlements and for one-phase rules where authorize // and capture produce the same amount. error?: unknown; trace?: EvalTrace; }` |
+| Type              | Type                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `CaptureResponse` | `{ phase: CapturePhase; settled: boolean; amount: Record<string, string>; // The original client request's method, path, and headers as // forwarded by the gateway. Useful for correlating settlement // events with access logs (e.g. via x-request-id). request: CaptureRequestInfo; // When settlement is attempted and fails, the error is propagated // here. Absent for successful settlements. error?: CaptureError; trace?: EvalTrace; // Present when settlement succeeded at this phase and a payment // handler returned a receipt. Absent when settlement failed // (`settled: false`, `error` is set). payment?: SettledPayment; }` |
 
 ### GatewayHandler
 
-| Type             | Type                                                                                                                                |
-| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| `GatewayHandler` | `{ handleRequest(ctx: RequestContext): Promise<GatewayResponse>; handleResponse(ctx: ResponseContext): Promise<CaptureResponse>; }` |
+| Type             | Type                                                                                                                                           |
+| ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `GatewayHandler` | `{ handleRequest(ctx: RequestContext): Promise<GatewayRequestResult>; handleResponse(ctx: ResponseContext): Promise<GatewayResponseResult>; }` |
 
 <!-- TSDOC_END -->

--- a/packages/middleware-openapi/src/handler.test.ts
+++ b/packages/middleware-openapi/src/handler.test.ts
@@ -8,7 +8,7 @@
 
 import t from "tap";
 import { createGatewayHandler } from "./handler";
-import type { Asset, FaremeterSpec, PricingRule } from "./types";
+import type { Asset, FaremeterSpec } from "./types";
 
 const DEFAULT_ASSETS: Record<string, Asset> = {
   "usdc-sol": {
@@ -279,7 +279,7 @@ await t.test(
 );
 
 await t.test(
-  "handleResponse returns captured amount when capture rule matches",
+  "handleResponse returns status 500 when two-phase rule matches but no handlers settle",
   async (t) => {
     const spec = makeSpec([
       {
@@ -295,16 +295,14 @@ await t.test(
         { model: "gpt-4o", messages: [] },
       ),
     );
-    t.equal(result.captured, true);
-    t.equal(result.amount["usdc-sol"], "100");
-    // No x402/mpp handlers configured, so nothing can actually settle.
-    t.equal(result.settled, false);
+    // No x402/mpp handlers configured, so settlement cannot succeed.
+    t.equal(result.status, 500);
     t.end();
   },
 );
 
 await t.test(
-  "handleResponse returns captured:false when no rule matches",
+  "handleResponse returns status 200 when no rule matches",
   async (t) => {
     const spec = makeSpec([
       {
@@ -320,14 +318,13 @@ await t.test(
         { model: "claude-sonnet", messages: [] },
       ),
     );
-    t.equal(result.captured, false);
-    t.equal(result.settled, false);
+    t.equal(result.status, 200);
     t.end();
   },
 );
 
 await t.test(
-  "handleResponse with unknown operationKey returns captured:false",
+  "handleResponse with unknown operationKey returns status 200",
   async (t) => {
     const spec = makeSpec([{ match: "$", capture: "1" }]);
     const handler = createGatewayHandler({ spec, baseURL: BASE_URL });
@@ -335,8 +332,7 @@ await t.test(
       ...responsePayload({ anything: true }, {}),
       operationKey: "GET /nonexistent",
     });
-    t.equal(result.captured, false);
-    t.equal(result.settled, false);
+    t.equal(result.status, 200);
     t.end();
   },
 );
@@ -377,8 +373,9 @@ await t.test(
         { model: "gpt-4o", messages: [] },
       ),
     );
-    // 100 * 10 + 50 * 30 = 2500
-    t.equal(result.amount["usdc-sol"], "2500");
+    // Two-phase rule with no handlers: capture evaluates but
+    // settlement cannot succeed.
+    t.equal(result.status, 500);
     t.end();
   },
 );
@@ -455,11 +452,12 @@ await t.test(
     ]);
     const handler = createGatewayHandler({ spec, baseURL: BASE_URL });
 
-    // Happy case — body forwarded verbatim — still works.
+    // Body forwarded verbatim — capture evaluates but no handlers
+    // means settlement fails.
     const withBody = await handler.handleResponse(
       responsePayload({ usage: { total_tokens: 50 } }, { tokens: 100 }),
     );
-    t.equal(withBody.captured, true);
+    t.equal(withBody.status, 500);
 
     // Body absent — must refuse, not re-derive a different amount.
     await t.rejects(
@@ -474,15 +472,11 @@ await t.test(
 );
 
 await t.test(
-  "handleResponse reports settled:true for one-phase rule with non-zero capture",
+  "handleResponse returns status 200 for one-phase rule with non-zero capture",
   async (t) => {
     // One-phase (capture-only) rules settle at /request time. When
     // handleResponse is called it means /request returned 200, which
-    // means settlement already succeeded. The CaptureResponse must
-    // reflect that so callers (e.g. the onCapture hook) can rely on
-    // settled:true for billing assertions without checking phase type.
-    // One-phase capture expressions must not reference $.response.*,
-    // so use a literal coefficient here.
+    // means settlement already succeeded.
     const spec = makeSpec([{ match: "$", capture: "50" }]);
     const handler = createGatewayHandler({ spec, baseURL: BASE_URL });
     const result = await handler.handleResponse(
@@ -491,20 +485,18 @@ await t.test(
         { model: "gpt-4o", messages: [] },
       ),
     );
-    t.equal(result.captured, true);
-    t.equal(result.settled, true);
-    t.equal(result.amount["usdc-sol"], "50");
+    t.equal(result.status, 200);
     t.end();
   },
 );
 
 await t.test(
-  "handleResponse reports settled:false for one-phase rule with zero capture",
+  "handleResponse returns status 200 for one-phase rule with zero capture",
   async (t) => {
     // When the capture expression evaluates to zero, toPricing drops
     // the entry and handleRequest returns 200 without settling. The
     // log phase still runs (access.lua sets fm_paid on any 200), but
-    // no payment was taken, so settled must remain false.
+    // no payment was taken, so settled remains false.
     const spec = makeSpec([{ match: "$", capture: "0" }]);
     const handler = createGatewayHandler({ spec, baseURL: BASE_URL });
     const result = await handler.handleResponse(
@@ -513,21 +505,46 @@ await t.test(
         { model: "gpt-4o", messages: [] },
       ),
     );
-    t.equal(result.captured, true);
-    t.equal(result.settled, false);
+    t.equal(result.status, 200);
     t.end();
   },
 );
 
 await t.test(
-  "handleResponse includes two-phase trace with authorize and capture bindings",
+  "handleResponse returns status 200 for two-phase rule with zero capture",
   async (t) => {
-    const rule: PricingRule = {
-      match: "$",
-      authorize: "$.request.body.max_tokens",
-      capture: "$.response.body.usage.total_tokens",
-    };
-    const spec = makeSpec([rule]);
+    // authorize evaluates to a non-zero hold at /request, but capture
+    // evaluates to zero at /response. toPricing drops zero-amount
+    // entries, so no settlement is attempted — this is not a failure.
+    const spec = makeSpec([
+      {
+        match: "$",
+        authorize: "100",
+        capture: "$.response.body.usage.total_tokens",
+      },
+    ]);
+    const handler = createGatewayHandler({ spec, baseURL: BASE_URL });
+    const result = await handler.handleResponse(
+      responsePayload(
+        { usage: { total_tokens: 0 } },
+        { model: "gpt-4o", messages: [] },
+      ),
+    );
+    t.equal(result.status, 200);
+    t.end();
+  },
+);
+
+await t.test(
+  "handleResponse returns status 500 for two-phase rule without handlers",
+  async (t) => {
+    const spec = makeSpec([
+      {
+        match: "$",
+        authorize: "$.request.body.max_tokens",
+        capture: "$.response.body.usage.total_tokens",
+      },
+    ]);
     const handler = createGatewayHandler({ spec, baseURL: BASE_URL });
     const result = await handler.handleResponse(
       responsePayload(
@@ -535,34 +552,15 @@ await t.test(
         { model: "gpt-4o", max_tokens: 100 },
       ),
     );
-    t.ok(result.trace, "trace must be defined when a rule matched");
-    t.equal(result.trace?.ruleIndex, 0, "first rule matched");
-    t.matchOnly(result.trace?.rule, rule, "rule must match the spec rule");
-    t.ok(
-      result.trace?.authorize,
-      "authorize trace must be present for two-phase rule",
-    );
-    t.match(result.trace?.authorize?.bindings, {
-      "$.request.body.max_tokens": 100,
-    });
-    t.equal(result.trace?.authorize?.coefficient, 100);
-    t.ok(result.trace?.capture, "capture trace must be present");
-    t.match(result.trace?.capture?.bindings, {
-      "$.response.body.usage.total_tokens": 42,
-    });
-    t.equal(result.trace?.capture?.coefficient, 42);
+    t.equal(result.status, 500);
     t.end();
   },
 );
 
 await t.test(
-  "handleResponse includes capture-only trace without authorize",
+  "handleResponse returns status 200 for capture-only rule",
   async (t) => {
-    const rule: PricingRule = {
-      match: "$",
-      capture: "50",
-    };
-    const spec = makeSpec([rule]);
+    const spec = makeSpec([{ match: "$", capture: "50" }]);
     const handler = createGatewayHandler({ spec, baseURL: BASE_URL });
     const result = await handler.handleResponse(
       responsePayload(
@@ -570,36 +568,69 @@ await t.test(
         { model: "gpt-4o", messages: [] },
       ),
     );
-    t.ok(result.trace, "trace must be defined when a rule matched");
-    t.equal(result.trace?.ruleIndex, 0);
-    t.matchOnly(result.trace?.rule, rule);
-    t.equal(
-      result.trace?.authorize,
-      undefined,
-      "no authorize on capture-only rule",
-    );
-    t.ok(result.trace?.capture);
-    t.equal(result.trace?.capture?.coefficient, 50);
-    t.equal(result.trace?.rule.authorize, undefined);
+    t.equal(result.status, 200);
     t.end();
   },
 );
 
-await t.test("handleResponse omits trace when no rule matches", async (t) => {
-  const spec = makeSpec([
-    {
-      match: '$[?@.request.body.model == "gpt-4o"]',
-      authorize: "100",
-      capture: "$.response.body.usage.total_tokens",
-    },
-  ]);
-  const handler = createGatewayHandler({ spec, baseURL: BASE_URL });
-  const result = await handler.handleResponse(
-    responsePayload(
-      { usage: { total_tokens: 50 } },
-      { model: "claude-sonnet", messages: [] },
-    ),
-  );
-  t.equal(result.trace, undefined, "trace must be absent when no rule matched");
-  t.end();
-});
+await t.test(
+  "handleResponse returns status 200 when no rule matches",
+  async (t) => {
+    const spec = makeSpec([
+      {
+        match: '$[?@.request.body.model == "gpt-4o"]',
+        authorize: "100",
+        capture: "$.response.body.usage.total_tokens",
+      },
+    ]);
+    const handler = createGatewayHandler({ spec, baseURL: BASE_URL });
+    const result = await handler.handleResponse(
+      responsePayload(
+        { usage: { total_tokens: 50 } },
+        { model: "claude-sonnet", messages: [] },
+      ),
+    );
+    t.equal(result.status, 200);
+    t.end();
+  },
+);
+
+await t.test(
+  "onCapture does not fire when no payment handlers are configured",
+  async (t) => {
+    // When no x402 or mpp handlers are configured, handleMiddlewareRequest
+    // returns without invoking the body callback, leaving paymentSettled=false
+    // and settlementError=undefined. The onCapture hook must not fire in
+    // this case — callers cannot distinguish "settlement failed" from
+    // "settlement was never attempted" if both produce settled:false,
+    // error:undefined.
+    const spec = makeSpec([
+      {
+        match: "$",
+        authorize: "100",
+        capture: "$.response.body.usage.total_tokens",
+      },
+    ]);
+    let captureFired = false;
+    const handler = createGatewayHandler({
+      spec,
+      baseURL: BASE_URL,
+      onCapture: () => {
+        captureFired = true;
+      },
+    });
+    const result = await handler.handleResponse(
+      responsePayload(
+        { usage: { total_tokens: 50 } },
+        { model: "gpt-4o", messages: [] },
+      ),
+    );
+    t.equal(result.status, 500, "no handlers means settlement cannot succeed");
+    t.equal(
+      captureFired,
+      false,
+      "onCapture must not fire when no handlers are configured",
+    );
+    t.end();
+  },
+);

--- a/packages/middleware-openapi/src/handler.ts
+++ b/packages/middleware-openapi/src/handler.ts
@@ -1,7 +1,15 @@
 import { type } from "arktype";
 import type { FacilitatorHandler } from "@faremeter/types/facilitator";
-import type { MPPMethodHandler } from "@faremeter/types/mpp";
+import type { MPPMethodHandler, mppReceipt } from "@faremeter/types/mpp";
 import type { ResourcePricing } from "@faremeter/types/pricing";
+import type {
+  x402VerifyResponse as x402VerifyResponseV1,
+  x402SettleResponse as x402SettleResponseV1,
+} from "@faremeter/types/x402";
+import type {
+  x402VerifyResponse as x402VerifyResponseV2,
+  x402SettleResponse as x402SettleResponseV2,
+} from "@faremeter/types/x402v2";
 import type { SupportedVersionsConfig } from "@faremeter/middleware/common";
 import {
   handleMiddlewareRequest,
@@ -18,7 +26,60 @@ export type GatewayHandlerConfig = {
   x402Handlers?: FacilitatorHandler[];
   mppMethodHandlers?: MPPMethodHandler[];
   supportedVersions?: SupportedVersionsConfig;
+  /**
+   * Called post-settlement when a pricing rule matched and produced
+   * a non-empty capture amount. `result.phase` indicates whether
+   * settlement happened at `/request` (one-phase) or `/response`
+   * (two-phase).
+   *
+   * For two-phase rules the hook fires at `/response` when settlement
+   * is attempted, regardless of whether it succeeded or failed
+   * (`result.settled` and `result.error` distinguish the outcome).
+   * For one-phase rules the hook fires at `/request` only on
+   * successful settlement -- if the facilitator rejects the payment,
+   * the request gets a 402 and the hook is not invoked.
+   *
+   * The hook does NOT fire when the capture expression evaluates to
+   * zero across all assets. A zero-amount capture produces no
+   * settlement and no hook invocation.
+   *
+   * The hook is awaited -- a slow async hook delays the caller. The
+   * return value is computed before the hook is invoked, so a throw
+   * or rejected promise is caught and logged without affecting it.
+   *
+   * Requires payment handlers (`x402Handlers` or `mppMethodHandlers`)
+   * to be configured. Without them no settlement occurs and this
+   * hook is never invoked.
+   */
+  onCapture?: (
+    operationKey: string,
+    result: CaptureResponse,
+  ) => void | Promise<void>;
+  /**
+   * Called when a two-phase rule's payment is successfully verified at
+   * `/request` time. Does not fire for one-phase (capture-only) rules,
+   * which settle immediately and report through `onCapture` instead.
+   * Does not fire when verification fails (the request gets a 402).
+   *
+   * The hook is awaited -- a slow async hook delays the caller. A
+   * throw or rejected promise is caught and logged without affecting
+   * the gateway response, which is already determined at this point.
+   */
+  onAuthorize?: (
+    operationKey: string,
+    result: AuthorizeResponse,
+  ) => void | Promise<void>;
 };
+
+export type AuthorizeResponse =
+  | { protocol: "x402v1"; verification: x402VerifyResponseV1 }
+  | { protocol: "x402v2"; verification: x402VerifyResponseV2 }
+  | { protocol: "mpp"; verification: mppReceipt };
+
+export type SettledPayment =
+  | { protocol: "x402v1"; settlement: x402SettleResponseV1 }
+  | { protocol: "x402v2"; settlement: x402SettleResponseV2 }
+  | { protocol: "mpp"; settlement: mppReceipt };
 
 // Headers and query values can arrive as arrays when the same name
 // appears more than once in the original HTTP message (the Lua
@@ -59,27 +120,58 @@ export const responseContext = type({
 
 export type ResponseContext = typeof responseContext.infer;
 
-export type GatewayResponse = {
+export type GatewayRequestResult = {
   status: number;
   headers?: Record<string, string>;
   body?: unknown;
 };
 
+export type GatewayResponseResult = {
+  status: number;
+};
+
+export type CapturePhase = "request" | "response";
+
+export type CaptureError = {
+  status: number;
+  message?: string;
+};
+
+function toCaptureError(status: number, message?: string): CaptureError {
+  const error: CaptureError = { status };
+  if (message !== undefined) {
+    error.message = message;
+  }
+  return error;
+}
+
+export type CaptureRequestInfo = {
+  method: string;
+  path: string;
+  headers: Record<string, string>;
+};
+
 export type CaptureResponse = {
-  captured: boolean;
+  phase: CapturePhase;
   settled: boolean;
   amount: Record<string, string>;
-  // When settlement is attempted and fails, the facilitator's
-  // machine-readable error payload is propagated here. Absent for
-  // successful settlements and for one-phase rules where authorize
-  // and capture produce the same amount.
-  error?: unknown;
+  // The original client request's method, path, and headers as
+  // forwarded by the gateway. Useful for correlating settlement
+  // events with access logs (e.g. via x-request-id).
+  request: CaptureRequestInfo;
+  // When settlement is attempted and fails, the error is propagated
+  // here. Absent for successful settlements.
+  error?: CaptureError;
   trace?: EvalTrace;
+  // Present when settlement succeeded at this phase and a payment
+  // handler returned a receipt. Absent when settlement failed
+  // (`settled: false`, `error` is set).
+  payment?: SettledPayment;
 };
 
 export type GatewayHandler = {
-  handleRequest(ctx: RequestContext): Promise<GatewayResponse>;
-  handleResponse(ctx: ResponseContext): Promise<CaptureResponse>;
+  handleRequest(ctx: RequestContext): Promise<GatewayRequestResult>;
+  handleResponse(ctx: ResponseContext): Promise<GatewayResponseResult>;
 };
 
 /**
@@ -202,7 +294,14 @@ function makeBodyGetter(
 export function createGatewayHandler(
   config: GatewayHandlerConfig,
 ): GatewayHandler {
-  const { spec, baseURL, x402Handlers = [], mppMethodHandlers = [] } = config;
+  const {
+    spec,
+    baseURL,
+    x402Handlers = [],
+    mppMethodHandlers = [],
+    onCapture,
+    onAuthorize,
+  } = config;
   if (!baseURL) {
     throw new Error("createGatewayHandler: baseURL is required");
   }
@@ -219,7 +318,9 @@ export function createGatewayHandler(
   const supportedVersions = resolveSupportedVersions(config.supportedVersions);
   const evaluator = createPricingEvaluator(spec);
 
-  async function handleRequest(ctx: RequestContext): Promise<GatewayResponse> {
+  async function handleRequest(
+    ctx: RequestContext,
+  ): Promise<GatewayRequestResult> {
     const headers = normalizeHeaderMap(ctx.headers);
     const query = normalizeHeaderMap(ctx.query);
     const body = requireBody(ctx.body, ctx.method, "handleRequest");
@@ -248,8 +349,11 @@ export function createGatewayHandler(
     }
 
     const responseHeaders: Record<string, string> = {};
+    let settledAtRequest = false;
+    let settledPayment: SettledPayment | undefined;
+    let authorizeResponse: AuthorizeResponse | undefined;
 
-    const result = await handleMiddlewareRequest<GatewayResponse>({
+    const result = await handleMiddlewareRequest<GatewayRequestResult>({
       x402Handlers,
       mppMethodHandlers,
       pricing,
@@ -268,29 +372,88 @@ export function createGatewayHandler(
         headers?: Record<string, string>,
       ) => {
         const merged = { ...responseHeaders, ...headers };
-        const resp: GatewayResponse = { status };
+        const resp: GatewayRequestResult = { status };
         if (Object.keys(merged).length > 0) resp.headers = merged;
         if (body) resp.body = body;
         return resp;
       },
 
       body: async (context) => {
-        if (authResult.hasAuthorize && "verify" in context) {
+        if (authResult.hasAuthorize && "verify" in context && context.verify) {
           // authorize + capture: verify the payment now, settle
           // later at /response with the captured amount.
-          const verifyResult = await context.verify();
-          if (!verifyResult.success) {
-            return verifyResult.errorResponse;
+          switch (context.protocolVersion) {
+            case 1: {
+              const r = await context.verify();
+              if (!r.success) return r.errorResponse;
+              authorizeResponse = {
+                protocol: "x402v1",
+                verification: r.facilitatorResponse,
+              };
+              break;
+            }
+            case 2: {
+              const r = await context.verify();
+              if (!r.success) return r.errorResponse;
+              authorizeResponse = {
+                protocol: "x402v2",
+                verification: r.facilitatorResponse,
+              };
+              break;
+            }
+            case "mpp": {
+              const r = await context.verify();
+              if (!r.success) return r.errorResponse;
+              authorizeResponse = {
+                protocol: "mpp",
+                verification: r.receipt,
+              };
+              break;
+            }
+            default: {
+              const _: never = context;
+              break;
+            }
           }
         } else {
           // capture only, or the payment scheme does not support
           // verify: settle immediately.
-          const settleResult = await context.settle();
-          if (!settleResult.success) {
-            return settleResult.errorResponse;
+          switch (context.protocolVersion) {
+            case 1: {
+              const r = await context.settle();
+              if (!r.success) return r.errorResponse;
+              settledPayment = {
+                protocol: "x402v1",
+                settlement: r.facilitatorResponse,
+              };
+              break;
+            }
+            case 2: {
+              const r = await context.settle();
+              if (!r.success) return r.errorResponse;
+              settledPayment = {
+                protocol: "x402v2",
+                settlement: r.facilitatorResponse,
+              };
+              break;
+            }
+            case "mpp": {
+              const r = await context.settle();
+              if (!r.success) return r.errorResponse;
+              settledPayment = {
+                protocol: "mpp",
+                settlement: r.receipt,
+              };
+              break;
+            }
+            default: {
+              const _: never = context;
+              break;
+            }
           }
+          settledAtRequest = true;
         }
-        const resp: GatewayResponse = { status: 200 };
+        const resp: GatewayRequestResult = { status: 200 };
         if (Object.keys(responseHeaders).length > 0) {
           resp.headers = { ...responseHeaders };
         }
@@ -298,12 +461,59 @@ export function createGatewayHandler(
       },
     });
 
+    if (onAuthorize && authorizeResponse) {
+      try {
+        await onAuthorize(ctx.operationKey, authorizeResponse);
+      } catch (cause) {
+        logger.error("onAuthorize hook threw", {
+          operationKey: ctx.operationKey,
+          cause: cause instanceof Error ? cause.message : String(cause),
+        });
+      }
+    }
+
+    if (onCapture && settledAtRequest) {
+      // For one-phase rules the evaluator falls back to the capture
+      // expression when computing authorize, so authResult.trace IS
+      // the capture trace here.
+      const trace: EvalTrace | undefined =
+        authResult.trace &&
+        authResult.ruleIndex !== undefined &&
+        authResult.rule
+          ? {
+              ruleIndex: authResult.ruleIndex,
+              rule: authResult.rule,
+              capture: authResult.trace,
+            }
+          : undefined;
+      const capture: CaptureResponse = {
+        phase: "request",
+        settled: true,
+        amount: amountToJSON(authResult.amount),
+        request: { method: ctx.method, path: ctx.path, headers },
+      };
+      if (settledPayment) {
+        capture.payment = settledPayment;
+      }
+      if (trace) {
+        capture.trace = trace;
+      }
+      try {
+        await onCapture(ctx.operationKey, capture);
+      } catch (cause) {
+        logger.error("onCapture hook threw", {
+          operationKey: ctx.operationKey,
+          cause: cause instanceof Error ? cause.message : String(cause),
+        });
+      }
+    }
+
     return result ?? { status: 200 };
   }
 
   async function handleResponse(
     ctx: ResponseContext,
-  ): Promise<CaptureResponse> {
+  ): Promise<GatewayResponseResult> {
     const headers = normalizeHeaderMap(ctx.headers);
     const query = normalizeHeaderMap(ctx.query);
     const responseHeaders = normalizeHeaderMap(ctx.response.headers);
@@ -335,15 +545,29 @@ export function createGatewayHandler(
       authEvalCtx,
     );
 
-    let paymentSettled = false;
-    let settlementError: unknown;
+    if (!authResult.matched) {
+      return { status: 200 };
+    }
 
-    if (authResult.matched && authResult.hasAuthorize) {
+    let paymentSettled = false;
+    let settlementError: CaptureError | undefined;
+    let settledPayment: SettledPayment | undefined;
+    // Set when an MPP handler without handleVerify is encountered at
+    // /response. This means /request already settled as one-phase, so
+    // /response must skip settlement entirely (no double-charge, no
+    // second onCapture fire).
+    let alreadySettledAtRequest = false;
+
+    if (authResult.hasAuthorize) {
       // authorize + capture: settle the captured amount now.
       // Capture-only rules already settled at /request.
       const pricing = toPricing(captureResult.amount, spec.assets);
-      if (pricing.length > 0) {
-        await handleMiddlewareRequest<GatewayResponse>({
+      if (pricing.length === 0) {
+        // Captured amount is zero — no payment needed. toPricing
+        // drops zero-amount entries, so there is nothing to settle.
+        paymentSettled = true;
+      } else {
+        await handleMiddlewareRequest<GatewayResponseResult>({
           x402Handlers,
           mppMethodHandlers,
           pricing,
@@ -357,10 +581,71 @@ export function createGatewayHandler(
           sendJSONResponse: (status) => ({ status }),
 
           body: async (context) => {
-            const settleResult = await context.settle();
-            paymentSettled = settleResult.success;
-            if (!settleResult.success) {
-              settlementError = settleResult.errorResponse;
+            // If the spec rule has authorize but the payment scheme
+            // did not support verify (e.g. MPP handler without
+            // handleVerify), /request already settled as one-phase.
+            // Skip settlement here to avoid double-charging.
+            if (
+              context.protocolVersion === "mpp" &&
+              !("verify" in context && context.verify)
+            ) {
+              alreadySettledAtRequest = true;
+              return { status: 200 };
+            }
+
+            switch (context.protocolVersion) {
+              case 1: {
+                const r = await context.settle();
+                paymentSettled = r.success;
+                if (!r.success) {
+                  settlementError = toCaptureError(
+                    r.errorResponse.status,
+                    r.errorMessage,
+                  );
+                } else {
+                  settledPayment = {
+                    protocol: "x402v1",
+                    settlement: r.facilitatorResponse,
+                  };
+                }
+                break;
+              }
+              case 2: {
+                const r = await context.settle();
+                paymentSettled = r.success;
+                if (!r.success) {
+                  settlementError = toCaptureError(
+                    r.errorResponse.status,
+                    r.errorMessage,
+                  );
+                } else {
+                  settledPayment = {
+                    protocol: "x402v2",
+                    settlement: r.facilitatorResponse,
+                  };
+                }
+                break;
+              }
+              case "mpp": {
+                const r = await context.settle();
+                paymentSettled = r.success;
+                if (!r.success) {
+                  settlementError = toCaptureError(
+                    r.errorResponse.status,
+                    r.errorMessage,
+                  );
+                } else {
+                  settledPayment = {
+                    protocol: "mpp",
+                    settlement: r.receipt,
+                  };
+                }
+                break;
+              }
+              default: {
+                const _: never = context;
+                break;
+              }
             }
             return { status: paymentSettled ? 200 : 500 };
           },
@@ -368,18 +653,11 @@ export function createGatewayHandler(
       }
     }
 
-    if (
-      !paymentSettled &&
-      !settlementError &&
-      authResult.matched &&
-      !authResult.hasAuthorize
-    ) {
-      // One-phase rule: settlement already happened at /request time.
-      // If handleResponse is called, the request succeeded (200), so
-      // settlement succeeded. Only set settled if a non-zero amount
-      // was actually captured (zero amounts are filtered by toPricing
-      // and skip settlement entirely).
-      paymentSettled = Object.values(captureResult.amount).some((v) => v > 0n);
+    if (!authResult.hasAuthorize || alreadySettledAtRequest) {
+      // One-phase rule (or MPP handler without handleVerify that
+      // settled as one-phase at /request): settlement already happened
+      // at /request time. The response phase has nothing to do.
+      return { status: 200 };
     }
 
     const trace: EvalTrace | undefined =
@@ -396,18 +674,36 @@ export function createGatewayHandler(
           }
         : undefined;
 
-    const response: CaptureResponse = {
-      captured: Object.keys(captureResult.amount).length > 0,
-      settled: paymentSettled,
-      amount: amountToJSON(captureResult.amount),
-    };
-    if (settlementError !== undefined) {
-      response.error = settlementError;
+    const hasCaptureAmount = Object.values(captureResult.amount).some(
+      (v) => v > 0n,
+    );
+    const settlementAttempted = paymentSettled || settlementError !== undefined;
+    if (onCapture && hasCaptureAmount && settlementAttempted) {
+      const capture: CaptureResponse = {
+        phase: "response",
+        settled: paymentSettled,
+        amount: amountToJSON(captureResult.amount),
+        request: { method: ctx.method, path: ctx.path, headers },
+      };
+      if (settledPayment) {
+        capture.payment = settledPayment;
+      }
+      if (settlementError !== undefined) {
+        capture.error = settlementError;
+      }
+      if (trace) {
+        capture.trace = trace;
+      }
+      try {
+        await onCapture(ctx.operationKey, capture);
+      } catch (cause) {
+        logger.error("onCapture hook threw", {
+          operationKey: ctx.operationKey,
+          cause: cause instanceof Error ? cause.message : String(cause),
+        });
+      }
     }
-    if (trace) {
-      response.trace = trace;
-    }
-    return response;
+    return { status: paymentSettled ? 200 : 500 };
   }
 
   return { handleRequest, handleResponse };

--- a/packages/middleware-openapi/src/index.ts
+++ b/packages/middleware-openapi/src/index.ts
@@ -12,12 +12,18 @@ export {
   responseContext,
 } from "./handler";
 export type {
+  AuthorizeResponse,
+  CaptureError,
+  CapturePhase,
+  CaptureRequestInfo,
+  CaptureResponse,
   GatewayHandler,
   GatewayHandlerConfig,
+  GatewayRequestResult,
+  GatewayResponseResult,
   RequestContext,
-  GatewayResponse,
   ResponseContext,
-  CaptureResponse,
+  SettledPayment,
 } from "./handler";
 export type {
   Asset,

--- a/packages/middleware/README.md
+++ b/packages/middleware/README.md
@@ -318,14 +318,14 @@ Supports two mutually exclusive modes: in-process handlers or remote facilitator
 ### SettleResultV1
 
 | Type             | Type |
-| ---------------- | ---- | ---------------------------------------------------------------------------------------------------------------------- |
-| `SettleResultV1` | `    | { success: true; facilitatorResponse: x402SettleResponseV1 } or { success: false; errorResponse: MiddlewareResponse }` |
+| ---------------- | ---- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `SettleResultV1` | `    | { success: true; facilitatorResponse: x402SettleResponseV1 } or { success: false; errorResponse: MiddlewareResponse; errorMessage?: string; }` |
 
 ### SettleResultV2
 
 | Type             | Type |
-| ---------------- | ---- | -------------------------------------------------------------------------------------------------------------------- |
-| `SettleResultV2` | `    | { success: true; facilitatorResponse: x402SettleResponse } or { success: false; errorResponse: MiddlewareResponse }` |
+| ---------------- | ---- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `SettleResultV2` | `    | { success: true; facilitatorResponse: x402SettleResponse } or { success: false; errorResponse: MiddlewareResponse; errorMessage?: string; }` |
 
 ### SettleResult
 
@@ -336,14 +336,14 @@ Supports two mutually exclusive modes: in-process handlers or remote facilitator
 ### VerifyResultV1
 
 | Type             | Type |
-| ---------------- | ---- | ---------------------------------------------------------------------------------------------------------------------- |
-| `VerifyResultV1` | `    | { success: true; facilitatorResponse: x402VerifyResponseV1 } or { success: false; errorResponse: MiddlewareResponse }` |
+| ---------------- | ---- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `VerifyResultV1` | `    | { success: true; facilitatorResponse: x402VerifyResponseV1 } or { success: false; errorResponse: MiddlewareResponse; errorMessage?: string; }` |
 
 ### VerifyResultV2
 
 | Type             | Type |
-| ---------------- | ---- | -------------------------------------------------------------------------------------------------------------------- |
-| `VerifyResultV2` | `    | { success: true; facilitatorResponse: x402VerifyResponse } or { success: false; errorResponse: MiddlewareResponse }` |
+| ---------------- | ---- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `VerifyResultV2` | `    | { success: true; facilitatorResponse: x402VerifyResponse } or { success: false; errorResponse: MiddlewareResponse; errorMessage?: string; }` |
 
 ### VerifyResult
 
@@ -372,14 +372,14 @@ Contains payment information and functions to verify or settle the payment.
 ### SettleResultMPP
 
 | Type              | Type |
-| ----------------- | ---- | ------------------------------------------------------------------------------------------------ |
-| `SettleResultMPP` | `    | { success: true; receipt: mppReceipt } or { success: false; errorResponse: MiddlewareResponse }` |
+| ----------------- | ---- | ------------------------------------------------------------------------------------------------------------------------ |
+| `SettleResultMPP` | `    | { success: true; receipt: mppReceipt } or { success: false; errorResponse: MiddlewareResponse; errorMessage?: string; }` |
 
 ### VerifyResultMPP
 
 | Type              | Type |
-| ----------------- | ---- | ------------------------------------------------------------------------------------------------ |
-| `VerifyResultMPP` | `    | { success: true; receipt: mppReceipt } or { success: false; errorResponse: MiddlewareResponse }` |
+| ----------------- | ---- | ------------------------------------------------------------------------------------------------------------------------ |
+| `VerifyResultMPP` | `    | { success: true; receipt: mppReceipt } or { success: false; errorResponse: MiddlewareResponse; errorMessage?: string; }` |
 
 ### MiddlewareBodyContextMPP
 

--- a/packages/middleware/README.md
+++ b/packages/middleware/README.md
@@ -260,6 +260,7 @@ capacity (least recently used entries are removed first).
 - [MiddlewareBodyContextV1](#middlewarebodycontextv1)
 - [MiddlewareBodyContextV2](#middlewarebodycontextv2)
 - [SettleResultMPP](#settleresultmpp)
+- [VerifyResultMPP](#verifyresultmpp)
 - [MiddlewareBodyContextMPP](#middlewarebodycontextmpp)
 - [MiddlewareBodyContext](#middlewarebodycontext)
 - [HandleMiddlewareRequestArgs](#handlemiddlewarerequestargs)
@@ -374,13 +375,19 @@ Contains payment information and functions to verify or settle the payment.
 | ----------------- | ---- | ------------------------------------------------------------------------------------------------ |
 | `SettleResultMPP` | `    | { success: true; receipt: mppReceipt } or { success: false; errorResponse: MiddlewareResponse }` |
 
+### VerifyResultMPP
+
+| Type              | Type |
+| ----------------- | ---- | ------------------------------------------------------------------------------------------------ |
+| `VerifyResultMPP` | `    | { success: true; receipt: mppReceipt } or { success: false; errorResponse: MiddlewareResponse }` |
+
 ### MiddlewareBodyContextMPP
 
 Context provided to the middleware body handler for MPP protocol requests.
 
-| Type                       | Type                                                                                                                 |
-| -------------------------- | -------------------------------------------------------------------------------------------------------------------- |
-| `MiddlewareBodyContextMPP` | `{ protocolVersion: "mpp"; credential: mppCredential; settle: () => Promise<SettleResultMPP<MiddlewareResponse>>; }` |
+| Type                       | Type                                                                                                                                                                                             |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `MiddlewareBodyContextMPP` | `{ protocolVersion: "mpp"; credential: mppCredential; settle: () => Promise<SettleResultMPP<MiddlewareResponse>>; verify?: (() => Promise<VerifyResultMPP<MiddlewareResponse>>) or undefined; }` |
 
 ### MiddlewareBodyContext
 

--- a/packages/middleware/src/common.ts
+++ b/packages/middleware/src/common.ts
@@ -50,6 +50,7 @@ import {
   PAYMENT_RECEIPT_HEADER,
   resolveMPPChallenges,
   settleMPPPayment,
+  verifyMPPPayment,
 } from "@faremeter/types/mpp";
 import { normalizeNetworkId } from "@faremeter/info";
 import type { AgedLRUCacheOpts } from "./cache";
@@ -500,6 +501,13 @@ export type SettleResultMPP<MiddlewareResponse> =
   | { success: true; receipt: mppReceipt }
   | { success: false; errorResponse: MiddlewareResponse };
 
+export type VerifyResultMPP<MiddlewareResponse> =
+  | { success: true; receipt: mppReceipt }
+  | {
+      success: false;
+      errorResponse: MiddlewareResponse;
+    };
+
 /**
  * Context provided to the middleware body handler for MPP protocol requests.
  */
@@ -507,6 +515,7 @@ export type MiddlewareBodyContextMPP<MiddlewareResponse> = {
   protocolVersion: "mpp";
   credential: mppCredential;
   settle: () => Promise<SettleResultMPP<MiddlewareResponse>>;
+  verify?: (() => Promise<VerifyResultMPP<MiddlewareResponse>>) | undefined;
 };
 
 /**
@@ -978,9 +987,31 @@ async function handleMPPRequest<MiddlewareResponse>(
     }
   };
 
+  const method = credential.challenge.method;
+  const hasVerifyHandlers = mppHandlers.some(
+    (h) => h.method === method && h.handleVerify !== undefined,
+  );
+
+  const verify = hasVerifyHandlers
+    ? async (): Promise<VerifyResultMPP<MiddlewareResponse>> => {
+        try {
+          const receipt = await verifyMPPPayment(mppHandlers, credential);
+          return { success: true, receipt };
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          logger.warning("failed to verify MPP payment", { error: msg });
+          return {
+            success: false,
+            errorResponse: await sendPaymentRequired(),
+          };
+        }
+      }
+    : undefined;
+
   return await args.body({
     protocolVersion: "mpp",
     credential,
     settle,
+    verify,
   });
 }

--- a/packages/middleware/src/common.ts
+++ b/packages/middleware/src/common.ts
@@ -451,11 +451,19 @@ export function resolveConfig(args: CommonMiddlewareArgs): ResolvedConfig {
 
 export type SettleResultV1<MiddlewareResponse> =
   | { success: true; facilitatorResponse: x402SettleResponseV1 }
-  | { success: false; errorResponse: MiddlewareResponse };
+  | {
+      success: false;
+      errorResponse: MiddlewareResponse;
+      errorMessage?: string;
+    };
 
 export type SettleResultV2<MiddlewareResponse> =
   | { success: true; facilitatorResponse: x402SettleResponse }
-  | { success: false; errorResponse: MiddlewareResponse };
+  | {
+      success: false;
+      errorResponse: MiddlewareResponse;
+      errorMessage?: string;
+    };
 
 export type SettleResult<MiddlewareResponse> =
   | SettleResultV1<MiddlewareResponse>
@@ -463,11 +471,19 @@ export type SettleResult<MiddlewareResponse> =
 
 export type VerifyResultV1<MiddlewareResponse> =
   | { success: true; facilitatorResponse: x402VerifyResponseV1 }
-  | { success: false; errorResponse: MiddlewareResponse };
+  | {
+      success: false;
+      errorResponse: MiddlewareResponse;
+      errorMessage?: string;
+    };
 
 export type VerifyResultV2<MiddlewareResponse> =
   | { success: true; facilitatorResponse: x402VerifyResponse }
-  | { success: false; errorResponse: MiddlewareResponse };
+  | {
+      success: false;
+      errorResponse: MiddlewareResponse;
+      errorMessage?: string;
+    };
 
 export type VerifyResult<MiddlewareResponse> =
   | VerifyResultV1<MiddlewareResponse>
@@ -499,13 +515,18 @@ export type MiddlewareBodyContextV2<MiddlewareResponse> = {
 
 export type SettleResultMPP<MiddlewareResponse> =
   | { success: true; receipt: mppReceipt }
-  | { success: false; errorResponse: MiddlewareResponse };
+  | {
+      success: false;
+      errorResponse: MiddlewareResponse;
+      errorMessage?: string;
+    };
 
 export type VerifyResultMPP<MiddlewareResponse> =
   | { success: true; receipt: mppReceipt }
   | {
       success: false;
       errorResponse: MiddlewareResponse;
+      errorMessage?: string;
     };
 
 /**
@@ -814,7 +835,14 @@ async function handleV1Request<MiddlewareResponse>(
         "failed to settle payment: {errorReason}",
         settlementResponse,
       );
-      return { success: false, errorResponse: await sendPaymentRequired() };
+      const result: SettleResultV1<MiddlewareResponse> = {
+        success: false,
+        errorResponse: await sendPaymentRequired(),
+      };
+      if (settlementResponse.errorReason) {
+        result.errorMessage = settlementResponse.errorReason;
+      }
+      return result;
     }
 
     return { success: true, facilitatorResponse: settlementResponse };
@@ -834,7 +862,14 @@ async function handleV1Request<MiddlewareResponse>(
         "failed to verify payment: {invalidReason}",
         verifyResponse,
       );
-      return { success: false, errorResponse: await sendPaymentRequired() };
+      const result: VerifyResultV1<MiddlewareResponse> = {
+        success: false,
+        errorResponse: await sendPaymentRequired(),
+      };
+      if (verifyResponse.invalidReason) {
+        result.errorMessage = verifyResponse.invalidReason;
+      }
+      return result;
     }
 
     return { success: true, facilitatorResponse: verifyResponse };
@@ -891,7 +926,14 @@ async function handleV2Request<MiddlewareResponse>(
         "failed to settle v2 payment: {errorReason}",
         settlementResponse,
       );
-      return { success: false, errorResponse: await sendPaymentRequired() };
+      const result: SettleResultV2<MiddlewareResponse> = {
+        success: false,
+        errorResponse: await sendPaymentRequired(),
+      };
+      if (settlementResponse.errorReason) {
+        result.errorMessage = settlementResponse.errorReason;
+      }
+      return result;
     }
 
     return { success: true, facilitatorResponse: settlementResponse };
@@ -909,7 +951,14 @@ async function handleV2Request<MiddlewareResponse>(
         "failed to verify v2 payment: {invalidReason}",
         verifyResponse,
       );
-      return { success: false, errorResponse: await sendPaymentRequired() };
+      const result: VerifyResultV2<MiddlewareResponse> = {
+        success: false,
+        errorResponse: await sendPaymentRequired(),
+      };
+      if (verifyResponse.invalidReason) {
+        result.errorMessage = verifyResponse.invalidReason;
+      }
+      return result;
     }
 
     return { success: true, facilitatorResponse: verifyResponse };
@@ -983,7 +1032,11 @@ async function handleMPPRequest<MiddlewareResponse>(
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       logger.warning("failed to settle MPP payment", { error: msg });
-      return { success: false, errorResponse: await sendPaymentRequired() };
+      return {
+        success: false,
+        errorResponse: await sendPaymentRequired(),
+        errorMessage: msg,
+      };
     }
   };
 
@@ -1003,6 +1056,7 @@ async function handleMPPRequest<MiddlewareResponse>(
           return {
             success: false,
             errorResponse: await sendPaymentRequired(),
+            errorMessage: msg,
           };
         }
       }

--- a/packages/test-harness/README.md
+++ b/packages/test-harness/README.md
@@ -1324,9 +1324,9 @@ Resource context for v2 protocol.
 
 Resource context for MPP protocol.
 
-| Type                 | Type                                                                                                  |
-| -------------------- | ----------------------------------------------------------------------------------------------------- |
-| `ResourceContextMPP` | `ResourceContextBase and { protocolVersion: "mpp"; credential: mppCredential; receipt: mppReceipt; }` |
+| Type                 | Type                                                                                                                                           |
+| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ResourceContextMPP` | `ResourceContextBase and { protocolVersion: "mpp"; credential: mppCredential; receipt: mppReceipt; verifyReceipt?: mppReceipt or undefined; }` |
 
 ### ResourceContextX402
 
@@ -1391,9 +1391,9 @@ Options for creating a test payment handler.
 
 ### CreateTestMPPHandlerOpts
 
-| Type                       | Type                                                                                                                                                                                                 |
-| -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `CreateTestMPPHandlerOpts` | `{ method?: string; realm?: string; intents?: string[]; onChallenge?: ( intent: string, pricing: ResourcePricing, resourceURL: string, ) => void; onSettle?: (credential: mppCredential) => void; }` |
+| Type                       | Type                                                                                                                                                                                                                                                                           |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `CreateTestMPPHandlerOpts` | `{ method?: string; realm?: string; intents?: string[]; supportsVerify?: boolean; onChallenge?: ( intent: string, pricing: ResourcePricing, resourceURL: string, ) => void; onSettle?: (credential: mppCredential) => void; onVerify?: (credential: mppCredential) => void; }` |
 
 ### CreateTestMPPPaymentHandlerOpts
 

--- a/packages/test-harness/src/harness/harness.ts
+++ b/packages/test-harness/src/harness/harness.ts
@@ -38,7 +38,7 @@ import type {
   ResourceContextV1,
   ResourceContextV2,
 } from "./resource";
-import { defaultResourceHandler } from "./resource";
+import { defaultResourceHandler, type ResourceContextMPP } from "./resource";
 
 /**
  * Type guard to check if a middleware context is v1.
@@ -422,6 +422,12 @@ export class TestHarness {
     let ctx: ResourceContext;
 
     if (context.protocolVersion === "mpp") {
+      let verifyReceipt: ResourceContextMPP["verifyReceipt"];
+      if (this.settleMode === "verify-then-settle" && context.verify) {
+        const verifyResult = await context.verify();
+        if (!verifyResult.success) return verifyResult.errorResponse;
+        verifyReceipt = verifyResult.receipt;
+      }
       const settleResult = await context.settle();
       if (!settleResult.success) return settleResult.errorResponse;
 
@@ -431,6 +437,7 @@ export class TestHarness {
         request: c.req.raw,
         credential: context.credential,
         receipt: settleResult.receipt,
+        verifyReceipt,
       };
     } else if (isV1Context(context)) {
       let verifyResponse: ResourceContextV1["verifyResponse"];

--- a/packages/test-harness/src/harness/resource.ts
+++ b/packages/test-harness/src/harness/resource.ts
@@ -49,6 +49,7 @@ export type ResourceContextMPP = ResourceContextBase & {
   protocolVersion: "mpp";
   credential: mppCredential;
   receipt: mppReceipt;
+  verifyReceipt?: mppReceipt | undefined;
 };
 
 /**

--- a/packages/test-harness/src/scheme/mpp.ts
+++ b/packages/test-harness/src/scheme/mpp.ts
@@ -48,12 +48,14 @@ export type CreateTestMPPHandlerOpts = {
   method?: string;
   realm?: string;
   intents?: string[];
+  supportsVerify?: boolean;
   onChallenge?: (
     intent: string,
     pricing: ResourcePricing,
     resourceURL: string,
   ) => void;
   onSettle?: (credential: mppCredential) => void;
+  onVerify?: (credential: mppCredential) => void;
 };
 
 export function createTestMPPHandler(
@@ -64,7 +66,9 @@ export function createTestMPPHandler(
   const intents = opts.intents ?? [TEST_MPP_INTENT];
   const challengeStore = new Map<string, boolean>();
 
-  return {
+  const supportsVerify = opts.supportsVerify ?? false;
+
+  const handler: MPPMethodHandler = {
     method,
     capabilities: {
       networks: [],
@@ -116,6 +120,27 @@ export function createTestMPPHandler(
       };
     },
   };
+
+  if (supportsVerify) {
+    handler.handleVerify = async (credential) => {
+      opts.onVerify?.(credential);
+
+      if (credential.challenge.method !== method) return null;
+
+      if (!challengeStore.has(credential.challenge.id)) {
+        throw new Error("unknown challenge ID");
+      }
+
+      return {
+        status: "success" as const,
+        method,
+        timestamp: new Date().toISOString(),
+        reference: `test-verify-${Date.now()}`,
+      };
+    };
+  }
+
+  return handler;
 }
 
 export type CreateTestMPPPaymentHandlerOpts = {

--- a/packages/types/src/mpp/handler.test.ts
+++ b/packages/types/src/mpp/handler.test.ts
@@ -1,0 +1,191 @@
+#!/usr/bin/env pnpm tsx
+
+import t from "tap";
+import type { MPPMethodHandler } from "./handler";
+import { settleMPPPayment, verifyMPPPayment } from "./handler";
+import type { mppCredential, mppReceipt } from "./types";
+
+function makeCredential(method: string): mppCredential {
+  return {
+    challenge: {
+      id: "test-id",
+      realm: "test-realm",
+      method,
+      intent: "charge",
+      request: btoa(JSON.stringify({ amount: "100", currency: "USD" })),
+    },
+    payload: { type: "transaction", transaction: "dGVzdA" },
+  };
+}
+
+function makeReceipt(method: string, ref: string): mppReceipt {
+  return {
+    status: "success",
+    method,
+    timestamp: new Date().toISOString(),
+    reference: ref,
+  };
+}
+
+function makeHandler(
+  method: string,
+  opts?: {
+    settleResult?: mppReceipt | null;
+    verifyResult?: mppReceipt | null;
+    hasVerify?: boolean;
+  },
+): MPPMethodHandler {
+  const handler: MPPMethodHandler = {
+    method,
+    capabilities: { networks: [], assets: [] },
+    getSupportedIntents: () => ["charge"],
+    getChallenge: async () => ({
+      id: "c",
+      realm: "r",
+      method,
+      intent: "charge",
+      request: "req",
+    }),
+    handleSettle: async () => opts?.settleResult ?? null,
+  };
+  if (opts?.hasVerify !== false) {
+    handler.handleVerify = async () => opts?.verifyResult ?? null;
+  }
+  return handler;
+}
+
+await t.test("settleMPPPayment", async (t) => {
+  await t.test("routes to matching handler and returns receipt", async (t) => {
+    const receipt = makeReceipt("solana", "tx-1");
+    const handler = makeHandler("solana", { settleResult: receipt });
+    const result = await settleMPPPayment([handler], makeCredential("solana"));
+    t.matchOnly(result, receipt);
+    t.end();
+  });
+
+  await t.test(
+    "throws when no handler matches the credential method",
+    async (t) => {
+      const handler = makeHandler("ethereum", {
+        settleResult: makeReceipt("ethereum", "tx-1"),
+      });
+      await t.rejects(settleMPPPayment([handler], makeCredential("solana")), {
+        message: 'no MPP handler accepted settlement for method "solana"',
+      });
+      t.end();
+    },
+  );
+
+  await t.test("throws when all matching handlers return null", async (t) => {
+    const h1 = makeHandler("solana", { settleResult: null });
+    const h2 = makeHandler("solana", { settleResult: null });
+    await t.rejects(settleMPPPayment([h1, h2], makeCredential("solana")), {
+      message: 'no MPP handler accepted settlement for method "solana"',
+    });
+    t.end();
+  });
+
+  await t.test("throws when handler list is empty", async (t) => {
+    await t.rejects(settleMPPPayment([], makeCredential("solana")), {
+      message: 'no MPP handler accepted settlement for method "solana"',
+    });
+    t.end();
+  });
+
+  await t.test(
+    "returns first non-null result from multiple candidates",
+    async (t) => {
+      const expected = makeReceipt("solana", "tx-second");
+      const h1 = makeHandler("solana", { settleResult: null });
+      const h2 = makeHandler("solana", { settleResult: expected });
+      const result = await settleMPPPayment([h1, h2], makeCredential("solana"));
+      t.matchOnly(result, expected);
+      t.end();
+    },
+  );
+
+  t.end();
+});
+
+await t.test("verifyMPPPayment", async (t) => {
+  await t.test("routes to matching handler and returns receipt", async (t) => {
+    const receipt = makeReceipt("solana", "verify-1");
+    const handler = makeHandler("solana", { verifyResult: receipt });
+    const result = await verifyMPPPayment([handler], makeCredential("solana"));
+    t.matchOnly(result, receipt);
+    t.end();
+  });
+
+  await t.test(
+    "throws when no handler supports verification for the method",
+    async (t) => {
+      const handler = makeHandler("solana", { hasVerify: false });
+      await t.rejects(verifyMPPPayment([handler], makeCredential("solana")), {
+        message: 'no MPP handler supports verification for method "solana"',
+      });
+      t.end();
+    },
+  );
+
+  await t.test(
+    "throws when verify-capable handler exists for a different method",
+    async (t) => {
+      const handler = makeHandler("ethereum", {
+        verifyResult: makeReceipt("ethereum", "verify-1"),
+      });
+      await t.rejects(verifyMPPPayment([handler], makeCredential("solana")), {
+        message: 'no MPP handler supports verification for method "solana"',
+      });
+      t.end();
+    },
+  );
+
+  await t.test(
+    "throws when all verify-capable handlers return null",
+    async (t) => {
+      const h1 = makeHandler("solana", { verifyResult: null });
+      const h2 = makeHandler("solana", { verifyResult: null });
+      await t.rejects(verifyMPPPayment([h1, h2], makeCredential("solana")), {
+        message: 'no MPP handler accepted verification for method "solana"',
+      });
+      t.end();
+    },
+  );
+
+  await t.test("throws when handler list is empty", async (t) => {
+    await t.rejects(verifyMPPPayment([], makeCredential("solana")), {
+      message: 'no MPP handler supports verification for method "solana"',
+    });
+    t.end();
+  });
+
+  await t.test(
+    "skips handlers without handleVerify even if method matches",
+    async (t) => {
+      const noVerify = makeHandler("solana", { hasVerify: false });
+      const withVerify = makeHandler("solana", {
+        verifyResult: makeReceipt("solana", "verify-2"),
+      });
+      const result = await verifyMPPPayment(
+        [noVerify, withVerify],
+        makeCredential("solana"),
+      );
+      t.equal(result.reference, "verify-2");
+      t.end();
+    },
+  );
+
+  await t.test(
+    "returns first non-null result from multiple candidates",
+    async (t) => {
+      const expected = makeReceipt("solana", "verify-second");
+      const h1 = makeHandler("solana", { verifyResult: null });
+      const h2 = makeHandler("solana", { verifyResult: expected });
+      const result = await verifyMPPPayment([h1, h2], makeCredential("solana"));
+      t.matchOnly(result, expected);
+      t.end();
+    },
+  );
+
+  t.end();
+});

--- a/packages/types/src/mpp/handler.ts
+++ b/packages/types/src/mpp/handler.ts
@@ -24,6 +24,7 @@ export interface MPPMethodHandler {
     opts?: ChallengeOpts,
   ): Promise<mppChallengeParams>;
   handleSettle(credential: mppCredential): Promise<mppReceipt | null>;
+  handleVerify?(credential: mppCredential): Promise<mppReceipt | null>;
 }
 
 /**
@@ -124,4 +125,39 @@ export async function settleMPPPayment(
   }
 
   throw new Error(`no MPP handler accepted settlement for method "${method}"`);
+}
+
+/**
+ * Routes an MPP credential to the appropriate handler for verification.
+ *
+ * Filters handlers by exact method match and presence of handleVerify,
+ * then iterates until one returns a non-null result.
+ */
+export async function verifyMPPPayment(
+  handlers: MPPMethodHandler[],
+  credential: mppCredential,
+): Promise<mppReceipt> {
+  const method = credential.challenge.method;
+  const candidates = handlers.filter(
+    (
+      h,
+    ): h is MPPMethodHandler & {
+      handleVerify: NonNullable<MPPMethodHandler["handleVerify"]>;
+    } => h.method === method && h.handleVerify !== undefined,
+  );
+
+  if (candidates.length === 0) {
+    throw new Error(
+      `no MPP handler supports verification for method "${method}"`,
+    );
+  }
+
+  for (const handler of candidates) {
+    const result = await handler.handleVerify(credential);
+    if (result) return result;
+  }
+
+  throw new Error(
+    `no MPP handler accepted verification for method "${method}"`,
+  );
 }

--- a/tests/openapi-nginx/nginx-sidecar.test.ts
+++ b/tests/openapi-nginx/nginx-sidecar.test.ts
@@ -549,7 +549,7 @@ await t.test("nginx sidecar integration", async (t) => {
       // Log phase still fires for capture telemetry.
       await cb.awaitCapture("POST /v1/images/generations");
       const cap = requireCapture(cb, "POST /v1/images/generations");
-      t.equal(cap.captured, true);
+      t.equal(cap.phase, "request");
       t.equal(cap.settled, true);
       t.equal(cap.amount.usdc, "1");
       t.end();
@@ -600,7 +600,7 @@ await t.test("nginx sidecar integration", async (t) => {
       t.equal(cb.x402SettleRecords[0]?.requirementsAmount, "30");
 
       const cap = requireCapture(cb, "POST /v1/chat/completions");
-      t.equal(cap.captured, true);
+      t.equal(cap.phase, "response");
       t.equal(cap.amount.usdc, "30");
       t.end();
     },
@@ -628,7 +628,7 @@ await t.test("nginx sidecar integration", async (t) => {
       t.ok(cb.x402SettleCount > 0, "settle must fire in log phase");
 
       const cap = requireCapture(cb, "POST /v1/chat/stream");
-      t.equal(cap.captured, true);
+      t.equal(cap.phase, "response");
       t.equal(cap.amount.usdc, "30");
       t.end();
     },
@@ -658,28 +658,29 @@ await t.test("nginx sidecar integration", async (t) => {
     t.end();
   });
 
-  // -- MPP: settles at access --
+  // -- MPP: one-phase settle at access --
 
   await t.test(
-    "MPP payment flow: 402 -> credential -> settle -> 200",
+    "MPP one-phase: settle at access via credential on images route",
     async (t) => {
       cb.reset();
-      const res = await mppFetch(`${NGINX_BASE}/v1/chat/completions`, {
+      const res = await mppFetch(`${NGINX_BASE}/v1/images/generations`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ model: "gpt-3.5", messages: [] }),
+        body: JSON.stringify({ prompt: "a cat" }),
       });
 
       t.equal(res.status, 200);
       t.ok(cb.mppSettleCount > 0, "MPP settle must fire");
 
-      const body = (await res.json()) as { object: string };
-      t.equal(body.object, "chat.completion");
+      const body = (await res.json()) as { data: unknown[] };
+      t.ok(Array.isArray(body.data));
 
-      await cb.awaitCapture("POST /v1/chat/completions");
-      const cap = requireCapture(cb, "POST /v1/chat/completions");
-      t.equal(cap.captured, true);
-      t.equal(cap.amount.usdc, "30");
+      await cb.awaitCapture("POST /v1/images/generations");
+      const cap = requireCapture(cb, "POST /v1/images/generations");
+      t.equal(cap.phase, "request");
+      t.equal(cap.settled, true);
+      t.equal(cap.amount.usdc, "1");
       t.end();
     },
   );
@@ -933,7 +934,7 @@ await t.test("nginx sidecar integration", async (t) => {
       // Wait for the async log-phase capture (timer-deferred).
       await cb.awaitCapture("GET /v1/ws/chat");
       const cap = requireCapture(cb, "GET /v1/ws/chat");
-      t.equal(cap.captured, true);
+      t.equal(cap.phase, "response");
       t.equal(cap.amount.usdc, "25", "capture from WebSocket frame");
       t.end();
     },

--- a/tests/openapi/pricing-settlement.test.ts
+++ b/tests/openapi/pricing-settlement.test.ts
@@ -3,13 +3,26 @@
 import t from "tap";
 import {
   createTestFacilitatorHandler,
+  createTestMPPHandler,
+  createTestMPPPaymentHandler,
   TEST_SCHEME,
   TEST_NETWORK,
   TEST_ASSET,
   generateTestId,
 } from "@faremeter/test-harness";
+import {
+  parseWWWAuthenticate,
+  serializeCredential,
+} from "@faremeter/types/mpp";
 import { createGatewayHandler } from "@faremeter/middleware-openapi";
-import type { Asset, FaremeterSpec } from "@faremeter/middleware-openapi";
+import type {
+  Asset,
+  AuthorizeResponse,
+  CaptureResponse,
+  EvalTrace,
+  FaremeterSpec,
+  PricingRule,
+} from "@faremeter/middleware-openapi";
 
 const OP = "POST /v1/chat/completions";
 const PAY_TO = "test-receiver";
@@ -100,7 +113,7 @@ await t.test("openapi gateway: pricing settlement", async (t) => {
       const result = await handler.handleResponse(
         makeResponsePayload(100, "100"),
       );
-      t.equal(result.settled, true, "sanity: harness wiring works");
+      t.equal(result.status, 200, "sanity: harness wiring works");
       t.end();
     },
   );
@@ -131,8 +144,7 @@ await t.test("openapi gateway: pricing settlement", async (t) => {
         makeResponsePayload(50, "100"),
       );
 
-      t.equal(result.captured, true, "capture fires");
-      t.equal(result.settled, true, "partial settlement must succeed");
+      t.equal(result.status, 200, "partial settlement must succeed");
       t.end();
     },
   );
@@ -249,12 +261,19 @@ await t.test("openapi gateway: pricing settlement", async (t) => {
       // less than the actual cost: signed hold is 50 but capture
       // is 100 → settlement exceeds the signed hold → facilitator
       // rejects.
+      const captureCalls: {
+        operationKey: string;
+        result: CaptureResponse;
+      }[] = [];
       const spec = makeSpec("100", "100");
       const handler = createGatewayHandler({
         spec,
         baseURL: BASE_URL,
         supportedVersions: { x402v1: false, x402v2: true },
         x402Handlers: [createTestFacilitatorHandler({ payTo: PAY_TO })],
+        onCapture: (operationKey, result) => {
+          captureCalls.push({ operationKey, result });
+        },
       });
 
       const result = await handler.handleResponse({
@@ -272,10 +291,16 @@ await t.test("openapi gateway: pricing settlement", async (t) => {
         },
       });
 
-      t.equal(result.settled, false);
-      t.ok(
-        result.error !== undefined,
-        "CaptureResponse must carry the facilitator's error reason when settlement fails",
+      t.equal(result.status, 500);
+      t.equal(
+        captureCalls.length,
+        1,
+        "onCapture must fire on settlement failure",
+      );
+      t.match(
+        captureCalls[0]?.result.error,
+        { status: Number },
+        "error must be populated with a status when settlement fails",
       );
       t.end();
     },
@@ -372,7 +397,7 @@ await t.test("openapi gateway: pricing settlement", async (t) => {
         1,
         "no additional settle call at /response for one-phase",
       );
-      t.equal(result.captured, true, "capture telemetry still fires");
+      t.equal(result.status, 200, "handleResponse returns 200 for one-phase");
       t.end();
     },
   );
@@ -467,7 +492,1189 @@ await t.test("openapi gateway: pricing settlement", async (t) => {
         "50",
         "settlement must use the captured amount (actual cost)",
       );
-      t.equal(result.settled, true, "settlement must succeed");
+      t.equal(result.status, 200, "settlement must succeed");
+      t.end();
+    },
+  );
+
+  await t.test(
+    "onAuthorize fires on successful two-phase verification with correct shape",
+    async (t) => {
+      const authorizeCalls: {
+        operationKey: string;
+        result: AuthorizeResponse;
+      }[] = [];
+      const spec = makeSpec("100", "$.response.body.usage.total_tokens");
+      const handler = createGatewayHandler({
+        spec,
+        baseURL: BASE_URL,
+        supportedVersions: { x402v1: false, x402v2: true },
+        x402Handlers: [
+          createTestFacilitatorHandler({
+            payTo: PAY_TO,
+            amountPolicy: holdAndSettle,
+          }),
+        ],
+        onAuthorize: (operationKey, result) => {
+          authorizeCalls.push({ operationKey, result });
+        },
+      });
+
+      const reqResult = await handler.handleRequest({
+        operationKey: OP,
+        method: "POST",
+        path: "/v1/chat/completions",
+        headers: { "PAYMENT-SIGNATURE": makeV2PaymentHeader("100") },
+        query: {},
+        body: { model: "gpt-4o" },
+      });
+
+      t.equal(reqResult.status, 200, "request with valid payment must pass");
+      t.equal(authorizeCalls.length, 1, "onAuthorize must fire exactly once");
+      t.equal(
+        authorizeCalls[0]?.operationKey,
+        OP,
+        "operationKey must match the request",
+      );
+      t.match(
+        authorizeCalls[0]?.result,
+        { protocol: "x402v2", verification: { isValid: true } },
+        "result must be x402v2 with successful verification",
+      );
+      t.end();
+    },
+  );
+
+  await t.test(
+    "onAuthorize does not fire when verification fails",
+    async (t) => {
+      const authorizeCalls: unknown[] = [];
+      const spec = makeSpec("100", "$.response.body.usage.total_tokens");
+      const handler = createGatewayHandler({
+        spec,
+        baseURL: BASE_URL,
+        supportedVersions: { x402v1: false, x402v2: true },
+        x402Handlers: [createTestFacilitatorHandler({ payTo: PAY_TO })],
+        onAuthorize: (_operationKey, result) => {
+          authorizeCalls.push(result);
+        },
+      });
+
+      // Payment signed for "50" but the authorize expression evaluates
+      // to "100": the facilitator rejects with isValid=false → 402.
+      const reqResult = await handler.handleRequest({
+        operationKey: OP,
+        method: "POST",
+        path: "/v1/chat/completions",
+        headers: { "PAYMENT-SIGNATURE": makeV2PaymentHeader("50") },
+        query: {},
+        body: { model: "gpt-4o" },
+      });
+
+      t.not(
+        reqResult.status,
+        200,
+        "request with invalid payment must not pass",
+      );
+      t.equal(authorizeCalls.length, 0, "onAuthorize must not fire on failure");
+      t.end();
+    },
+  );
+
+  await t.test(
+    "onAuthorize does not fire for one-phase capture-only rules",
+    async (t) => {
+      const authorizeCalls: unknown[] = [];
+      const onePhaseSpec: FaremeterSpec = {
+        assets: TEST_SPEC_ASSETS,
+        operations: {
+          [OP]: {
+            method: "POST",
+            path: "/v1/chat/completions",
+            transport: "json",
+            rates: { test: 1n },
+            rules: [{ match: "$", capture: "42" }],
+          },
+        },
+      };
+      const handler = createGatewayHandler({
+        spec: onePhaseSpec,
+        baseURL: BASE_URL,
+        supportedVersions: { x402v1: false, x402v2: true },
+        x402Handlers: [createTestFacilitatorHandler({ payTo: PAY_TO })],
+        onAuthorize: (_operationKey, result) => {
+          authorizeCalls.push(result);
+        },
+      });
+
+      const reqResult = await handler.handleRequest({
+        operationKey: OP,
+        method: "POST",
+        path: "/v1/chat/completions",
+        headers: { "PAYMENT-SIGNATURE": makeV2PaymentHeader("42") },
+        query: {},
+        body: { model: "gpt-4o" },
+      });
+
+      t.equal(reqResult.status, 200, "one-phase paid request must pass");
+      t.equal(
+        authorizeCalls.length,
+        0,
+        "onAuthorize must not fire for one-phase rules",
+      );
+      t.end();
+    },
+  );
+
+  await t.test(
+    "onCapture receives payment with correct shape after two-phase settlement",
+    async (t) => {
+      const captureCalls: {
+        operationKey: string;
+        result: CaptureResponse;
+      }[] = [];
+      const spec = makeSpec("100", "$.response.body.usage.total_tokens");
+      const handler = createGatewayHandler({
+        spec,
+        baseURL: BASE_URL,
+        supportedVersions: { x402v1: false, x402v2: true },
+        x402Handlers: [
+          createTestFacilitatorHandler({
+            payTo: PAY_TO,
+            amountPolicy: holdAndSettle,
+          }),
+        ],
+        onCapture: (operationKey, result) => {
+          captureCalls.push({ operationKey, result });
+        },
+      });
+
+      // /request: verify the hold (authorize), no settlement yet.
+      const reqResult = await handler.handleRequest({
+        operationKey: OP,
+        method: "POST",
+        path: "/v1/chat/completions",
+        headers: { "PAYMENT-SIGNATURE": makeV2PaymentHeader("100") },
+        query: {},
+        body: { model: "gpt-4o" },
+      });
+      t.equal(reqResult.status, 200, "request with valid payment must pass");
+      t.equal(
+        captureCalls.length,
+        0,
+        "onCapture must not fire at /request for two-phase rules",
+      );
+
+      // /response: settle the captured amount.
+      const result = await handler.handleResponse(
+        makeResponsePayload(75, "100"),
+      );
+      t.equal(result.status, 200, "two-phase settlement must succeed");
+      t.equal(captureCalls.length, 1, "onCapture must fire exactly once");
+      t.equal(
+        captureCalls[0]?.operationKey,
+        OP,
+        "operationKey must match the request",
+      );
+      t.match(
+        captureCalls[0]?.result,
+        {
+          phase: "response",
+          settled: true,
+          payment: {
+            protocol: "x402v2",
+            settlement: { success: true },
+          },
+        },
+        "result must have phase=response, settled=true, and x402v2 payment",
+      );
+      t.notOk(
+        captureCalls[0]?.result.error,
+        "error must not be present on successful settlement",
+      );
+      t.end();
+    },
+  );
+
+  await t.test(
+    "onCapture receives payment with correct shape after one-phase settlement",
+    async (t) => {
+      const captureCalls: {
+        operationKey: string;
+        result: CaptureResponse;
+      }[] = [];
+      const onePhaseSpec: FaremeterSpec = {
+        assets: TEST_SPEC_ASSETS,
+        operations: {
+          [OP]: {
+            method: "POST",
+            path: "/v1/chat/completions",
+            transport: "json",
+            rates: { test: 1n },
+            rules: [{ match: "$", capture: "42" }],
+          },
+        },
+      };
+      const handler = createGatewayHandler({
+        spec: onePhaseSpec,
+        baseURL: BASE_URL,
+        supportedVersions: { x402v1: false, x402v2: true },
+        x402Handlers: [createTestFacilitatorHandler({ payTo: PAY_TO })],
+        onCapture: (operationKey, result) => {
+          captureCalls.push({ operationKey, result });
+        },
+      });
+
+      // /request: one-phase rule — settle immediately at /request.
+      const reqResult = await handler.handleRequest({
+        operationKey: OP,
+        method: "POST",
+        path: "/v1/chat/completions",
+        headers: { "PAYMENT-SIGNATURE": makeV2PaymentHeader("42") },
+        query: {},
+        body: { model: "gpt-4o" },
+      });
+      t.equal(reqResult.status, 200, "one-phase paid request must pass");
+      t.equal(captureCalls.length, 1, "onCapture must fire at /request");
+      t.equal(
+        captureCalls[0]?.operationKey,
+        OP,
+        "operationKey must match the request",
+      );
+      t.match(
+        captureCalls[0]?.result,
+        {
+          phase: "request",
+          settled: true,
+          payment: {
+            protocol: "x402v2",
+            settlement: { success: true },
+          },
+        },
+        "result must have phase=request, settled=true, and x402v2 payment",
+      );
+      t.end();
+    },
+  );
+
+  await t.test(
+    "onCapture payment is absent when settlement fails",
+    async (t) => {
+      const captureCalls: {
+        operationKey: string;
+        result: CaptureResponse;
+      }[] = [];
+      // authorize=100, capture=100. The payment header is signed for
+      // 50, which is less than the capture amount of 100. The test
+      // facilitator rejects the settlement and returns success=false.
+      const spec = makeSpec("100", "100");
+      const handler = createGatewayHandler({
+        spec,
+        baseURL: BASE_URL,
+        supportedVersions: { x402v1: false, x402v2: true },
+        x402Handlers: [createTestFacilitatorHandler({ payTo: PAY_TO })],
+        onCapture: (operationKey, result) => {
+          captureCalls.push({ operationKey, result });
+        },
+      });
+
+      const result = await handler.handleResponse({
+        operationKey: OP,
+        method: "POST",
+        path: "/v1/chat/completions",
+        // Signed for 50 but capture expression evaluates to 100.
+        headers: { "PAYMENT-SIGNATURE": makeV2PaymentHeader("50") },
+        query: {},
+        body: { model: "gpt-4o" },
+        response: {
+          status: 200,
+          headers: {},
+          body: { usage: { total_tokens: 100 } },
+        },
+      });
+
+      t.equal(result.status, 500, "failed settlement must return 500");
+      t.equal(
+        captureCalls.length,
+        1,
+        "onCapture must fire even when settlement fails",
+      );
+      t.equal(
+        captureCalls[0]?.result.settled,
+        false,
+        "settled must be false when settlement fails",
+      );
+      t.notOk(
+        captureCalls[0]?.result.payment,
+        "payment must be absent when settlement fails",
+      );
+      t.ok(
+        captureCalls[0]?.result.error,
+        "error must be present when settlement fails",
+      );
+      t.end();
+    },
+  );
+
+  await t.test(
+    "zero capture on two-phase rule settles without calling facilitator",
+    async (t) => {
+      // authorize: 100, capture: 0. The capture expression evaluates
+      // to zero at /response time. toPricing drops zero-amount entries
+      // so there is nothing to settle — the handler sets
+      // paymentSettled=true without calling the facilitator.
+      const settleCalls: { amount: string }[] = [];
+      const captureCalls: {
+        operationKey: string;
+        result: CaptureResponse;
+      }[] = [];
+      const spec = makeSpec("100", "0");
+      const handler = createGatewayHandler({
+        spec,
+        baseURL: BASE_URL,
+        supportedVersions: { x402v1: false, x402v2: true },
+        x402Handlers: [
+          createTestFacilitatorHandler({
+            payTo: PAY_TO,
+            amountPolicy: holdAndSettle,
+            onSettle: (r) => {
+              settleCalls.push({ amount: r.amount });
+            },
+          }),
+        ],
+        onCapture: (operationKey, result) => {
+          captureCalls.push({ operationKey, result });
+        },
+      });
+
+      // /request: verify the hold (authorize=100).
+      const reqResult = await handler.handleRequest({
+        operationKey: OP,
+        method: "POST",
+        path: "/v1/chat/completions",
+        headers: { "PAYMENT-SIGNATURE": makeV2PaymentHeader("100") },
+        query: {},
+        body: { model: "gpt-4o" },
+      });
+      t.equal(reqResult.status, 200, "request with valid payment must pass");
+
+      // /response: capture evaluates to 0 — no settlement needed.
+      const result = await handler.handleResponse(
+        makeResponsePayload(0, "100"),
+      );
+      t.equal(result.status, 200, "zero-capture must succeed");
+      t.equal(
+        settleCalls.length,
+        0,
+        "facilitator must not be called when capture is zero",
+      );
+      t.equal(
+        captureCalls.length,
+        0,
+        "onCapture must not fire when capture amount is zero",
+      );
+      t.end();
+    },
+  );
+
+  await t.test(
+    "onCapture trace includes authorize and capture bindings for two-phase rule",
+    async (t) => {
+      const rule: PricingRule = {
+        match: "$",
+        authorize: "$.request.body.max_tokens",
+        capture: "$.response.body.usage.total_tokens",
+      };
+      const spec: FaremeterSpec = {
+        assets: TEST_SPEC_ASSETS,
+        operations: {
+          [OP]: {
+            method: "POST",
+            path: "/v1/chat/completions",
+            transport: "json",
+            rates: { test: 1n },
+            rules: [rule],
+          },
+        },
+      };
+      const traces: EvalTrace[] = [];
+      const handler = createGatewayHandler({
+        spec,
+        baseURL: BASE_URL,
+        supportedVersions: { x402v1: false, x402v2: true },
+        x402Handlers: [
+          createTestFacilitatorHandler({
+            payTo: PAY_TO,
+            amountPolicy: holdAndSettle,
+          }),
+        ],
+        onCapture: (_operationKey, result) => {
+          if (result.trace) traces.push(result.trace);
+        },
+      });
+
+      // /request: verify the hold (authorize = max_tokens = 100).
+      await handler.handleRequest({
+        operationKey: OP,
+        method: "POST",
+        path: "/v1/chat/completions",
+        headers: { "PAYMENT-SIGNATURE": makeV2PaymentHeader("100") },
+        query: {},
+        body: { model: "gpt-4o", max_tokens: 100 },
+      });
+
+      // /response: settle (capture = total_tokens = 42).
+      await handler.handleResponse({
+        operationKey: OP,
+        method: "POST",
+        path: "/v1/chat/completions",
+        headers: { "PAYMENT-SIGNATURE": makeV2PaymentHeader("100") },
+        query: {},
+        body: { model: "gpt-4o", max_tokens: 100 },
+        response: {
+          status: 200,
+          headers: {},
+          body: { usage: { total_tokens: 42 } },
+        },
+      });
+
+      t.equal(traces.length, 1, "onCapture must fire with trace");
+      if (traces[0] === undefined) throw new Error("trace missing");
+      const trace = traces[0];
+      t.equal(trace.ruleIndex, 0, "first rule matched");
+      t.matchOnly(trace.rule, rule, "rule must match the spec rule");
+      t.ok(
+        trace.authorize,
+        "authorize trace must be present for two-phase rule",
+      );
+      t.match(trace.authorize?.bindings, {
+        "$.request.body.max_tokens": 100,
+      });
+      t.equal(trace.authorize?.coefficient, 100);
+      t.ok(trace.capture, "capture trace must be present");
+      t.match(trace.capture?.bindings, {
+        "$.response.body.usage.total_tokens": 42,
+      });
+      t.equal(trace.capture?.coefficient, 42);
+      t.end();
+    },
+  );
+
+  await t.test(
+    "onCapture trace includes capture only for one-phase rule",
+    async (t) => {
+      const rule: PricingRule = {
+        match: "$",
+        capture: "42",
+      };
+      const spec: FaremeterSpec = {
+        assets: TEST_SPEC_ASSETS,
+        operations: {
+          [OP]: {
+            method: "POST",
+            path: "/v1/chat/completions",
+            transport: "json",
+            rates: { test: 1n },
+            rules: [rule],
+          },
+        },
+      };
+      const traces: EvalTrace[] = [];
+      const handler = createGatewayHandler({
+        spec,
+        baseURL: BASE_URL,
+        supportedVersions: { x402v1: false, x402v2: true },
+        x402Handlers: [createTestFacilitatorHandler({ payTo: PAY_TO })],
+        onCapture: (_operationKey, result) => {
+          if (result.trace) traces.push(result.trace);
+        },
+      });
+
+      // /request: one-phase settles immediately.
+      await handler.handleRequest({
+        operationKey: OP,
+        method: "POST",
+        path: "/v1/chat/completions",
+        headers: { "PAYMENT-SIGNATURE": makeV2PaymentHeader("42") },
+        query: {},
+        body: { model: "gpt-4o" },
+      });
+
+      t.equal(traces.length, 1, "onCapture must fire with trace");
+      if (traces[0] === undefined) throw new Error("trace missing");
+      const trace = traces[0];
+      t.equal(trace.ruleIndex, 0);
+      t.matchOnly(trace.rule, rule);
+      t.equal(
+        trace.authorize,
+        undefined,
+        "no authorize trace for capture-only rule",
+      );
+      t.ok(trace.capture);
+      t.equal(trace.capture?.coefficient, 42);
+      t.end();
+    },
+  );
+
+  await t.test(
+    "a thrown onAuthorize callback does not corrupt the gateway response",
+    async (t) => {
+      const spec = makeSpec("100", "$.response.body.usage.total_tokens");
+      const handler = createGatewayHandler({
+        spec,
+        baseURL: BASE_URL,
+        supportedVersions: { x402v1: false, x402v2: true },
+        x402Handlers: [
+          createTestFacilitatorHandler({
+            payTo: PAY_TO,
+            amountPolicy: holdAndSettle,
+          }),
+        ],
+        onAuthorize: () => {
+          throw new Error("intentional onAuthorize error");
+        },
+      });
+
+      const reqResult = await handler.handleRequest({
+        operationKey: OP,
+        method: "POST",
+        path: "/v1/chat/completions",
+        headers: { "PAYMENT-SIGNATURE": makeV2PaymentHeader("100") },
+        query: {},
+        body: { model: "gpt-4o" },
+      });
+
+      t.equal(
+        reqResult.status,
+        200,
+        "thrown onAuthorize must not corrupt the response",
+      );
+      t.end();
+    },
+  );
+
+  await t.test(
+    "a thrown onCapture callback does not corrupt the gateway response",
+    async (t) => {
+      const spec = makeSpec("100", "$.response.body.usage.total_tokens");
+      const handler = createGatewayHandler({
+        spec,
+        baseURL: BASE_URL,
+        supportedVersions: { x402v1: false, x402v2: true },
+        x402Handlers: [
+          createTestFacilitatorHandler({
+            payTo: PAY_TO,
+            amountPolicy: holdAndSettle,
+          }),
+        ],
+        onCapture: () => {
+          throw new Error("intentional onCapture error");
+        },
+      });
+
+      const reqResult = await handler.handleRequest({
+        operationKey: OP,
+        method: "POST",
+        path: "/v1/chat/completions",
+        headers: { "PAYMENT-SIGNATURE": makeV2PaymentHeader("100") },
+        query: {},
+        body: { model: "gpt-4o" },
+      });
+      t.equal(reqResult.status, 200, "request with valid payment must pass");
+
+      const result = await handler.handleResponse(
+        makeResponsePayload(75, "100"),
+      );
+      t.equal(
+        result.status,
+        200,
+        "thrown onCapture must not corrupt the response",
+      );
+      t.end();
+    },
+  );
+
+  await t.test(
+    "async onAuthorize rejection does not leak an unhandled rejection",
+    async (t) => {
+      const spec = makeSpec("100", "$.response.body.usage.total_tokens");
+      const rejections: unknown[] = [];
+      const listener = (reason: unknown) => {
+        rejections.push(reason);
+      };
+      process.on("unhandledRejection", listener);
+      try {
+        const handler = createGatewayHandler({
+          spec,
+          baseURL: BASE_URL,
+          supportedVersions: { x402v1: false, x402v2: true },
+          x402Handlers: [
+            createTestFacilitatorHandler({
+              payTo: PAY_TO,
+              amountPolicy: holdAndSettle,
+            }),
+          ],
+          onAuthorize: (() => {
+            return Promise.reject(new Error("async hook rejection"));
+          }) as (key: string, result: AuthorizeResponse) => void,
+        });
+
+        const reqResult = await handler.handleRequest({
+          operationKey: OP,
+          method: "POST",
+          path: "/v1/chat/completions",
+          headers: { "PAYMENT-SIGNATURE": makeV2PaymentHeader("100") },
+          query: {},
+          body: { model: "gpt-4o" },
+        });
+        t.equal(
+          reqResult.status,
+          200,
+          "request must succeed despite async hook",
+        );
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        t.equal(
+          rejections.length,
+          0,
+          "async onAuthorize must not leak unhandled rejections",
+        );
+      } finally {
+        process.off("unhandledRejection", listener);
+      }
+      t.end();
+    },
+  );
+
+  await t.test(
+    "async onCapture rejection does not leak an unhandled rejection",
+    async (t) => {
+      const spec = makeSpec("100", "$.response.body.usage.total_tokens");
+      const rejections: unknown[] = [];
+      const listener = (reason: unknown) => {
+        rejections.push(reason);
+      };
+      process.on("unhandledRejection", listener);
+      try {
+        const handler = createGatewayHandler({
+          spec,
+          baseURL: BASE_URL,
+          supportedVersions: { x402v1: false, x402v2: true },
+          x402Handlers: [
+            createTestFacilitatorHandler({
+              payTo: PAY_TO,
+              amountPolicy: holdAndSettle,
+            }),
+          ],
+          onCapture: (() => {
+            return Promise.reject(new Error("async hook rejection"));
+          }) as (key: string, result: CaptureResponse) => void,
+        });
+
+        const reqResult = await handler.handleRequest({
+          operationKey: OP,
+          method: "POST",
+          path: "/v1/chat/completions",
+          headers: { "PAYMENT-SIGNATURE": makeV2PaymentHeader("100") },
+          query: {},
+          body: { model: "gpt-4o" },
+        });
+        t.equal(reqResult.status, 200, "request with valid payment must pass");
+
+        const result = await handler.handleResponse(
+          makeResponsePayload(75, "100"),
+        );
+        t.equal(result.status, 200, "response must succeed despite async hook");
+        // Give the event loop time for any unhandled rejection to fire.
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        t.equal(
+          rejections.length,
+          0,
+          "async onCapture must not leak unhandled rejections",
+        );
+      } finally {
+        process.off("unhandledRejection", listener);
+      }
+      t.end();
+    },
+  );
+
+  t.end();
+});
+
+await t.test("openapi gateway: MPP verify-then-settle", async (t) => {
+  await t.test(
+    "two-phase rule verifies at /request and settles at /response",
+    async (t) => {
+      const verifyCalls: unknown[] = [];
+      const settleCalls: unknown[] = [];
+      const authorizeCalls: {
+        operationKey: string;
+        result: AuthorizeResponse;
+      }[] = [];
+      const captureCalls: {
+        operationKey: string;
+        result: CaptureResponse;
+      }[] = [];
+
+      const spec: FaremeterSpec = {
+        assets: TEST_SPEC_ASSETS,
+        operations: {
+          [OP]: {
+            method: "POST",
+            path: "/v1/chat/completions",
+            transport: "json",
+            rates: { test: 1n },
+            rules: [
+              {
+                match: "$",
+                authorize: "100",
+                capture: "$.response.body.usage.total_tokens",
+              },
+            ],
+          },
+        },
+      };
+
+      const mppHandler = createTestMPPHandler({
+        supportsVerify: true,
+        onVerify: (credential) => {
+          verifyCalls.push(credential);
+        },
+        onSettle: (credential) => {
+          settleCalls.push(credential);
+        },
+      });
+
+      const handler = createGatewayHandler({
+        spec,
+        baseURL: BASE_URL,
+        mppMethodHandlers: [mppHandler],
+        onAuthorize: (operationKey, result) => {
+          authorizeCalls.push({ operationKey, result });
+        },
+        onCapture: (operationKey, result) => {
+          captureCalls.push({ operationKey, result });
+        },
+      });
+
+      // Step 1: /request without credentials — get 402 with challenge.
+      const challengeResult = await handler.handleRequest({
+        operationKey: OP,
+        method: "POST",
+        path: "/v1/chat/completions",
+        headers: {},
+        query: {},
+        body: { model: "gpt-4o" },
+      });
+      t.equal(challengeResult.status, 402, "must return 402 challenge");
+      const wwwAuth = challengeResult.headers?.["WWW-Authenticate"];
+      if (!wwwAuth) throw new Error("no WWW-Authenticate header");
+      const challenges = parseWWWAuthenticate(wwwAuth);
+      if (challenges.length === 0) throw new Error("no challenges parsed");
+
+      // Step 2: Build credential from the challenge.
+      const challenge = challenges[0];
+      if (!challenge) throw new Error("no challenge in parsed list");
+      const clientHandler = createTestMPPPaymentHandler();
+      const execer = await clientHandler(challenge);
+      if (!execer) throw new Error("client handler did not match challenge");
+      const credential = await execer.exec();
+      const authHeader = `Payment ${serializeCredential(credential)}`;
+
+      // Step 3: /request with credential — verify fires, onAuthorize fires.
+      const verifyResult = await handler.handleRequest({
+        operationKey: OP,
+        method: "POST",
+        path: "/v1/chat/completions",
+        headers: { Authorization: authHeader },
+        query: {},
+        body: { model: "gpt-4o" },
+      });
+      t.equal(verifyResult.status, 200, "verified request must pass");
+      t.equal(verifyCalls.length, 1, "handleVerify must fire once");
+      t.equal(settleCalls.length, 0, "handleSettle must not fire at /request");
+      t.equal(authorizeCalls.length, 1, "onAuthorize must fire once");
+      t.match(
+        authorizeCalls[0]?.result,
+        { protocol: "mpp", verification: { status: "success" } },
+        "onAuthorize must report mpp protocol with verification receipt",
+      );
+      t.equal(
+        captureCalls.length,
+        0,
+        "onCapture must not fire at /request for two-phase",
+      );
+
+      // Step 4: /response with credential — settle fires, onCapture fires.
+      const settleResult = await handler.handleResponse({
+        operationKey: OP,
+        method: "POST",
+        path: "/v1/chat/completions",
+        headers: { Authorization: authHeader },
+        query: {},
+        body: { model: "gpt-4o" },
+        response: {
+          status: 200,
+          headers: {},
+          body: { usage: { total_tokens: 75 } },
+        },
+      });
+      t.equal(settleResult.status, 200, "settlement must succeed");
+      t.equal(
+        settleCalls.length,
+        1,
+        "handleSettle must fire once at /response",
+      );
+      t.equal(captureCalls.length, 1, "onCapture must fire once at /response");
+      t.match(
+        captureCalls[0]?.result,
+        {
+          phase: "response",
+          settled: true,
+          payment: { protocol: "mpp" },
+        },
+        "onCapture must report mpp settlement",
+      );
+      t.end();
+    },
+  );
+
+  await t.test(
+    "MPP verify failure at /request returns 402 re-challenge",
+    async (t) => {
+      const mppHandler = createTestMPPHandler({ supportsVerify: true });
+
+      const spec: FaremeterSpec = {
+        assets: TEST_SPEC_ASSETS,
+        operations: {
+          [OP]: {
+            method: "POST",
+            path: "/v1/chat/completions",
+            transport: "json",
+            rates: { test: 1n },
+            rules: [
+              {
+                match: "$",
+                authorize: "100",
+                capture: "$.response.body.usage.total_tokens",
+              },
+            ],
+          },
+        },
+      };
+
+      const handler = createGatewayHandler({
+        spec,
+        baseURL: BASE_URL,
+        mppMethodHandlers: [mppHandler],
+      });
+
+      // Build a credential with a bogus challenge ID that the handler
+      // will not recognize. handleVerify throws "unknown challenge ID".
+      const bogusCredential = {
+        challenge: {
+          id: "nonexistent-id",
+          realm: "test-realm",
+          method: "test-solana",
+          intent: "charge",
+          request: btoa(
+            JSON.stringify({
+              amount: "100",
+              currency: "USD",
+              recipient: PAY_TO,
+            }),
+          ),
+        },
+        payload: { type: "transaction", transaction: "dGVzdA" },
+      };
+      const authHeader = `Payment ${serializeCredential(bogusCredential)}`;
+
+      const result = await handler.handleRequest({
+        operationKey: OP,
+        method: "POST",
+        path: "/v1/chat/completions",
+        headers: { Authorization: authHeader },
+        query: {},
+        body: { model: "gpt-4o" },
+      });
+
+      t.equal(result.status, 402, "failed verify must return 402 re-challenge");
+      t.ok(
+        result.headers?.["WWW-Authenticate"],
+        "must include WWW-Authenticate header for re-challenge",
+      );
+      t.end();
+    },
+  );
+
+  await t.test(
+    "MPP settlement failure propagates error message to onCapture",
+    async (t) => {
+      const captureCalls: {
+        operationKey: string;
+        result: CaptureResponse;
+      }[] = [];
+
+      const spec: FaremeterSpec = {
+        assets: TEST_SPEC_ASSETS,
+        operations: {
+          [OP]: {
+            method: "POST",
+            path: "/v1/chat/completions",
+            transport: "json",
+            rates: { test: 1n },
+            rules: [
+              {
+                match: "$",
+                authorize: "100",
+                capture: "$.response.body.usage.total_tokens",
+              },
+            ],
+          },
+        },
+      };
+
+      const mppHandler = createTestMPPHandler({ supportsVerify: true });
+
+      const handler = createGatewayHandler({
+        spec,
+        baseURL: BASE_URL,
+        mppMethodHandlers: [mppHandler],
+        onCapture: (operationKey, result) => {
+          captureCalls.push({ operationKey, result });
+        },
+      });
+
+      // Step 1: Get a challenge.
+      const challengeResult = await handler.handleRequest({
+        operationKey: OP,
+        method: "POST",
+        path: "/v1/chat/completions",
+        headers: {},
+        query: {},
+        body: { model: "gpt-4o" },
+      });
+      t.equal(challengeResult.status, 402);
+      const wwwAuth = challengeResult.headers?.["WWW-Authenticate"];
+      if (!wwwAuth) throw new Error("no WWW-Authenticate header");
+      const challenges = parseWWWAuthenticate(wwwAuth);
+      const challenge = challenges[0];
+      if (!challenge) throw new Error("no challenge parsed");
+
+      // Step 2: Build a valid credential, verify it.
+      const clientHandler = createTestMPPPaymentHandler();
+      const execer = await clientHandler(challenge);
+      if (!execer) throw new Error("client handler did not match");
+      const credential = await execer.exec();
+      const authHeader = `Payment ${serializeCredential(credential)}`;
+
+      const verifyResult = await handler.handleRequest({
+        operationKey: OP,
+        method: "POST",
+        path: "/v1/chat/completions",
+        headers: { Authorization: authHeader },
+        query: {},
+        body: { model: "gpt-4o" },
+      });
+      t.equal(verifyResult.status, 200, "verify must pass");
+
+      // Step 3: Settle once to consume the challenge ID.
+      const firstSettle = await handler.handleResponse({
+        operationKey: OP,
+        method: "POST",
+        path: "/v1/chat/completions",
+        headers: { Authorization: authHeader },
+        query: {},
+        body: { model: "gpt-4o" },
+        response: {
+          status: 200,
+          headers: {},
+          body: { usage: { total_tokens: 75 } },
+        },
+      });
+      t.equal(firstSettle.status, 200, "first settle must succeed");
+      t.equal(captureCalls.length, 1, "onCapture fires on first settle");
+
+      // Step 4: Settle again -- the challenge ID was consumed, so
+      // handleSettle throws "unknown or consumed challenge ID".
+      captureCalls.length = 0;
+      const secondSettle = await handler.handleResponse({
+        operationKey: OP,
+        method: "POST",
+        path: "/v1/chat/completions",
+        headers: { Authorization: authHeader },
+        query: {},
+        body: { model: "gpt-4o" },
+        response: {
+          status: 200,
+          headers: {},
+          body: { usage: { total_tokens: 75 } },
+        },
+      });
+      t.equal(secondSettle.status, 500, "re-settle must fail");
+      t.equal(captureCalls.length, 1, "onCapture fires on failed settle");
+
+      const error = captureCalls[0]?.result.error;
+      t.ok(error, "error must be present");
+      t.ok(error?.message, "error.message must be present");
+      t.match(
+        error?.message,
+        /unknown or consumed challenge ID/,
+        "error.message must propagate the MPP handler error",
+      );
+      t.end();
+    },
+  );
+
+  await t.test(
+    "two-phase rule with MPP handler lacking handleVerify does not double-settle",
+    async (t) => {
+      const settleCalls: unknown[] = [];
+
+      const spec: FaremeterSpec = {
+        assets: TEST_SPEC_ASSETS,
+        operations: {
+          [OP]: {
+            method: "POST",
+            path: "/v1/chat/completions",
+            transport: "json",
+            rates: { test: 1n },
+            rules: [
+              {
+                match: "$",
+                authorize: "100",
+                capture: "$.response.body.usage.total_tokens",
+              },
+            ],
+          },
+        },
+      };
+
+      const mppHandler = createTestMPPHandler({
+        onSettle: (credential) => {
+          settleCalls.push(credential);
+        },
+      });
+
+      const gatewayHandler = createGatewayHandler({
+        spec,
+        baseURL: BASE_URL,
+        mppMethodHandlers: [mppHandler],
+      });
+
+      // Step 1: Get a challenge.
+      const challengeResult = await gatewayHandler.handleRequest({
+        operationKey: OP,
+        method: "POST",
+        path: "/v1/chat/completions",
+        headers: {},
+        query: {},
+        body: { model: "gpt-4o" },
+      });
+      t.equal(challengeResult.status, 402);
+      const wwwAuth = challengeResult.headers?.["WWW-Authenticate"];
+      if (!wwwAuth) throw new Error("no WWW-Authenticate header");
+      const challenges = parseWWWAuthenticate(wwwAuth);
+      const challenge = challenges[0];
+      if (!challenge) throw new Error("no challenge parsed");
+
+      // Step 2: Build a credential and send it at /request.
+      // Without handleVerify, /request settles immediately (one-phase).
+      const clientHandler = createTestMPPPaymentHandler();
+      const execer = await clientHandler(challenge);
+      if (!execer) throw new Error("client handler did not match");
+      const credential = await execer.exec();
+      const authHeader = `Payment ${serializeCredential(credential)}`;
+
+      const reqResult = await gatewayHandler.handleRequest({
+        operationKey: OP,
+        method: "POST",
+        path: "/v1/chat/completions",
+        headers: { Authorization: authHeader },
+        query: {},
+        body: { model: "gpt-4o" },
+      });
+      t.equal(reqResult.status, 200, "one-phase settle at /request must pass");
+      t.equal(settleCalls.length, 1, "handleSettle must fire once at /request");
+
+      // Step 3: /response must not attempt settlement again.
+      const responseResult = await gatewayHandler.handleResponse({
+        operationKey: OP,
+        method: "POST",
+        path: "/v1/chat/completions",
+        headers: { Authorization: authHeader },
+        query: {},
+        body: { model: "gpt-4o" },
+        response: {
+          status: 200,
+          headers: {},
+          body: { usage: { total_tokens: 75 } },
+        },
+      });
+      t.equal(
+        responseResult.status,
+        200,
+        "/response must succeed without re-settling",
+      );
+      t.equal(
+        settleCalls.length,
+        1,
+        "handleSettle must not fire again at /response",
+      );
+      t.end();
+    },
+  );
+
+  t.end();
+});
+
+await t.test("openapi gateway: errorMessage propagation", async (t) => {
+  await t.test(
+    "x402v2 settlement failure propagates errorReason to onCapture error message",
+    async (t) => {
+      const captureCalls: {
+        operationKey: string;
+        result: CaptureResponse;
+      }[] = [];
+
+      const spec = makeSpec("100", "100");
+      const handler = createGatewayHandler({
+        spec,
+        baseURL: BASE_URL,
+        supportedVersions: { x402v1: false, x402v2: true },
+        x402Handlers: [createTestFacilitatorHandler({ payTo: PAY_TO })],
+        onCapture: (operationKey, result) => {
+          captureCalls.push({ operationKey, result });
+        },
+      });
+
+      // Signed for 50, capture evaluates to 100. The test facilitator
+      // rejects with "Amount policy rejected: settle=100, signed=50".
+      const result = await handler.handleResponse({
+        operationKey: OP,
+        method: "POST",
+        path: "/v1/chat/completions",
+        headers: { "PAYMENT-SIGNATURE": makeV2PaymentHeader("50") },
+        query: {},
+        body: { model: "gpt-4o" },
+        response: {
+          status: 200,
+          headers: {},
+          body: { usage: { total_tokens: 100 } },
+        },
+      });
+
+      t.equal(result.status, 500, "failed settlement must return 500");
+      t.equal(captureCalls.length, 1, "onCapture must fire");
+
+      const error = captureCalls[0]?.result.error;
+      t.ok(error, "error must be present");
+      t.ok(error?.message, "error.message must be present");
+      t.match(
+        error?.message,
+        /Amount policy rejected/,
+        "error.message must propagate the facilitator errorReason",
+      );
       t.end();
     },
   );


### PR DESCRIPTION
## Summary

- Add MPP verify handlers (`handleVerify` on `MPPMethodHandler`, `verifyMPPPayment` routing function) and wire verify support through the middleware and test harness, enabling two-phase payment flows for MPP
- Forward the nginx `x-request-id` header to the sidecar via request headers for request traceability
- Add `errorMessage` field to settle and verify result types (`SettleResultV1`, `SettleResultV2`, `VerifyResultV1`, `VerifyResultV2`, `SettleResultMPP`, `VerifyResultMPP`) so payment handlers can surface human-readable error reasons
- Introduce `onCapture` and `onAuthorize` hooks on `GatewayHandlerConfig`, allowing callers to observe settlement and authorization events without coupling to the gateway internals
- Fix `hasVerifyHandlers` to filter by credential method, preventing verify from being offered for handlers that match a different payment method
- Fix the sidecar `/response` endpoint to forward `handleResponse`'s status as the HTTP transport status, preserving the Lua `flush_capture` retry contract (non-2xx retries, 2xx deletes the capture buffer)
- Add `extraDirectives` support to the nginx config generator, allowing callers to inject arbitrary nginx directives into every generated location block via the programmatic API or the repeatable `--extra-directive` CLI flag
- Normalize location block indentation to a consistent four spaces

## Bug fixes

**`hasVerifyHandlers` was method-agnostic** -- the middleware checked whether *any* MPP handler had `handleVerify`, regardless of method. This caused verify to be offered for off-method handlers, which then rejected the credential, failing the payment when one-phase settlement would have succeeded.

**Sidecar `/response` always returned HTTP 200** -- `c.json(result)` without a status argument returned transport 200 even when settlement failed. The Lua `flush_capture` contract deletes the capture buffer on any 2xx, so a failed settlement silently lost the bill with no retry.

## Test plan

- [x] 2172 tests passing (`make` clean)
- [x] MPP verify routing tests cover method-match, method-mismatch, and no-verify-handler cases
- [x] Sidecar tests assert HTTP transport status matches settlement outcome
- [x] Hook tests cover `onCapture`/`onAuthorize` for x402v2 and MPP, including async rejection and verification receipt shape
- [x] `supportsVerify` defaults to `false` (opt-in); tests that need verify pass `supportsVerify: true` explicitly
- [x] Extra directives emitted in all location block types (HTTP, WebSocket, named WS upgrade)
- [x] Multi-line directives split and indented correctly
- [x] Directive ordering verified (before Lua blocks, before upgrade detection)