### PR TITLE
Fix flex example cleanup and gate it behind --flex

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -74,6 +74,13 @@ Setup your environment using the [quickstart guide](./QUICKSTART.md). Then you c
 cd scripts && pnpm tsx solana-example/run-examples.ts
 ```
 
+The flex payment example is opt-in via `--flex`; it adds roughly 60 seconds
+of wall-clock wait per run for the on-chain refund window to elapse:
+
+```
+cd scripts && pnpm tsx solana-example/run-examples.ts --flex
+```
+
 #### EVM
 
 ```

--- a/scripts/solana-example/flex-payment.ts
+++ b/scripts/solana-example/flex-payment.ts
@@ -194,7 +194,7 @@ const fetchWithPayer = wrapFetch(fetch, { handlers: [handler] });
 const req = await fetchWithPayer("http://127.0.0.1:3000/protected");
 await logResponse(req);
 
-// --- Cleanup: refund pending settlements, revoke session key, close everything ---
+// --- Cleanup: refund the settlement, let the facilitator finalize it, then close everything ---
 
 // Wait for the facilitator to submit the authorization on-chain.
 for (let i = 0; i < 30; i++) {
@@ -205,6 +205,7 @@ for (let i = 0; i < 30; i++) {
 
 const pendings = await findPendingSettlementsByEscrow(rpc, escrowAddress);
 for (const pending of pendings) {
+  if (pending.account.amount === 0n) continue;
   const refundIx = getRefundInstruction({
     escrow: escrowAddress,
     facilitator,
@@ -212,6 +213,24 @@ for (const pending of pendings) {
     refundAmount: pending.account.amount,
   });
   await sendInstructions(facilitator, [refundIx]);
+}
+
+// Wait for the facilitator's auto-finalize loop to close each zero-amount
+// pending settlement; only finalize (or the deadman-gated voidPending) clears
+// pending_count on-chain. Calling finalize from here would race the facilitator
+// and leave it looping on a vanished PDA, so we just poll until the count
+// drops to zero.
+for (let i = 0; i < 120; i++) {
+  const escrow = await fetchEscrowAccount(rpc, escrowAddress);
+  if (escrow && escrow.pendingCount === 0n) break;
+  await new Promise((r) => setTimeout(r, 1000));
+}
+
+const finalEscrow = await fetchEscrowAccount(rpc, escrowAddress);
+if (!finalEscrow || finalEscrow.pendingCount !== 0n) {
+  throw new Error(
+    `pending settlements did not drain (pendingCount=${finalEscrow?.pendingCount ?? "missing"})`,
+  );
 }
 
 const revokeIx = getRevokeSessionKeyInstruction({

--- a/scripts/solana-example/run-examples.ts
+++ b/scripts/solana-example/run-examples.ts
@@ -6,11 +6,20 @@ $.verbose = true;
 const FACILITATOR_URL = "http://localhost:4000";
 const RESOURCE_SERVER_URL = "http://localhost:3000";
 
+// flex-payment.ts adds ~60s of mandatory wall-clock wait per run for the
+// on-chain refund window, so it's opt-in via --flex.
+const runFlex = process.argv.includes("--flex");
+if (!runFlex) {
+  echo("Skipping flex example (pass --flex to enable)");
+}
+
 async function runX402Payments() {
   await $`pnpm tsx solana-example/solana-exact-payment.ts`;
   await $`pnpm tsx solana-example/token2022-exact-payment.ts`;
   await $`pnpm tsx solana-example/ows-exact-payment.ts`;
-  await $`pnpm tsx solana-example/flex-payment.ts`;
+  if (runFlex) {
+    await $`pnpm tsx solana-example/flex-payment.ts`;
+  }
   // XXX - Add the Crossmint, Ledger, and Squads payments in future.
 }
 

--- a/skills/run-examples/SKILL.md
+++ b/skills/run-examples/SKILL.md
@@ -18,6 +18,10 @@ real payment flows against testnets.
 - `/run-examples solana` -- run only the Solana examples
 - `/run-examples all` or `/run-examples` (no argument) -- run both
 
+Append `--flex` to also run the Solana flex example, which is skipped by
+default because it adds ~60 seconds of mandatory wait per run for the
+on-chain refund window (e.g. `/run-examples solana --flex`).
+
 ## Execution
 
 Each suite is run via `pnpm tsx` from the `scripts/` directory with a generous
@@ -29,6 +33,9 @@ pnpm tsx evm-example/run-examples.ts
 
 # Solana examples (SOL, Squads, Token, Exact payments via Hono + Express servers)
 pnpm tsx solana-example/run-examples.ts
+
+# Solana examples including the flex example (adds ~60s for the refund window)
+pnpm tsx solana-example/run-examples.ts --flex
 ```
 
 The working directory MUST be `scripts/` (i.e., use workdir parameter).
@@ -44,10 +51,12 @@ The working directory MUST be `scripts/` (i.e., use workdir parameter).
 
 Based on `$ARGUMENTS`:
 
-- If the argument is `evm`, run only the EVM examples.
-- If the argument is `solana`, run only the Solana examples.
+- If the argument contains `evm`, run only the EVM examples.
+- If the argument contains `solana`, run only the Solana examples.
 - If the argument is `all`, empty, or omitted, run both sequentially (EVM first,
   then Solana).
+- If the argument contains `--flex`, append `--flex` to the Solana
+  invocation so the flex example is included.
 
 Report a summary of results when done (which suites passed, how many payments
 settled).


### PR DESCRIPTION
## Summary

- Drain pending settlements in the Solana flex example before closing the escrow. The refund instruction only zeros `pending.amount`; it does not close the pending PDA or decrement `pending_count`, so `close_escrow` always failed with `PendingSettlementsExist`. The script now refunds, then waits for the facilitator's auto-finalize loop to drain `pending_count` before tearing the escrow down.
- Gate the flex example behind `--flex` in `scripts/solana-example/run-examples.ts`. The flex run adds ~60 s of mandatory wall-clock wait for the on-chain refund window; the default Solana suite now skips it and prints a one-line notice. Documented in `DEV.md` and the `/run-examples` skill.

## Test plan

- [ ] `cd scripts && pnpm tsx solana-example/run-examples.ts` runs the default Solana suite (no flex) and exits 0
- [ ] `cd scripts && pnpm tsx solana-example/run-examples.ts --flex` runs the full suite including flex, and the flex example exits cleanly with the escrow closed
- [ ] `make` is green