### PR TITLE
Make @logtape/logtape import opaque to bundlers so Workers apps build

### DIFF
--- a/packages/logs/src/index.test.ts
+++ b/packages/logs/src/index.test.ts
@@ -5,10 +5,18 @@ import t from "tap";
 import * as logtape from "@logtape/logtape";
 import type { Sink, LogRecord } from "@logtape/logtape";
 import { ConsoleBackend } from "./console";
-import { LogtapeBackend } from "./logtape";
+import { LogtapeBackend, isLogtapeAvailable } from "./logtape";
 import { configureApp, getLogger } from "./index";
 import type { LogArgs, Logger, LoggingBackend, LogLevel } from "./types";
 import { shouldLog, LogLevels } from "./types";
+
+await t.test(
+  "isLogtapeAvailable resolves true when logtape is installed",
+  async (t) => {
+    t.equal(await isLogtapeAvailable(), true);
+    t.end();
+  },
+);
 
 await t.test("getLogger without configureApp", async (t) => {
   const logger = await getLogger(["faremeter", "auto", "test"]);

--- a/packages/logs/src/index.ts
+++ b/packages/logs/src/index.ts
@@ -31,11 +31,14 @@ let activeBackend: LoggingBackend | null = null;
 
 async function resolveBackend() {
   try {
-    const { LogtapeBackend } = await import("./logtape");
-    return LogtapeBackend;
+    const mod = await import("./logtape");
+    if (await mod.isLogtapeAvailable()) {
+      return mod.LogtapeBackend;
+    }
   } catch {
-    return ConsoleBackend;
+    // fall through to ConsoleBackend
   }
+  return ConsoleBackend;
 }
 
 /**

--- a/packages/logs/src/logtape.ts
+++ b/packages/logs/src/logtape.ts
@@ -1,6 +1,31 @@
-import * as logtape from "@logtape/logtape";
 import type { Sink } from "@logtape/logtape";
 import type { LogArgs, LoggingBackend, LogLevel, Context } from "./types";
+
+type LogtapeModule = typeof import("@logtape/logtape");
+let logtapeCache: LogtapeModule | null = null;
+
+async function loadLogtape(): Promise<LogtapeModule> {
+  if (logtapeCache) return logtapeCache;
+  // Variable specifier keeps this import opaque to bundlers like esbuild and
+  // wrangler. Consumers that do not install @logtape/logtape (e.g. a
+  // Cloudflare Workers app using ConsoleBackend only) can still bundle
+  // @faremeter/logs without a build-time "Could not resolve" error. On any
+  // runtime without the module available, the import rejects at runtime and
+  // the caller is expected to fall back (see resolveBackend in index.ts).
+  const spec = ["@logtape", "logtape"].join("/");
+  const mod = (await import(spec)) as LogtapeModule;
+  logtapeCache = mod;
+  return mod;
+}
+
+export async function isLogtapeAvailable(): Promise<boolean> {
+  try {
+    await loadLogtape();
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 function convertArgs([msg, context]: LogArgs): [string, Context?] {
   if (context !== undefined) {
@@ -20,12 +45,17 @@ function convertArgs([msg, context]: LogArgs): [string, Context?] {
  * Provides structured logging with configurable sinks. When available,
  * this backend is preferred over {@link ConsoleBackend} for its richer
  * formatting and sink flexibility.
+ *
+ * The @logtape/logtape module is loaded lazily via a bundler-opaque dynamic
+ * import. Consumers that never use LogtapeBackend do not need the module
+ * installed and can bundle for environments like Cloudflare Workers cleanly.
  */
 export const LogtapeBackend: LoggingBackend<{
   level: LogLevel;
   sink?: Sink;
 }> = {
   async configureApp(args: { level: LogLevel; sink?: Sink }) {
+    const logtape = await loadLogtape();
     const lowestLevel = args.level;
 
     await logtape.configure({
@@ -42,7 +72,14 @@ export const LogtapeBackend: LoggingBackend<{
   },
 
   getLogger(subsystem: readonly string[]) {
-    const impl = logtape.getLogger(subsystem);
+    if (!logtapeCache) {
+      throw new Error(
+        "LogtapeBackend.getLogger called before configureApp. " +
+          "Call await LogtapeBackend.configureApp() first, " +
+          "or install @logtape/logtape alongside @faremeter/logs.",
+      );
+    }
+    const impl = logtapeCache.getLogger(subsystem);
 
     return {
       debug: (...args) => {


### PR DESCRIPTION
## Summary

Resolves #147. `@faremeter/logs` could not be bundled for Cloudflare Workers unless `@logtape/logtape` was also installed, even when the consumer only used `ConsoleBackend`. The static `import * as logtape from "@logtape/logtape"` at the top of `src/logtape.ts` forced esbuild/wrangler to resolve the dependency at build time, and the advertised alias workaround did not help because aliasing the module does not satisfy the downstream call sites.

## Approach

- `src/logtape.ts` now loads the module through a variable specifier (`["@logtape", "logtape"].join("/")`) inside a lazy `loadLogtape()` helper. The type-only import is retained for `Sink`. Bundlers cannot statically follow the variable, so a Workers build succeeds without the module installed; on any runtime without the module, `await import()` rejects and the caller handles it.
- A new `isLogtapeAvailable()` helper performs the probe so the top-level resolver in `src/index.ts` can consult it instead of relying on the old static-import-throws path. The documented "auto-resolve to LogtapeBackend when available" contract is preserved.
- `LogtapeBackend.getLogger` now throws a clear error if called before `configureApp` on a fresh instance, replacing the previous behavior where the static `logtape` binding happened to be loaded as a side effect of import.

## Reproduction

Minimal Worker that only uses `ConsoleBackend`:

```ts
import { configureApp, getLogger } from "@faremeter/logs";

export default {
  async fetch(): Promise<Response> {
    await configureApp({ level: "info" });
    const logger = await getLogger(["repro"]);
    logger.info("hello from worker");
    return new Response("ok");
  },
};
```

Before this change: `wrangler deploy --dry-run` fails with `Could not resolve "@logtape/logtape"`.

After this change: same command reports `Total Upload: 6.58 KiB / gzip: 1.70 KiB`.

## Test plan

- [x] `pnpm tsc` in `packages/logs` compiles clean
- [x] `pnpm prettier -c packages/logs` clean
- [x] `pnpm eslint --cache packages/logs` clean
- [x] `pnpm tap --disable-coverage packages/logs/src/index.test.ts` — 81/81 pass, including new `isLogtapeAvailable` test
- [x] Reproduction Worker above bundles successfully via `wrangler deploy --dry-run`
- [x] Existing `getLogger without configureApp` test still passes, confirming auto-resolve on Node remains intact