### PR TITLE
Add optional memo requirement to Solana exact facilitator

### DIFF
--- a/packages/payment-solana/src/exact/facilitator.ts
+++ b/packages/payment-solana/src/exact/facilitator.ts
@@ -99,6 +99,10 @@ interface FacilitatorOptions {
   // Calculated as: (CU limit * CU price in microlamports) / 1,000,000
   maxPriorityFee?: number;
   maxTransactionAge?: number;
+  // When false, accept transactions without a Memo instruction so that
+  // older clients that do not include one can still pay.  Defaults to
+  // true for spec compliance.
+  requireMemo?: boolean;
   features?: {
     enableSettlementAccounts?: boolean;
     enableDuplicateCheck?: boolean;
@@ -379,7 +383,7 @@ export const createFacilitatorHandler = async (
         requirements,
         feePayerSigner.address,
         tokenProgram,
-        maxPriorityFee,
+        { maxPriorityFee, requireMemo: config?.requireMemo ?? true },
       );
       if (!validResult) {
         logger.error("Invalid transaction");

--- a/packages/payment-solana/src/exact/verify.test.ts
+++ b/packages/payment-solana/src/exact/verify.test.ts
@@ -358,7 +358,7 @@ await t.test("isValidTransaction", async (t) => {
       f.requirements,
       f.facilitator.address,
       f.tokenProgram,
-      100_000,
+      { maxPriorityFee: 100_000 },
     );
     t.ok(result);
     t.equal(result && result.payer, f.sender.address);
@@ -385,7 +385,7 @@ await t.test("isValidTransaction", async (t) => {
           f.requirements,
           f.facilitator.address,
           f.tokenProgram,
-          100,
+          { maxPriorityFee: 100 },
         ),
         false,
       );
@@ -419,7 +419,7 @@ await t.test("isValidTransaction", async (t) => {
           f.requirements,
           f.facilitator.address,
           f.tokenProgram,
-          100,
+          { maxPriorityFee: 100 },
         ),
         false,
       );
@@ -862,6 +862,213 @@ await t.test("isValidTransaction", async (t) => {
           requirements,
           f.facilitator.address,
           f.tokenProgram,
+        ),
+        false,
+      );
+      t.end();
+    },
+  );
+
+  await t.test(
+    "rejects transaction without memo when requireMemo defaults to true",
+    async (t) => {
+      const f = await createFixtures();
+
+      // Older clients build exactly 3 instructions:
+      //   1. SetComputeUnitLimit
+      //   2. SetComputeUnitPrice
+      //   3. TransferChecked
+      // No memo instruction is included.  With requireMemo defaulting to
+      // true, the facilitator rejects these transactions.
+      const txMsg = buildTxMessage(
+        [f.computeLimitIx, f.computePriceIx, f.transferIx],
+        f.facilitator,
+      );
+
+      t.equal(
+        await isValidTransaction(
+          txMsg,
+          f.requirements,
+          f.facilitator.address,
+          f.tokenProgram,
+        ),
+        false,
+      );
+
+      t.equal(
+        await isValidTransaction(
+          txMsg,
+          f.requirements,
+          f.facilitator.address,
+          f.tokenProgram,
+          { requireMemo: true },
+        ),
+        false,
+      );
+
+      t.end();
+    },
+  );
+
+  await t.test(
+    "accepts transaction without memo when requireMemo is false",
+    async (t) => {
+      const f = await createFixtures();
+
+      const txMsg = buildTxMessage(
+        [f.computeLimitIx, f.computePriceIx, f.transferIx],
+        f.facilitator,
+      );
+
+      const result = await isValidTransaction(
+        txMsg,
+        f.requirements,
+        f.facilitator.address,
+        f.tokenProgram,
+        { requireMemo: false },
+      );
+
+      t.ok(result);
+      t.equal(result && result.payer, f.sender.address);
+      t.end();
+    },
+  );
+
+  await t.test(
+    "accepts transaction with lighthouse but no memo when requireMemo is false",
+    async (t) => {
+      const f = await createFixtures();
+
+      const txMsg = buildTxMessage(
+        [f.computeLimitIx, f.computePriceIx, f.transferIx, makeLighthouseIx()],
+        f.facilitator,
+      );
+
+      const result = await isValidTransaction(
+        txMsg,
+        f.requirements,
+        f.facilitator.address,
+        f.tokenProgram,
+        { requireMemo: false },
+      );
+
+      t.ok(result);
+      t.equal(result && result.payer, f.sender.address);
+      t.end();
+    },
+  );
+
+  await t.test(
+    "accepts transaction with memo when requireMemo is false",
+    async (t) => {
+      const f = await createFixtures();
+
+      const txMsg = buildTxMessage(
+        [f.computeLimitIx, f.computePriceIx, f.transferIx, makeMemoIx("nonce")],
+        f.facilitator,
+      );
+
+      const result = await isValidTransaction(
+        txMsg,
+        f.requirements,
+        f.facilitator.address,
+        f.tokenProgram,
+        { requireMemo: false },
+      );
+
+      t.ok(result);
+      t.equal(result && result.payer, f.sender.address);
+      t.end();
+    },
+  );
+
+  await t.test(
+    "rejects multiple memos even when requireMemo is false",
+    async (t) => {
+      const f = await createFixtures();
+
+      const txMsg = buildTxMessage(
+        [
+          f.computeLimitIx,
+          f.computePriceIx,
+          f.transferIx,
+          makeMemoIx("a"),
+          makeMemoIx("b"),
+        ],
+        f.facilitator,
+      );
+
+      t.equal(
+        await isValidTransaction(
+          txMsg,
+          f.requirements,
+          f.facilitator.address,
+          f.tokenProgram,
+          { requireMemo: false },
+        ),
+        false,
+      );
+      t.end();
+    },
+  );
+
+  await t.test(
+    "rejects memo mismatch when requireMemo is false and extra.memo is set",
+    async (t) => {
+      const f = await createFixtures();
+      const requirements = {
+        ...f.requirements,
+        extra: { ...f.requirements.extra, memo: "expected-value" },
+      };
+
+      const txMsg = buildTxMessage(
+        [
+          f.computeLimitIx,
+          f.computePriceIx,
+          f.transferIx,
+          makeMemoIx("wrong-value"),
+        ],
+        f.facilitator,
+      );
+
+      t.equal(
+        await isValidTransaction(
+          txMsg,
+          requirements,
+          f.facilitator.address,
+          f.tokenProgram,
+          { requireMemo: false },
+        ),
+        false,
+      );
+      t.end();
+    },
+  );
+
+  await t.test(
+    "rejects missing memo when requireMemo is false but extra.memo is set",
+    async (t) => {
+      const f = await createFixtures();
+      const requirements = {
+        ...f.requirements,
+        extra: { ...f.requirements.extra, memo: "invoice-789" },
+      };
+
+      // An older client cannot supply a memo instruction, so a seller
+      // that requires a specific memo value should still reject the
+      // transaction regardless of the requireMemo setting.
+      const txMsg = buildTxMessage(
+        [f.computeLimitIx, f.computePriceIx, f.transferIx],
+        f.facilitator,
+      );
+
+      t.equal(
+        await isValidTransaction(
+          txMsg,
+          requirements,
+          f.facilitator.address,
+          f.tokenProgram,
+          { requireMemo: false },
         ),
         false,
       );

--- a/packages/payment-solana/src/exact/verify.ts
+++ b/packages/payment-solana/src/exact/verify.ts
@@ -133,12 +133,17 @@ async function verifyTransferInstruction(
   return false;
 }
 
+export interface TransactionValidationOptions {
+  maxPriorityFee?: number;
+  requireMemo?: boolean;
+}
+
 export async function isValidTransaction(
   transactionMessage: CompilableTransactionMessage,
   paymentRequirements: x402PaymentRequirements,
   facilitatorAddress: string,
   tokenProgram: Address,
-  maxPriorityFee?: number,
+  options?: TransactionValidationOptions,
 ): Promise<{ payer: string } | false> {
   const extra = PaymentRequirementsExtra(paymentRequirements.extra);
   if (isValidationError(extra)) {
@@ -172,6 +177,8 @@ export async function isValidTransaction(
   if (!limitResult.valid || !priceResult.valid) {
     return false;
   }
+
+  const { maxPriorityFee, requireMemo = true } = options ?? {};
 
   if (
     maxPriorityFee !== undefined &&
@@ -210,7 +217,12 @@ export async function isValidTransaction(
 
   const memoInstructions = rest.filter(isMemoInstruction);
 
-  if (memoInstructions.length !== 1) {
+  if (memoInstructions.length > 1) {
+    logger.error("Expected at most one Memo instruction");
+    return false;
+  }
+
+  if (requireMemo && memoInstructions.length !== 1) {
     logger.error("Expected exactly one Memo instruction");
     return false;
   }
@@ -218,6 +230,7 @@ export async function isValidTransaction(
   if (extra.memo !== undefined) {
     const memoIx = memoInstructions[0];
     if (!memoIx) {
+      logger.error("extra.memo is set but no Memo instruction found");
       return false;
     }
 


### PR DESCRIPTION
## Summary

- Adds a `requireMemo` option to `FacilitatorOptions` (defaults to `true`) that controls whether the facilitator requires a Memo instruction in client transactions
- When set to `false`, older clients that do not include a memo instruction can still pay, while newer clients with memo are also accepted
- Multiple memo instructions and memo content mismatches are still rejected regardless of the setting

## Test plan

- [x] Verify transaction without memo is rejected when `requireMemo` defaults to true
- [x] Verify transaction without memo is accepted when `requireMemo` is false
- [x] Verify transaction with lighthouse but no memo is accepted when `requireMemo` is false
- [x] Verify transaction with memo is accepted when `requireMemo` is false
- [x] Verify multiple memos are rejected even when `requireMemo` is false
- [x] Verify memo content mismatch is rejected when `requireMemo` is false and `extra.memo` is set
- [x] Verify missing memo is rejected when `requireMemo` is false but `extra.memo` is set
- [x] Full `make` passes (2099 tests)