### PR TITLE
Fmtr 465 - Sync our mpp solana charge implementation to the spec

### DIFF
--- a/packages/fetch/src/internal.ts
+++ b/packages/fetch/src/internal.ts
@@ -26,6 +26,7 @@ import { normalizeNetworkId, translateNetworkToLegacy } from "@faremeter/info";
 
 import type { MPPPaymentHandler } from "@faremeter/types/mpp";
 import {
+  parseMPPExpiresAtMs,
   parseWWWAuthenticate,
   serializeCredential,
   WWW_AUTHENTICATE_HEADER,
@@ -218,8 +219,8 @@ export async function processPaymentRequiredResponseMPP(
 
   for (const challenge of challenges) {
     if (challenge.expires !== undefined) {
-      const expiresAtMs = Number(challenge.expires) * 1000;
-      if (expiresAtMs <= Date.now()) continue;
+      const expiresAtMs = parseMPPExpiresAtMs(challenge.expires);
+      if (expiresAtMs === null || expiresAtMs <= Date.now()) continue;
     }
 
     if (challenge.digest !== undefined) {

--- a/packages/fetch/src/mpp-expiry.test.ts
+++ b/packages/fetch/src/mpp-expiry.test.ts
@@ -1,12 +1,13 @@
 #!/usr/bin/env pnpm tsx
 
 import t from "tap";
-import { processPaymentRequiredResponseMPP } from "./internal";
-import { formatWWWAuthenticate } from "@faremeter/types/mpp";
+import { formatMPPDateTime, formatWWWAuthenticate } from "@faremeter/types/mpp";
 import type {
   MPPPaymentHandler,
   mppChallengeParams,
 } from "@faremeter/types/mpp";
+
+import { processPaymentRequiredResponseMPP } from "./internal";
 
 function makeChallenge(
   overrides: Partial<mppChallengeParams> = {},
@@ -25,6 +26,10 @@ function makeResponse(challenges: mppChallengeParams[]): Response {
   const headers = new Headers();
   headers.set("WWW-Authenticate", formatWWWAuthenticate(challenges));
   return new Response(null, { status: 402, headers });
+}
+
+function expiresIn(seconds: number) {
+  return formatMPPDateTime(new Date(Date.now() + seconds * 1000));
 }
 
 function makeMockHandler(): {
@@ -49,7 +54,7 @@ await t.test("MPP challenge expiry", async (t) => {
   await t.test("skips expired challenges", async (t) => {
     const expired = makeChallenge({
       id: "expired",
-      expires: String(Math.floor(Date.now() / 1000) - 10),
+      expires: expiresIn(-10),
     });
 
     const { handler, calls } = makeMockHandler();
@@ -84,11 +89,11 @@ await t.test("MPP challenge expiry", async (t) => {
   await t.test("skips expired, uses valid", async (t) => {
     const expired = makeChallenge({
       id: "expired",
-      expires: String(Math.floor(Date.now() / 1000) - 10),
+      expires: expiresIn(-10),
     });
     const valid = makeChallenge({
       id: "valid",
-      expires: String(Math.floor(Date.now() / 1000) + 60),
+      expires: expiresIn(60),
     });
 
     const { handler, calls } = makeMockHandler();
@@ -100,6 +105,41 @@ await t.test("MPP challenge expiry", async (t) => {
     t.ok(result, "should produce an authorization header");
     t.equal(calls.length, 1, "handler should be called once");
     t.equal(calls[0]?.id, "valid", "should use the non-expired challenge");
+    t.end();
+  });
+
+  await t.test("accepts legacy unix-second expires", async (t) => {
+    const valid = makeChallenge({
+      id: "legacy-valid",
+      expires: String(Math.floor(Date.now() / 1000) + 60),
+    });
+
+    const { handler, calls } = makeMockHandler();
+    const result = await processPaymentRequiredResponseMPP(
+      makeResponse([valid]),
+      [handler],
+    );
+
+    t.ok(result, "should produce an authorization header");
+    t.equal(calls.length, 1, "handler should be called");
+    t.equal(calls[0]?.id, "legacy-valid");
+    t.end();
+  });
+
+  await t.test("skips malformed expires", async (t) => {
+    const malformed = makeChallenge({
+      id: "malformed",
+      expires: "not-a-date",
+    });
+
+    const { handler, calls } = makeMockHandler();
+    const result = await processPaymentRequiredResponseMPP(
+      makeResponse([malformed]),
+      [handler],
+    );
+
+    t.equal(result, undefined, "should not produce an authorization header");
+    t.equal(calls.length, 0, "handler should not be called");
     t.end();
   });
 

--- a/packages/middleware/src/common.ts
+++ b/packages/middleware/src/common.ts
@@ -1208,8 +1208,8 @@ async function handleV2Request<MiddlewareResponse>(
 /**
  * Handle an MPP protocol request.
  *
- * The credential carries its challenge, so there is no matching step.
- * Settlement routes by method through the MPP glue layer.
+ * Settlement routes by method, then binds the credential to a pricing
+ * option for the current resource.
  */
 async function handleMPPRequest<MiddlewareResponse>(
   args: HandleMiddlewareRequestArgs<MiddlewareResponse>,
@@ -1252,7 +1252,12 @@ async function handleMPPRequest<MiddlewareResponse>(
 
   const capture = async (): Promise<CaptureResultMPP<MiddlewareResponse>> => {
     try {
-      const receipt = await settleMPPPayment(mppHandlers, credential);
+      const receipt = await settleMPPPayment(
+        mppHandlers,
+        credential,
+        pricing,
+        resource,
+      );
 
       if (args.setResponseHeader) {
         args.setResponseHeader(
@@ -1281,7 +1286,12 @@ async function handleMPPRequest<MiddlewareResponse>(
   const authorize = canAuthorize
     ? async (): Promise<AuthorizeResultMPP<MiddlewareResponse>> => {
         try {
-          const receipt = await verifyMPPPayment(mppHandlers, credential);
+          const receipt = await verifyMPPPayment(
+            mppHandlers,
+            credential,
+            pricing,
+            resource,
+          );
           return { success: true, receipt };
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);

--- a/packages/payment-solana/src/charge/client.test.ts
+++ b/packages/payment-solana/src/charge/client.test.ts
@@ -1,0 +1,840 @@
+#!/usr/bin/env pnpm tsx
+
+import t from "tap";
+import { MEMO_PROGRAM_ADDRESS } from "@solana-program/memo";
+import {
+  ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
+  TOKEN_PROGRAM_ADDRESS,
+} from "@solana-program/token";
+import {
+  decompileTransactionMessage,
+  generateKeyPairSigner,
+  getBase64Encoder,
+  getCompiledTransactionMessageDecoder,
+  type Rpc,
+  type SolanaRpcApi,
+} from "@solana/kit";
+import {
+  getTransactionDecoder,
+  partiallySignTransaction,
+} from "@solana/transactions";
+
+import { isValidationError } from "@faremeter/types";
+import {
+  canonicalizeSortedJSON,
+  encodeBase64URL,
+  formatMPPDateTime,
+  type mppChallengeParams,
+} from "@faremeter/types/mpp";
+
+import {
+  createMPPSolanaChargeClient,
+  createMPPSolanaNativeChargeClient,
+} from "./client";
+import { chargeCredentialPayload, type mppChargeRequest } from "./common";
+import {
+  verifyChargeTransaction,
+  verifyNativeChargeTransaction,
+} from "./verify";
+import type { CompilableTransactionMessage } from "../common";
+import type { Wallet } from "../exact/client";
+
+const FAKE_BLOCKHASH = "EETubP46DHLkT9hAFKy4x2BoFUqUFvKjiiNVY3CaYRi3";
+const OVERSIZED_MEMO = "x".repeat(567);
+
+async function createWallet(
+  onSign?: () => void,
+  network = "mainnet-beta",
+): Promise<Wallet> {
+  const signer = await generateKeyPairSigner();
+  return {
+    network,
+    publicKey: signer.address,
+    partiallySignTransaction: (tx) => {
+      onSign?.();
+      return partiallySignTransaction([signer.keyPair], tx);
+    },
+  };
+}
+
+function makeChallenge(request: mppChargeRequest): mppChallengeParams {
+  return {
+    id: "challenge-id",
+    realm: "test",
+    method: "solana",
+    intent: "charge",
+    request: encodeBase64URL(canonicalizeSortedJSON(request)),
+    expires: formatMPPDateTime(new Date("2100-01-01T00:00:00Z")),
+  };
+}
+
+function decodeTransactionPayload(
+  transaction: string,
+): CompilableTransactionMessage {
+  const txBytes = getBase64Encoder().encode(transaction);
+  const decodedTx = getTransactionDecoder().decode(txBytes);
+  const compiledMessage = getCompiledTransactionMessageDecoder().decode(
+    decodedTx.messageBytes,
+  );
+  return decompileTransactionMessage(compiledMessage);
+}
+
+function getTransactionPayload(payload: unknown) {
+  const validatedPayload = chargeCredentialPayload(payload);
+  if (isValidationError(validatedPayload)) {
+    throw new Error(validatedPayload.summary);
+  }
+  if (validatedPayload.type !== "transaction") {
+    throw new Error("expected transaction payload");
+  }
+  return validatedPayload.transaction;
+}
+
+function countMemoInstructions(
+  transactionMessage: CompilableTransactionMessage,
+) {
+  return transactionMessage.instructions.filter(
+    (instruction) => instruction.programAddress === MEMO_PROGRAM_ADDRESS,
+  ).length;
+}
+
+function countATAInstructions(
+  transactionMessage: CompilableTransactionMessage,
+) {
+  return transactionMessage.instructions.filter(
+    (instruction) =>
+      instruction.programAddress === ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
+  ).length;
+}
+
+function createMintAccountBase64(decimals: number) {
+  const data = new Uint8Array(82);
+  data[44] = decimals;
+  data[45] = 1;
+  return Buffer.from(data).toString("base64");
+}
+
+function createFakeRpc(): Rpc<SolanaRpcApi> {
+  return {
+    getAccountInfo: () => ({
+      send: async () => ({
+        value: {
+          data: [createMintAccountBase64(6), "base64"],
+          executable: false,
+          lamports: 1_000_000n,
+          owner: TOKEN_PROGRAM_ADDRESS,
+          space: 82n,
+        },
+      }),
+    }),
+  } as unknown as Rpc<SolanaRpcApi>;
+}
+
+await t.test(
+  "createMPPSolanaChargeClient includes challenge memo",
+  async (t) => {
+    const wallet = await createWallet();
+    const receiver = await generateKeyPairSigner();
+    const mint = await generateKeyPairSigner();
+    const request: mppChargeRequest = {
+      amount: "1000000",
+      currency: mint.address,
+      recipient: receiver.address,
+      externalId: "client-token-memo",
+      methodDetails: {
+        decimals: 6,
+        recentBlockhash: FAKE_BLOCKHASH,
+        tokenProgram: TOKEN_PROGRAM_ADDRESS,
+      },
+    };
+
+    const handler = createMPPSolanaChargeClient({
+      wallet,
+      mint: mint.address,
+    });
+    const execer = await handler(makeChallenge(request));
+    if (!execer) {
+      throw new Error("expected client to handle token charge challenge");
+    }
+
+    const credential = await execer.exec();
+    const transactionMessage = decodeTransactionPayload(
+      getTransactionPayload(credential.payload),
+    );
+
+    const result = await verifyChargeTransaction({
+      transactionMessage,
+      request,
+      feePayerAddress: "",
+      tokenProgram: TOKEN_PROGRAM_ADDRESS,
+    });
+
+    t.matchOnly(result, { payer: wallet.publicKey });
+    t.end();
+  },
+);
+
+await t.test("createMPPSolanaChargeClient includes splits", async (t) => {
+  const wallet = await createWallet();
+  const receiver = await generateKeyPairSigner();
+  const splitReceiver = await generateKeyPairSigner();
+  const mint = await generateKeyPairSigner();
+  const request: mppChargeRequest = {
+    amount: "1000000",
+    currency: mint.address,
+    recipient: receiver.address,
+    externalId: "client-token-split-memo",
+    methodDetails: {
+      decimals: 6,
+      recentBlockhash: FAKE_BLOCKHASH,
+      splits: [
+        {
+          amount: "250000",
+          memo: "client-token-split",
+          recipient: splitReceiver.address,
+        },
+      ],
+      tokenProgram: TOKEN_PROGRAM_ADDRESS,
+    },
+  };
+
+  const handler = createMPPSolanaChargeClient({
+    wallet,
+    mint: mint.address,
+  });
+  const execer = await handler(makeChallenge(request));
+  if (!execer) {
+    throw new Error("expected client to handle token charge challenge");
+  }
+
+  const credential = await execer.exec();
+  const transactionMessage = decodeTransactionPayload(
+    getTransactionPayload(credential.payload),
+  );
+
+  const result = await verifyChargeTransaction({
+    transactionMessage,
+    request,
+    feePayerAddress: "",
+    tokenProgram: TOKEN_PROGRAM_ADDRESS,
+  });
+
+  t.matchOnly(result, { payer: wallet.publicKey });
+  t.equal(countATAInstructions(transactionMessage), 1);
+  t.end();
+});
+
+await t.test(
+  "createMPPSolanaChargeClient includes challenge memo with fee payer",
+  async (t) => {
+    const wallet = await createWallet();
+    const receiver = await generateKeyPairSigner();
+    const feePayer = await generateKeyPairSigner();
+    const mint = await generateKeyPairSigner();
+    const request: mppChargeRequest = {
+      amount: "1000000",
+      currency: mint.address,
+      recipient: receiver.address,
+      externalId: "client-token-fee-payer-memo",
+      methodDetails: {
+        decimals: 6,
+        feePayer: true,
+        feePayerKey: feePayer.address,
+        recentBlockhash: FAKE_BLOCKHASH,
+        tokenProgram: TOKEN_PROGRAM_ADDRESS,
+      },
+    };
+
+    const handler = createMPPSolanaChargeClient({
+      wallet,
+      mint: mint.address,
+    });
+    const execer = await handler(makeChallenge(request));
+    if (!execer) {
+      throw new Error("expected client to handle token charge challenge");
+    }
+
+    const credential = await execer.exec();
+    const transactionMessage = decodeTransactionPayload(
+      getTransactionPayload(credential.payload),
+    );
+
+    const result = await verifyChargeTransaction({
+      transactionMessage,
+      request,
+      feePayerAddress: feePayer.address,
+      tokenProgram: TOKEN_PROGRAM_ADDRESS,
+    });
+
+    t.matchOnly(result, { payer: wallet.publicKey });
+    t.end();
+  },
+);
+
+await t.test(
+  "createMPPSolanaChargeClient looks up tokenProgram when omitted",
+  async (t) => {
+    const wallet = await createWallet();
+    const receiver = await generateKeyPairSigner();
+    const mint = await generateKeyPairSigner();
+    const request: mppChargeRequest = {
+      amount: "1000000",
+      currency: mint.address,
+      recipient: receiver.address,
+      methodDetails: {
+        decimals: 6,
+        recentBlockhash: FAKE_BLOCKHASH,
+      },
+    };
+
+    const handler = createMPPSolanaChargeClient({
+      wallet,
+      mint: mint.address,
+      rpc: createFakeRpc(),
+    });
+    const execer = await handler(makeChallenge(request));
+    if (!execer) {
+      throw new Error("expected client to handle token charge challenge");
+    }
+
+    const credential = await execer.exec();
+    const transactionMessage = decodeTransactionPayload(
+      getTransactionPayload(credential.payload),
+    );
+
+    const result = await verifyChargeTransaction({
+      transactionMessage,
+      request,
+      feePayerAddress: "",
+      tokenProgram: TOKEN_PROGRAM_ADDRESS,
+    });
+
+    t.matchOnly(result, { payer: wallet.publicKey });
+    t.end();
+  },
+);
+
+await t.test(
+  "createMPPSolanaChargeClient rejects a mismatched token mint",
+  async (t) => {
+    const wallet = await createWallet();
+    const receiver = await generateKeyPairSigner();
+    const configuredMint = await generateKeyPairSigner();
+    const requestedMint = await generateKeyPairSigner();
+    const request: mppChargeRequest = {
+      amount: "1000000",
+      currency: requestedMint.address,
+      recipient: receiver.address,
+      methodDetails: {
+        decimals: 6,
+        recentBlockhash: FAKE_BLOCKHASH,
+        tokenProgram: TOKEN_PROGRAM_ADDRESS,
+      },
+    };
+
+    const handler = createMPPSolanaChargeClient({
+      wallet,
+      mint: configuredMint.address,
+    });
+
+    t.equal(await handler(makeChallenge(request)), null);
+    t.end();
+  },
+);
+
+await t.test(
+  "createMPPSolanaChargeClient rejects unexpected charge fields",
+  async (t) => {
+    const wallet = await createWallet();
+    const receiver = await generateKeyPairSigner();
+    const wrongReceiver = await generateKeyPairSigner();
+    const splitReceiver = await generateKeyPairSigner();
+    const wrongSplitReceiver = await generateKeyPairSigner();
+    const feePayer = await generateKeyPairSigner();
+    const wrongFeePayer = await generateKeyPairSigner();
+    const mint = await generateKeyPairSigner();
+    const request: mppChargeRequest = {
+      amount: "1000000",
+      currency: mint.address,
+      recipient: receiver.address,
+      methodDetails: {
+        decimals: 6,
+        feePayer: true,
+        feePayerKey: feePayer.address,
+        recentBlockhash: FAKE_BLOCKHASH,
+        splits: [
+          {
+            amount: "250000",
+            memo: "client-token-expected-split",
+            recipient: splitReceiver.address,
+          },
+        ],
+        tokenProgram: TOKEN_PROGRAM_ADDRESS,
+      },
+    };
+
+    const handler = createMPPSolanaChargeClient({
+      wallet,
+      mint: mint.address,
+      expected: {
+        amount: request.amount,
+        feePayerKey: feePayer.address,
+        recipient: receiver.address,
+        splits: [
+          {
+            amount: "250000",
+            memo: "client-token-expected-split",
+            recipient: splitReceiver.address,
+          },
+        ],
+      },
+    });
+
+    t.ok(await handler(makeChallenge(request)));
+    t.equal(
+      await handler(makeChallenge({ ...request, amount: "1000001" })),
+      null,
+    );
+    t.equal(
+      await handler(
+        makeChallenge({ ...request, recipient: wrongReceiver.address }),
+      ),
+      null,
+    );
+    t.equal(
+      await handler(
+        makeChallenge({
+          ...request,
+          methodDetails: {
+            ...request.methodDetails,
+            feePayerKey: wrongFeePayer.address,
+          },
+        }),
+      ),
+      null,
+    );
+    t.equal(
+      await handler(
+        makeChallenge({
+          ...request,
+          methodDetails: {
+            ...request.methodDetails,
+            splits: [
+              {
+                amount: "250000",
+                memo: "client-token-expected-split",
+                recipient: wrongSplitReceiver.address,
+              },
+            ],
+          },
+        }),
+      ),
+      null,
+    );
+    t.end();
+  },
+);
+
+await t.test(
+  "createMPPSolanaNativeChargeClient includes challenge memo",
+  async (t) => {
+    const wallet = await createWallet();
+    const receiver = await generateKeyPairSigner();
+    const request: mppChargeRequest = {
+      amount: "1000000",
+      currency: "sol",
+      recipient: receiver.address,
+      externalId: "client-native-memo",
+      methodDetails: {
+        recentBlockhash: FAKE_BLOCKHASH,
+      },
+    };
+
+    const handler = createMPPSolanaNativeChargeClient({ wallet });
+    const execer = await handler(makeChallenge(request));
+    if (!execer) {
+      throw new Error("expected client to handle native charge challenge");
+    }
+
+    const credential = await execer.exec();
+    const transactionMessage = decodeTransactionPayload(
+      getTransactionPayload(credential.payload),
+    );
+
+    const result = await verifyNativeChargeTransaction({
+      transactionMessage,
+      request,
+      feePayerAddress: "",
+    });
+
+    t.matchOnly(result, { payer: wallet.publicKey });
+    t.end();
+  },
+);
+
+await t.test(
+  "createMPPSolanaNativeChargeClient rejects unexpected charge fields",
+  async (t) => {
+    const wallet = await createWallet();
+    const receiver = await generateKeyPairSigner();
+    const splitReceiver = await generateKeyPairSigner();
+    const feePayer = await generateKeyPairSigner();
+    const request: mppChargeRequest = {
+      amount: "1000000",
+      currency: "sol",
+      recipient: receiver.address,
+      methodDetails: {
+        recentBlockhash: FAKE_BLOCKHASH,
+      },
+    };
+
+    const handler = createMPPSolanaNativeChargeClient({
+      wallet,
+      expected: {
+        amount: request.amount,
+        feePayerKey: null,
+        recipient: receiver.address,
+        splits: [],
+      },
+    });
+
+    t.ok(await handler(makeChallenge(request)));
+    t.equal(
+      await handler(
+        makeChallenge({
+          ...request,
+          methodDetails: {
+            ...request.methodDetails,
+            feePayer: true,
+            feePayerKey: feePayer.address,
+          },
+        }),
+      ),
+      null,
+    );
+    t.equal(
+      await handler(
+        makeChallenge({
+          ...request,
+          methodDetails: {
+            ...request.methodDetails,
+            splits: [
+              {
+                amount: "250000",
+                recipient: splitReceiver.address,
+              },
+            ],
+          },
+        }),
+      ),
+      null,
+    );
+    t.end();
+  },
+);
+
+await t.test(
+  "createMPPSolanaNativeChargeClient rejects network mismatch",
+  async (t) => {
+    const wallet = await createWallet(undefined, "devnet");
+    const receiver = await generateKeyPairSigner();
+    const request: mppChargeRequest = {
+      amount: "1000000",
+      currency: "sol",
+      recipient: receiver.address,
+      methodDetails: {
+        network: "mainnet",
+        recentBlockhash: FAKE_BLOCKHASH,
+      },
+    };
+
+    const handler = createMPPSolanaNativeChargeClient({ wallet });
+
+    t.equal(await handler(makeChallenge(request)), null);
+    t.end();
+  },
+);
+
+await t.test("createMPPSolanaNativeChargeClient includes splits", async (t) => {
+  const wallet = await createWallet();
+  const receiver = await generateKeyPairSigner();
+  const splitReceiver = await generateKeyPairSigner();
+  const request: mppChargeRequest = {
+    amount: "1000000",
+    currency: "sol",
+    recipient: receiver.address,
+    externalId: "client-native-split-memo",
+    methodDetails: {
+      recentBlockhash: FAKE_BLOCKHASH,
+      splits: [
+        {
+          amount: "250000",
+          memo: "client-native-split",
+          recipient: splitReceiver.address,
+        },
+      ],
+    },
+  };
+
+  const handler = createMPPSolanaNativeChargeClient({ wallet });
+  const execer = await handler(makeChallenge(request));
+  if (!execer) {
+    throw new Error("expected client to handle native charge challenge");
+  }
+
+  const credential = await execer.exec();
+  const transactionMessage = decodeTransactionPayload(
+    getTransactionPayload(credential.payload),
+  );
+
+  const result = await verifyNativeChargeTransaction({
+    transactionMessage,
+    request,
+    feePayerAddress: "",
+  });
+
+  t.matchOnly(result, { payer: wallet.publicKey });
+  t.end();
+});
+
+await t.test(
+  "createMPPSolanaNativeChargeClient includes challenge memo with fee payer",
+  async (t) => {
+    const wallet = await createWallet();
+    const receiver = await generateKeyPairSigner();
+    const feePayer = await generateKeyPairSigner();
+    const request: mppChargeRequest = {
+      amount: "1000000",
+      currency: "sol",
+      recipient: receiver.address,
+      externalId: "client-native-fee-payer-memo",
+      methodDetails: {
+        feePayer: true,
+        feePayerKey: feePayer.address,
+        recentBlockhash: FAKE_BLOCKHASH,
+      },
+    };
+
+    const handler = createMPPSolanaNativeChargeClient({ wallet });
+    const execer = await handler(makeChallenge(request));
+    if (!execer) {
+      throw new Error("expected client to handle native charge challenge");
+    }
+
+    const credential = await execer.exec();
+    const transactionMessage = decodeTransactionPayload(
+      getTransactionPayload(credential.payload),
+    );
+
+    const result = await verifyNativeChargeTransaction({
+      transactionMessage,
+      request,
+      feePayerAddress: feePayer.address,
+    });
+
+    t.matchOnly(result, { payer: wallet.publicKey });
+    t.end();
+  },
+);
+
+await t.test(
+  "token charge can build fee-sponsored challenge without externalId",
+  async (t) => {
+    let signCount = 0;
+    const wallet = await createWallet(() => {
+      signCount += 1;
+    });
+    const receiver = await generateKeyPairSigner();
+    const feePayer = await generateKeyPairSigner();
+    const mint = await generateKeyPairSigner();
+    const request: mppChargeRequest = {
+      amount: "1000000",
+      currency: mint.address,
+      recipient: receiver.address,
+      methodDetails: {
+        decimals: 6,
+        feePayer: true,
+        feePayerKey: feePayer.address,
+        recentBlockhash: FAKE_BLOCKHASH,
+        tokenProgram: TOKEN_PROGRAM_ADDRESS,
+      },
+    };
+
+    const handler = createMPPSolanaChargeClient({
+      wallet,
+      mint: mint.address,
+    });
+    const execer = await handler(makeChallenge(request));
+    if (!execer) {
+      throw new Error("expected client to handle token charge challenge");
+    }
+
+    const credential = await execer.exec();
+    const transactionMessage = decodeTransactionPayload(
+      getTransactionPayload(credential.payload),
+    );
+
+    t.equal(signCount, 1);
+    t.equal(countMemoInstructions(transactionMessage), 0);
+    t.end();
+  },
+);
+
+await t.test(
+  "native charge can build fee-sponsored challenge without externalId",
+  async (t) => {
+    let signCount = 0;
+    const wallet = await createWallet(() => {
+      signCount += 1;
+    });
+    const receiver = await generateKeyPairSigner();
+    const feePayer = await generateKeyPairSigner();
+    const request: mppChargeRequest = {
+      amount: "1000000",
+      currency: "sol",
+      recipient: receiver.address,
+      methodDetails: {
+        feePayer: true,
+        feePayerKey: feePayer.address,
+        recentBlockhash: FAKE_BLOCKHASH,
+      },
+    };
+
+    const handler = createMPPSolanaNativeChargeClient({ wallet });
+    const execer = await handler(makeChallenge(request));
+    if (!execer) {
+      throw new Error("expected client to handle native charge challenge");
+    }
+
+    const credential = await execer.exec();
+    const transactionMessage = decodeTransactionPayload(
+      getTransactionPayload(credential.payload),
+    );
+
+    t.equal(signCount, 1);
+    t.equal(countMemoInstructions(transactionMessage), 0);
+    t.end();
+  },
+);
+
+await t.test("token charge omits empty externalId memo", async (t) => {
+  let signCount = 0;
+  const wallet = await createWallet(() => {
+    signCount += 1;
+  });
+  const receiver = await generateKeyPairSigner();
+  const mint = await generateKeyPairSigner();
+  const request: mppChargeRequest = {
+    amount: "1000000",
+    currency: mint.address,
+    recipient: receiver.address,
+    externalId: "",
+    methodDetails: {
+      decimals: 6,
+      recentBlockhash: FAKE_BLOCKHASH,
+      tokenProgram: TOKEN_PROGRAM_ADDRESS,
+    },
+  };
+
+  const handler = createMPPSolanaChargeClient({
+    wallet,
+    mint: mint.address,
+  });
+  const execer = await handler(makeChallenge(request));
+  if (!execer) {
+    throw new Error("expected client to handle token charge challenge");
+  }
+
+  const credential = await execer.exec();
+  const transactionMessage = decodeTransactionPayload(
+    getTransactionPayload(credential.payload),
+  );
+
+  t.equal(signCount, 1);
+  t.equal(countMemoInstructions(transactionMessage), 0);
+  t.end();
+});
+
+await t.test("native charge omits empty externalId memo", async (t) => {
+  let signCount = 0;
+  const wallet = await createWallet(() => {
+    signCount += 1;
+  });
+  const receiver = await generateKeyPairSigner();
+  const request: mppChargeRequest = {
+    amount: "1000000",
+    currency: "sol",
+    recipient: receiver.address,
+    externalId: "",
+    methodDetails: {
+      recentBlockhash: FAKE_BLOCKHASH,
+    },
+  };
+
+  const handler = createMPPSolanaNativeChargeClient({ wallet });
+  const execer = await handler(makeChallenge(request));
+  if (!execer) {
+    throw new Error("expected client to handle native charge challenge");
+  }
+
+  const credential = await execer.exec();
+  const transactionMessage = decodeTransactionPayload(
+    getTransactionPayload(credential.payload),
+  );
+
+  t.equal(signCount, 1);
+  t.equal(countMemoInstructions(transactionMessage), 0);
+  t.end();
+});
+
+await t.test("token charge rejects oversized externalId memo", async (t) => {
+  const wallet = await createWallet();
+  const receiver = await generateKeyPairSigner();
+  const mint = await generateKeyPairSigner();
+  const request: mppChargeRequest = {
+    amount: "1000000",
+    currency: mint.address,
+    recipient: receiver.address,
+    externalId: OVERSIZED_MEMO,
+    methodDetails: {
+      decimals: 6,
+      recentBlockhash: FAKE_BLOCKHASH,
+      tokenProgram: TOKEN_PROGRAM_ADDRESS,
+    },
+  };
+
+  const handler = createMPPSolanaChargeClient({
+    wallet,
+    mint: mint.address,
+  });
+  const execer = await handler(makeChallenge(request));
+  t.equal(execer, null);
+  t.end();
+});
+
+await t.test("native charge rejects oversized split memo", async (t) => {
+  const wallet = await createWallet();
+  const receiver = await generateKeyPairSigner();
+  const splitReceiver = await generateKeyPairSigner();
+  const request: mppChargeRequest = {
+    amount: "1000000",
+    currency: "sol",
+    recipient: receiver.address,
+    externalId: "client-native-memo",
+    methodDetails: {
+      recentBlockhash: FAKE_BLOCKHASH,
+      splits: [
+        {
+          amount: "250000",
+          memo: OVERSIZED_MEMO,
+          recipient: splitReceiver.address,
+        },
+      ],
+    },
+  };
+
+  const handler = createMPPSolanaNativeChargeClient({ wallet });
+  const execer = await handler(makeChallenge(request));
+  t.equal(execer, null);
+  t.end();
+});

--- a/packages/payment-solana/src/charge/client.test.ts
+++ b/packages/payment-solana/src/charge/client.test.ts
@@ -130,6 +130,59 @@ function createFakeRpc(): Rpc<SolanaRpcApi> {
   } as unknown as Rpc<SolanaRpcApi>;
 }
 
+type CreateBroadcastRpcOpts = {
+  blockhashValid?: boolean;
+  blockHeights?: readonly bigint[];
+  confirmationStatus?: "confirmed" | "finalized" | "processed" | null;
+  onGetSignatureStatuses?: () => void;
+  onSendTransaction?: () => void;
+};
+
+function createBroadcastRpc(
+  opts: CreateBroadcastRpcOpts = {},
+): Rpc<SolanaRpcApi> {
+  const blockHeights = opts.blockHeights ?? [1000n];
+  let blockHeightIndex = 0;
+  const nextBlockHeight = () => {
+    const height =
+      blockHeights[Math.min(blockHeightIndex, blockHeights.length - 1)] ??
+      1000n;
+    blockHeightIndex += 1;
+    return height;
+  };
+  const signatureStatus =
+    opts.confirmationStatus === null
+      ? null
+      : {
+          confirmationStatus: opts.confirmationStatus ?? "confirmed",
+          err: null,
+        };
+  return {
+    getBlockHeight: () => ({
+      send: async () => nextBlockHeight(),
+    }),
+    getSignatureStatuses: () => ({
+      send: async () => {
+        opts.onGetSignatureStatuses?.();
+        return {
+          value: [signatureStatus],
+        };
+      },
+    }),
+    isBlockhashValid: () => ({
+      send: async () => ({
+        value: opts.blockhashValid ?? true,
+      }),
+    }),
+    sendTransaction: () => ({
+      send: async () => {
+        opts.onSendTransaction?.();
+        return "settlement-signature";
+      },
+    }),
+  } as unknown as Rpc<SolanaRpcApi>;
+}
+
 await t.test(
   "createMPPSolanaChargeClient includes challenge memo",
   async (t) => {
@@ -468,6 +521,143 @@ await t.test(
     });
 
     t.matchOnly(result, { payer: wallet.publicKey });
+    t.end();
+  },
+);
+
+await t.test(
+  "createMPPSolanaNativeChargeClient rejects invalid recentBlockhash",
+  async (t) => {
+    const wallet = await createWallet();
+    const receiver = await generateKeyPairSigner();
+    const request: mppChargeRequest = {
+      amount: "1000000",
+      currency: "sol",
+      recipient: receiver.address,
+      methodDetails: {
+        recentBlockhash: "not-a-blockhash",
+      },
+    };
+
+    const handler = createMPPSolanaNativeChargeClient({ wallet });
+    const execer = await handler(makeChallenge(request));
+    if (!execer) {
+      throw new Error("expected client to handle native charge challenge");
+    }
+
+    await t.rejects(execer.exec(), { message: "invalid recentBlockhash" });
+    t.end();
+  },
+);
+
+await t.test(
+  "createMPPSolanaNativeChargeClient rejects stale broadcast recentBlockhash",
+  async (t) => {
+    let sendCount = 0;
+    const wallet = await createWallet();
+    const receiver = await generateKeyPairSigner();
+    const request: mppChargeRequest = {
+      amount: "1000000",
+      currency: "sol",
+      recipient: receiver.address,
+      methodDetails: {
+        recentBlockhash: FAKE_BLOCKHASH,
+      },
+    };
+
+    const handler = createMPPSolanaNativeChargeClient({
+      wallet,
+      rpc: createBroadcastRpc({
+        blockhashValid: false,
+        onSendTransaction: () => {
+          sendCount += 1;
+        },
+      }),
+      broadcast: true,
+    });
+    const execer = await handler(makeChallenge(request));
+    if (!execer) {
+      throw new Error("expected client to handle native charge challenge");
+    }
+
+    await t.rejects(execer.exec(), {
+      message: "recentBlockhash is no longer valid",
+    });
+    t.equal(sendCount, 0);
+    t.end();
+  },
+);
+
+await t.test(
+  "createMPPSolanaNativeChargeClient expires server blockhash during polling",
+  async (t) => {
+    const wallet = await createWallet();
+    const receiver = await generateKeyPairSigner();
+    const request: mppChargeRequest = {
+      amount: "1000000",
+      currency: "sol",
+      recipient: receiver.address,
+      methodDetails: {
+        recentBlockhash: FAKE_BLOCKHASH,
+      },
+    };
+
+    const handler = createMPPSolanaNativeChargeClient({
+      wallet,
+      rpc: createBroadcastRpc({
+        blockHeights: [1000n, 10_000n],
+        confirmationStatus: "processed",
+      }),
+      broadcast: true,
+    });
+    const execer = await handler(makeChallenge(request));
+    if (!execer) {
+      throw new Error("expected client to handle native charge challenge");
+    }
+
+    await t.rejects(execer.exec(), {
+      message: "blockhash expired before confirmation",
+    });
+    t.end();
+  },
+);
+
+await t.test(
+  "createMPPSolanaNativeChargeClient honors broadcast polling options",
+  async (t) => {
+    let statusPolls = 0;
+    const wallet = await createWallet();
+    const receiver = await generateKeyPairSigner();
+    const request: mppChargeRequest = {
+      amount: "1000000",
+      currency: "sol",
+      recipient: receiver.address,
+      methodDetails: {
+        recentBlockhash: FAKE_BLOCKHASH,
+      },
+    };
+
+    const handler = createMPPSolanaNativeChargeClient({
+      wallet,
+      rpc: createBroadcastRpc({
+        confirmationStatus: null,
+        onGetSignatureStatuses: () => {
+          statusPolls += 1;
+        },
+      }),
+      broadcast: true,
+      maxRetries: 2,
+      retryDelayMs: 0,
+    });
+    const execer = await handler(makeChallenge(request));
+    if (!execer) {
+      throw new Error("expected client to handle native charge challenge");
+    }
+
+    await t.rejects(execer.exec(), {
+      message: "transaction confirmation timed out",
+    });
+    t.equal(statusPolls, 2);
     t.end();
   },
 );

--- a/packages/payment-solana/src/charge/client.ts
+++ b/packages/payment-solana/src/charge/client.ts
@@ -23,8 +23,8 @@ import {
   address,
   createNoopSigner,
   getBase64EncodedWireTransaction,
+  isBlockhash,
   type Address,
-  type Blockhash,
   type Instruction,
   type Rpc,
   type Signature,
@@ -79,13 +79,27 @@ type NormalizedChargeClientExpected = {
   splits: readonly NormalizedChargeClientExpectedSplit[] | undefined;
 };
 
+type ChargeLifetimeConstraint = WalletLifetimeConstraint & {
+  fallbackLastValidBlockHeight?: bigint;
+};
+
+type ChargeBroadcastConfirmOpts = {
+  maxRetries: number;
+  retryDelayMs: number;
+};
+
+const SERVER_BLOCKHASH_FALLBACK_VALIDITY_BLOCKS = 150n;
+const DEFAULT_BROADCAST_MAX_RETRIES = 60;
+const DEFAULT_BROADCAST_RETRY_DELAY_MS = 1000;
+
 async function broadcastAndConfirm(
   tx: Transaction,
   wallet: Wallet,
   rpc: Rpc<SolanaRpcApi>,
   challenge: mppChallengeParams,
   md: mppChargeRequest["methodDetails"],
-  lifetimeConstraint: WalletLifetimeConstraint,
+  lifetimeConstraint: ChargeLifetimeConstraint,
+  opts: ChargeBroadcastConfirmOpts,
 ): Promise<mppCredential> {
   if (md?.feePayer) {
     throw new Error("push mode is not allowed with fee sponsorship");
@@ -99,10 +113,8 @@ async function broadcastAndConfirm(
     signature = await rpc.sendTransaction(wire, { encoding: "base64" }).send();
   }
 
-  // Poll until the signature is confirmed or the blockhash expires.
-  const maxPolls = 60;
   let confirmed = false;
-  for (let i = 0; i < maxPolls; i++) {
+  for (let i = 0; i < opts.maxRetries; i++) {
     const status = await rpc
       .getSignatureStatuses([signature as Signature])
       .send();
@@ -119,13 +131,17 @@ async function broadcastAndConfirm(
       break;
     }
     const currentHeight = await rpc.getBlockHeight().send();
+    const lastValidBlockHeight =
+      lifetimeConstraint.lastValidBlockHeight > 0n
+        ? lifetimeConstraint.lastValidBlockHeight
+        : lifetimeConstraint.fallbackLastValidBlockHeight;
     if (
-      lifetimeConstraint.lastValidBlockHeight > 0n &&
-      currentHeight > lifetimeConstraint.lastValidBlockHeight
+      lastValidBlockHeight !== undefined &&
+      currentHeight > lastValidBlockHeight
     ) {
       throw new Error("blockhash expired before confirmation");
     }
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    await new Promise((resolve) => setTimeout(resolve, opts.retryDelayMs));
   }
 
   if (!confirmed) {
@@ -141,11 +157,33 @@ async function broadcastAndConfirm(
 async function fetchLifetimeConstraint(
   rpc: Rpc<SolanaRpcApi> | undefined,
   supplied: string | undefined,
-): Promise<WalletLifetimeConstraint> {
+  verifySuppliedFreshness: boolean,
+): Promise<ChargeLifetimeConstraint> {
   if (supplied) {
+    if (!isBlockhash(supplied)) {
+      throw new Error("invalid recentBlockhash");
+    }
+    if (!verifySuppliedFreshness) {
+      return {
+        blockhash: supplied,
+        lastValidBlockHeight: 0n,
+      };
+    }
+    if (!rpc) {
+      throw new Error("rpc is required to verify recentBlockhash");
+    }
+    const [{ value: isValid }, currentHeight] = await Promise.all([
+      rpc.isBlockhashValid(supplied).send(),
+      rpc.getBlockHeight().send(),
+    ]);
+    if (!isValid) {
+      throw new Error("recentBlockhash is no longer valid");
+    }
     return {
-      blockhash: supplied as Blockhash,
+      blockhash: supplied,
       lastValidBlockHeight: 0n,
+      fallbackLastValidBlockHeight:
+        currentHeight + SERVER_BLOCKHASH_FALLBACK_VALIDITY_BLOCKS,
     };
   }
   if (!rpc) {
@@ -303,6 +341,8 @@ export type CreateMPPSolanaChargeClientArgs = {
   mint: Address | { toBase58(): string };
   rpc?: Rpc<SolanaRpcApi> | string;
   broadcast?: boolean;
+  maxRetries?: number;
+  retryDelayMs?: number;
   expected?: MPPSolanaChargeClientExpected;
 };
 
@@ -311,7 +351,12 @@ export function createMPPSolanaChargeClient(
 ): MPPPaymentHandler {
   const mint = toAddress(args.mint);
   const rpc = args.rpc ? toRpc(args.rpc) : undefined;
-  const { wallet, broadcast = false } = args;
+  const {
+    wallet,
+    broadcast = false,
+    maxRetries = DEFAULT_BROADCAST_MAX_RETRIES,
+    retryDelayMs = DEFAULT_BROADCAST_RETRY_DELAY_MS,
+  } = args;
   const expected = normalizeChargeClientExpected(args.expected);
 
   if (broadcast && !rpc) {
@@ -354,6 +399,7 @@ export function createMPPSolanaChargeClient(
         const lifetimeConstraint = await fetchLifetimeConstraint(
           rpc,
           md?.recentBlockhash,
+          broadcast,
         );
 
         let decimals: number;
@@ -462,6 +508,7 @@ export function createMPPSolanaChargeClient(
             challenge,
             md,
             lifetimeConstraint,
+            { maxRetries, retryDelayMs },
           );
         }
 
@@ -481,6 +528,8 @@ export type CreateMPPSolanaNativeChargeClientArgs = {
   wallet: Wallet;
   rpc?: Rpc<SolanaRpcApi> | string;
   broadcast?: boolean;
+  maxRetries?: number;
+  retryDelayMs?: number;
   expected?: MPPSolanaChargeClientExpected;
 };
 
@@ -488,7 +537,12 @@ export function createMPPSolanaNativeChargeClient(
   args: CreateMPPSolanaNativeChargeClientArgs,
 ): MPPPaymentHandler {
   const rpc = args.rpc ? toRpc(args.rpc) : undefined;
-  const { wallet, broadcast = false } = args;
+  const {
+    wallet,
+    broadcast = false,
+    maxRetries = DEFAULT_BROADCAST_MAX_RETRIES,
+    retryDelayMs = DEFAULT_BROADCAST_RETRY_DELAY_MS,
+  } = args;
   const expected = normalizeChargeClientExpected(args.expected);
 
   if (broadcast && !rpc) {
@@ -533,6 +587,7 @@ export function createMPPSolanaNativeChargeClient(
         const lifetimeConstraint = await fetchLifetimeConstraint(
           rpc,
           md?.recentBlockhash,
+          broadcast,
         );
 
         const walletSigner = createNoopSigner(wallet.publicKey);
@@ -577,6 +632,7 @@ export function createMPPSolanaNativeChargeClient(
             challenge,
             md,
             lifetimeConstraint,
+            { maxRetries, retryDelayMs },
           );
         }
 

--- a/packages/payment-solana/src/charge/client.ts
+++ b/packages/payment-solana/src/charge/client.ts
@@ -6,16 +6,18 @@ import type {
 } from "@faremeter/types/mpp";
 import { decodeBase64URL } from "@faremeter/types/mpp";
 import { isValidationError } from "@faremeter/types";
+import { caip2ToCluster, normalizeNetworkId } from "@faremeter/info/solana";
 import {
+  getCreateAssociatedTokenIdempotentInstruction,
   fetchMint,
   findAssociatedTokenPda,
   getTransferCheckedInstruction,
-  TOKEN_PROGRAM_ADDRESS,
 } from "@solana-program/token";
 import {
   getSetComputeUnitLimitInstruction,
   getSetComputeUnitPriceInstruction,
 } from "@solana-program/compute-budget";
+import { getAddMemoInstruction } from "@solana-program/memo";
 import { getTransferSolInstruction } from "@solana-program/system";
 import {
   address,
@@ -34,8 +36,48 @@ import {
   type Wallet,
   type WalletLifetimeConstraint,
 } from "../exact/client";
-import { mppChargeRequest } from "./common";
+import {
+  chargeHasATACreationSplits,
+  getChargeChallengeMemo,
+  getChargeMemoValidationError,
+  getChargePrimaryAmount,
+  getChargeSplits,
+  mppChargeRequest,
+} from "./common";
 import { toAddress, toRpc } from "../compat";
+
+type AddressInput = Address | { toBase58(): string };
+type AmountInput = string | bigint;
+
+export type MPPSolanaChargeClientExpectedSplit = {
+  amount: AmountInput;
+  recipient: AddressInput;
+  memo?: string;
+  ataCreationRequired?: boolean;
+};
+
+export type MPPSolanaChargeClientExpected = {
+  amount?: AmountInput;
+  recipient?: AddressInput;
+  network?: string;
+  feePayerKey?: AddressInput | null;
+  splits?: readonly MPPSolanaChargeClientExpectedSplit[];
+};
+
+type NormalizedChargeClientExpectedSplit = {
+  amount: string;
+  recipient: Address;
+  memo: string | undefined;
+  ataCreationRequired: boolean;
+};
+
+type NormalizedChargeClientExpected = {
+  amount: string | undefined;
+  recipient: Address | undefined;
+  network: string | undefined;
+  feePayerKey: Address | null | undefined;
+  splits: readonly NormalizedChargeClientExpectedSplit[] | undefined;
+};
 
 async function broadcastAndConfirm(
   tx: Transaction,
@@ -116,23 +158,161 @@ async function fetchLifetimeConstraint(
   };
 }
 
+function getOptionalChargeMemo(request: mppChargeRequest): string | undefined {
+  const memo = getChargeChallengeMemo(request);
+  if (memo === undefined || memo.length === 0) {
+    return undefined;
+  }
+  const error = getChargeMemoValidationError(memo);
+  if (error) throw new Error(error);
+  return memo;
+}
+
+function addMemoInstruction(
+  instructions: Instruction[],
+  memo: string | undefined,
+) {
+  if (memo === undefined || memo.length === 0) return;
+  const error = getChargeMemoValidationError(memo);
+  if (error) throw new Error(error);
+  instructions.push(getAddMemoInstruction({ memo }));
+}
+
+function normalizeChargeAmount(amount: AmountInput): string {
+  if (typeof amount === "bigint") return amount.toString();
+  return amount;
+}
+
+function getNetworkString(network: Wallet["network"] | undefined) {
+  if (network === undefined) return undefined;
+  if (typeof network === "string") return network;
+  return network.caip2;
+}
+
+function normalizeChargeNetwork(network: Wallet["network"] | undefined) {
+  const rawNetwork = getNetworkString(network) ?? "mainnet";
+  const normalizedNetwork = normalizeNetworkId(rawNetwork);
+  const cluster = caip2ToCluster(normalizedNetwork) ?? normalizedNetwork;
+  if (cluster === "mainnet-beta") return "mainnet";
+  return cluster;
+}
+
+function normalizeChargeClientExpected(
+  expected: MPPSolanaChargeClientExpected | undefined,
+): NormalizedChargeClientExpected {
+  if (!expected) {
+    return {
+      amount: undefined,
+      recipient: undefined,
+      network: undefined,
+      feePayerKey: undefined,
+      splits: undefined,
+    };
+  }
+  return {
+    amount:
+      expected.amount === undefined
+        ? undefined
+        : normalizeChargeAmount(expected.amount),
+    recipient:
+      expected.recipient === undefined
+        ? undefined
+        : toAddress(expected.recipient),
+    network:
+      expected.network === undefined
+        ? undefined
+        : normalizeChargeNetwork(expected.network),
+    feePayerKey:
+      expected.feePayerKey === undefined || expected.feePayerKey === null
+        ? expected.feePayerKey
+        : toAddress(expected.feePayerKey),
+    splits: expected.splits?.map((split) => ({
+      amount: normalizeChargeAmount(split.amount),
+      recipient: toAddress(split.recipient),
+      memo: split.memo,
+      ataCreationRequired: split.ataCreationRequired === true,
+    })),
+  };
+}
+
+function getChargeFeePayerKey(request: mppChargeRequest): string | null {
+  const methodDetails = request.methodDetails;
+  if (methodDetails?.feePayer !== true) return null;
+  return methodDetails.feePayerKey ?? null;
+}
+
+function getChargeClientValidationError(
+  request: mppChargeRequest,
+  walletNetwork: Wallet["network"],
+  expected: NormalizedChargeClientExpected,
+) {
+  if (
+    normalizeChargeNetwork(request.methodDetails?.network) !==
+    normalizeChargeNetwork(walletNetwork)
+  ) {
+    return "charge network does not match wallet network";
+  }
+  if (expected.amount !== undefined && request.amount !== expected.amount) {
+    return "charge amount does not match expected amount";
+  }
+  if (
+    expected.recipient !== undefined &&
+    request.recipient !== expected.recipient
+  ) {
+    return "charge recipient does not match expected recipient";
+  }
+  if (
+    expected.network !== undefined &&
+    normalizeChargeNetwork(request.methodDetails?.network) !== expected.network
+  ) {
+    return "charge network does not match expected network";
+  }
+  if (
+    expected.feePayerKey !== undefined &&
+    getChargeFeePayerKey(request) !== expected.feePayerKey
+  ) {
+    return "charge fee payer does not match expected fee payer";
+  }
+  if (expected.splits !== undefined) {
+    const splits = getChargeSplits(request);
+    if (splits.length !== expected.splits.length) {
+      return "charge splits do not match expected splits";
+    }
+    for (let i = 0; i < splits.length; i++) {
+      const split = splits[i];
+      const expectedSplit = expected.splits[i];
+      if (!split || !expectedSplit) {
+        return "charge splits do not match expected splits";
+      }
+      if (
+        split.amount !== expectedSplit.amount ||
+        split.recipient !== expectedSplit.recipient ||
+        split.memo !== expectedSplit.memo ||
+        (split.ataCreationRequired === true) !==
+          expectedSplit.ataCreationRequired
+      ) {
+        return "charge splits do not match expected splits";
+      }
+    }
+  }
+  return null;
+}
+
 export type CreateMPPSolanaChargeClientArgs = {
   wallet: Wallet;
   mint: Address | { toBase58(): string };
   rpc?: Rpc<SolanaRpcApi> | string;
-  tokenProgramId?: Address | { toBase58(): string };
   broadcast?: boolean;
+  expected?: MPPSolanaChargeClientExpected;
 };
 
 export function createMPPSolanaChargeClient(
   args: CreateMPPSolanaChargeClientArgs,
 ): MPPPaymentHandler {
   const mint = toAddress(args.mint);
-  const defaultTokenProgram = args.tokenProgramId
-    ? toAddress(args.tokenProgramId)
-    : undefined;
   const rpc = args.rpc ? toRpc(args.rpc) : undefined;
   const { wallet, broadcast = false } = args;
+  const expected = normalizeChargeClientExpected(args.expected);
 
   if (broadcast && !rpc) {
     throw new Error("rpc is required when broadcast is true");
@@ -154,13 +334,18 @@ export function createMPPSolanaChargeClient(
     const request = mppChargeRequest(requestBody);
     if (isValidationError(request)) return null;
     if (request.currency === "sol") return null;
+    if (request.currency !== mint) return null;
+    if (getChargeClientValidationError(request, wallet.network, expected)) {
+      return null;
+    }
 
     return {
       challenge,
       exec: async (): Promise<mppCredential> => {
         const md = request.methodDetails;
-        const amount = BigInt(request.amount);
-        const recipientKey = address(request.recipient);
+        const memo = getOptionalChargeMemo(request);
+        const primaryAmount = getChargePrimaryAmount(request);
+        const splits = getChargeSplits(request);
         const feePayerKey =
           md?.feePayer === true && md.feePayerKey
             ? address(md.feePayerKey)
@@ -181,19 +366,22 @@ export function createMPPSolanaChargeClient(
           throw new Error("no decimals available");
         }
 
-        const tokenProgramId: Address = md?.tokenProgram
-          ? address(md.tokenProgram)
-          : (defaultTokenProgram ?? TOKEN_PROGRAM_ADDRESS);
+        let tokenProgramId: Address;
+        if (md?.tokenProgram !== undefined) {
+          tokenProgramId = address(md.tokenProgram);
+        } else {
+          if (!rpc) {
+            throw new Error("rpc is required when tokenProgram is absent");
+          }
+          // Servers should include tokenProgram; this lookup is required by
+          // the spec when it is omitted, but adds an RPC round trip.
+          const mintInfo = await fetchMint(rpc, mint);
+          tokenProgramId = mintInfo.programAddress;
+        }
 
         const [sourceAccount] = await findAssociatedTokenPda({
           mint,
           owner: wallet.publicKey,
-          tokenProgram: tokenProgramId,
-        });
-
-        const [receiverAccount] = await findAssociatedTokenPda({
-          mint,
-          owner: recipientKey,
           tokenProgram: tokenProgramId,
         });
 
@@ -202,18 +390,59 @@ export function createMPPSolanaChargeClient(
         const instructions: Instruction[] = [
           getSetComputeUnitLimitInstruction({ units: 200_000 }),
           getSetComputeUnitPriceInstruction({ microLamports: 1n }),
-          getTransferCheckedInstruction(
-            {
-              source: sourceAccount,
-              mint,
-              destination: receiverAccount,
-              authority: walletSigner,
-              amount,
-              decimals,
-            },
-            { programAddress: tokenProgramId },
-          ),
         ];
+        const addTransfer = async (
+          recipient: string,
+          amount: bigint,
+          createATA: boolean,
+        ) => {
+          const recipientKey = address(recipient);
+          const [receiverAccount] = await findAssociatedTokenPda({
+            mint,
+            owner: recipientKey,
+            tokenProgram: tokenProgramId,
+          });
+          if (createATA) {
+            instructions.push(
+              getCreateAssociatedTokenIdempotentInstruction({
+                ata: receiverAccount,
+                owner: recipientKey,
+                payer: feePayerKey
+                  ? createNoopSigner(feePayerKey)
+                  : walletSigner,
+                mint,
+                tokenProgram: tokenProgramId,
+              }),
+            );
+          }
+          instructions.push(
+            getTransferCheckedInstruction(
+              {
+                source: sourceAccount,
+                mint,
+                destination: receiverAccount,
+                authority: walletSigner,
+                amount,
+                decimals,
+              },
+              { programAddress: tokenProgramId },
+            ),
+          );
+        };
+
+        await addTransfer(request.recipient, primaryAmount, false);
+        addMemoInstruction(instructions, memo);
+
+        for (const split of splits) {
+          // Without a fee payer the wallet pays the rent, so it creates every
+          // split's ATA; with a sponsor, only the splits the server flagged.
+          await addTransfer(
+            split.recipient,
+            BigInt(split.amount),
+            feePayerKey ? split.ataCreationRequired === true : true,
+          );
+          addMemoInstruction(instructions, split.memo);
+        }
 
         const payerKey = feePayerKey ?? wallet.publicKey;
 
@@ -252,6 +481,7 @@ export type CreateMPPSolanaNativeChargeClientArgs = {
   wallet: Wallet;
   rpc?: Rpc<SolanaRpcApi> | string;
   broadcast?: boolean;
+  expected?: MPPSolanaChargeClientExpected;
 };
 
 export function createMPPSolanaNativeChargeClient(
@@ -259,6 +489,7 @@ export function createMPPSolanaNativeChargeClient(
 ): MPPPaymentHandler {
   const rpc = args.rpc ? toRpc(args.rpc) : undefined;
   const { wallet, broadcast = false } = args;
+  const expected = normalizeChargeClientExpected(args.expected);
 
   if (broadcast && !rpc) {
     throw new Error("rpc is required when broadcast is true");
@@ -280,13 +511,20 @@ export function createMPPSolanaNativeChargeClient(
     const request = mppChargeRequest(requestBody);
     if (isValidationError(request)) return null;
     if (request.currency !== "sol") return null;
+    if (getChargeClientValidationError(request, wallet.network, expected)) {
+      return null;
+    }
 
     return {
       challenge,
       exec: async (): Promise<mppCredential> => {
         const md = request.methodDetails;
-        const amount = BigInt(request.amount);
-        const recipientKey = address(request.recipient);
+        const memo = getOptionalChargeMemo(request);
+        const primaryAmount = getChargePrimaryAmount(request);
+        const splits = getChargeSplits(request);
+        if (chargeHasATACreationSplits(request)) {
+          throw new Error("ataCreationRequired requires an SPL token charge");
+        }
         const feePayerKey =
           md?.feePayer === true && md.feePayerKey
             ? address(md.feePayerKey)
@@ -304,10 +542,22 @@ export function createMPPSolanaNativeChargeClient(
           getSetComputeUnitPriceInstruction({ microLamports: 1n }),
           getTransferSolInstruction({
             source: walletSigner,
-            destination: recipientKey,
-            amount,
+            destination: address(request.recipient),
+            amount: primaryAmount,
           }),
         ];
+        addMemoInstruction(instructions, memo);
+
+        for (const split of splits) {
+          instructions.push(
+            getTransferSolInstruction({
+              source: walletSigner,
+              destination: address(split.recipient),
+              amount: BigInt(split.amount),
+            }),
+          );
+          addMemoInstruction(instructions, split.memo);
+        }
 
         const payerKey = feePayerKey ?? wallet.publicKey;
 

--- a/packages/payment-solana/src/charge/common.test.ts
+++ b/packages/payment-solana/src/charge/common.test.ts
@@ -1,0 +1,446 @@
+#!/usr/bin/env pnpm tsx
+
+import t from "tap";
+import { isValidationError } from "@faremeter/types";
+import { generateKeyPairSigner } from "@solana/kit";
+import { TOKEN_PROGRAM_ADDRESS } from "@solana-program/token";
+
+import {
+  SOLANA_CHARGE_CURRENCY_MAX_LENGTH,
+  SOLANA_CHARGE_DESCRIPTION_MAX_LENGTH,
+  SOLANA_CHARGE_TRANSACTION_MAX_BYTES,
+  SOLANA_MEMO_MAX_BYTES,
+  chargeCredentialPayload,
+  mppChargeRequest,
+} from "./common";
+import { TOKEN_2022_PROGRAM_ADDRESS } from "../splToken";
+
+const recipient = await generateKeyPairSigner();
+const splitRecipient = await generateKeyPairSigner();
+const mint = await generateKeyPairSigner();
+const feePayer = await generateKeyPairSigner();
+
+function createNativeRequest() {
+  return {
+    amount: "1000000",
+    currency: "sol",
+    recipient: recipient.address,
+    methodDetails: {},
+  };
+}
+
+function createTokenRequest() {
+  return {
+    amount: "1000000",
+    currency: mint.address,
+    recipient: recipient.address,
+    methodDetails: {
+      decimals: 6,
+      tokenProgram: TOKEN_PROGRAM_ADDRESS,
+    },
+  };
+}
+
+await t.test(
+  "mppChargeRequest validates positive uint64 amounts",
+  async (t) => {
+    for (const amount of ["0", "-1", "1.5", "1e3", "01"]) {
+      const request = mppChargeRequest({
+        ...createNativeRequest(),
+        amount,
+      });
+      t.equal(isValidationError(request), true, amount);
+    }
+
+    t.equal(
+      isValidationError(
+        mppChargeRequest({
+          ...createNativeRequest(),
+          amount: "18446744073709551615",
+        }),
+      ),
+      false,
+    );
+    t.equal(
+      isValidationError(
+        mppChargeRequest({
+          ...createNativeRequest(),
+          amount: "18446744073709551616",
+        }),
+      ),
+      true,
+    );
+    t.end();
+  },
+);
+
+await t.test("mppChargeRequest validates Solana public keys", async (t) => {
+  t.equal(
+    isValidationError(
+      mppChargeRequest({
+        ...createNativeRequest(),
+        recipient: "not-base58",
+      }),
+    ),
+    true,
+  );
+  t.equal(
+    isValidationError(
+      mppChargeRequest({
+        ...createTokenRequest(),
+        currency: "not-base58",
+      }),
+    ),
+    true,
+  );
+  t.equal(
+    isValidationError(
+      mppChargeRequest({
+        ...createNativeRequest(),
+        methodDetails: {
+          feePayer: true,
+          feePayerKey: "not-base58",
+        },
+      }),
+    ),
+    true,
+  );
+  t.end();
+});
+
+await t.test("mppChargeRequest enforces length limits", async (t) => {
+  t.equal(
+    isValidationError(
+      mppChargeRequest({
+        ...createTokenRequest(),
+        currency: "x".repeat(SOLANA_CHARGE_CURRENCY_MAX_LENGTH + 1),
+      }),
+    ),
+    true,
+  );
+  t.equal(
+    isValidationError(
+      mppChargeRequest({
+        ...createNativeRequest(),
+        description: "x".repeat(SOLANA_CHARGE_DESCRIPTION_MAX_LENGTH),
+      }),
+    ),
+    false,
+  );
+  t.equal(
+    isValidationError(
+      mppChargeRequest({
+        ...createNativeRequest(),
+        description: "x".repeat(SOLANA_CHARGE_DESCRIPTION_MAX_LENGTH + 1),
+      }),
+    ),
+    true,
+  );
+  t.equal(
+    isValidationError(
+      mppChargeRequest({
+        ...createNativeRequest(),
+        externalId: "x".repeat(SOLANA_MEMO_MAX_BYTES + 1),
+      }),
+    ),
+    true,
+  );
+  t.equal(
+    isValidationError(
+      mppChargeRequest({
+        ...createNativeRequest(),
+        methodDetails: {
+          splits: [
+            {
+              amount: "1",
+              memo: "x".repeat(SOLANA_MEMO_MAX_BYTES + 1),
+              recipient: splitRecipient.address,
+            },
+          ],
+        },
+      }),
+    ),
+    true,
+  );
+  t.end();
+});
+
+await t.test(
+  "mppChargeRequest enforces SPL token method details",
+  async (t) => {
+    for (const decimals of [-1, 1.5, 10]) {
+      const request = mppChargeRequest({
+        ...createTokenRequest(),
+        methodDetails: {
+          decimals,
+          tokenProgram: TOKEN_PROGRAM_ADDRESS,
+        },
+      });
+      t.equal(isValidationError(request), true, String(decimals));
+    }
+
+    t.equal(
+      isValidationError(
+        mppChargeRequest({
+          ...createTokenRequest(),
+          methodDetails: {
+            tokenProgram: TOKEN_PROGRAM_ADDRESS,
+          },
+        }),
+      ),
+      true,
+    );
+    t.equal(
+      isValidationError(
+        mppChargeRequest({
+          ...createTokenRequest(),
+          methodDetails: {
+            decimals: 6,
+          },
+        }),
+      ),
+      false,
+    );
+    t.equal(
+      isValidationError(
+        mppChargeRequest({
+          ...createTokenRequest(),
+          methodDetails: {
+            decimals: 6,
+            tokenProgram: feePayer.address,
+          },
+        }),
+      ),
+      true,
+    );
+    t.equal(
+      isValidationError(
+        mppChargeRequest({
+          ...createTokenRequest(),
+          methodDetails: {
+            decimals: 6,
+            tokenProgram: "not-base58",
+          },
+        }),
+      ),
+      true,
+    );
+    t.equal(
+      isValidationError(
+        mppChargeRequest({
+          ...createTokenRequest(),
+          methodDetails: {
+            decimals: 0,
+            tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
+          },
+        }),
+      ),
+      false,
+    );
+    t.end();
+  },
+);
+
+await t.test("mppChargeRequest enforces SOL method details", async (t) => {
+  t.equal(
+    isValidationError(
+      mppChargeRequest({
+        ...createNativeRequest(),
+        methodDetails: {
+          decimals: 9,
+        },
+      }),
+    ),
+    true,
+  );
+  t.equal(
+    isValidationError(
+      mppChargeRequest({
+        ...createNativeRequest(),
+        methodDetails: {
+          tokenProgram: TOKEN_PROGRAM_ADDRESS,
+        },
+      }),
+    ),
+    true,
+  );
+  t.equal(
+    isValidationError(
+      mppChargeRequest({
+        ...createNativeRequest(),
+        methodDetails: {
+          splits: [
+            {
+              amount: "1",
+              ataCreationRequired: true,
+              recipient: splitRecipient.address,
+            },
+          ],
+        },
+      }),
+    ),
+    true,
+  );
+  t.end();
+});
+
+await t.test("mppChargeRequest validates fee payer fields", async (t) => {
+  t.equal(
+    isValidationError(
+      mppChargeRequest({
+        ...createNativeRequest(),
+        methodDetails: {
+          feePayer: true,
+        },
+      }),
+    ),
+    true,
+  );
+  t.equal(
+    isValidationError(
+      mppChargeRequest({
+        ...createNativeRequest(),
+        methodDetails: {
+          feePayerKey: feePayer.address,
+        },
+      }),
+    ),
+    true,
+  );
+  t.equal(
+    isValidationError(
+      mppChargeRequest({
+        ...createNativeRequest(),
+        methodDetails: {
+          feePayer: false,
+          feePayerKey: feePayer.address,
+        },
+      }),
+    ),
+    true,
+  );
+  t.equal(
+    isValidationError(
+      mppChargeRequest({
+        ...createNativeRequest(),
+        methodDetails: {
+          feePayer: true,
+          feePayerKey: feePayer.address,
+        },
+      }),
+    ),
+    false,
+  );
+  t.end();
+});
+
+await t.test(
+  "mppChargeRequest validates split recipients and totals",
+  async (t) => {
+    t.equal(
+      isValidationError(
+        mppChargeRequest({
+          ...createNativeRequest(),
+          methodDetails: {
+            splits: [
+              {
+                amount: "1",
+                recipient: "not-base58",
+              },
+            ],
+          },
+        }),
+      ),
+      true,
+    );
+    t.equal(
+      isValidationError(
+        mppChargeRequest({
+          ...createNativeRequest(),
+          methodDetails: {
+            splits: [
+              {
+                amount: "1000000",
+                recipient: splitRecipient.address,
+              },
+            ],
+          },
+        }),
+      ),
+      true,
+    );
+    t.equal(
+      isValidationError(
+        mppChargeRequest({
+          ...createNativeRequest(),
+          methodDetails: {
+            splits: [
+              {
+                amount: "999999",
+                recipient: splitRecipient.address,
+              },
+            ],
+          },
+        }),
+      ),
+      false,
+    );
+    t.end();
+  },
+);
+
+await t.test("chargeCredentialPayload validates signatures", async (t) => {
+  t.equal(
+    isValidationError(
+      chargeCredentialPayload({
+        type: "signature",
+        signature: "1".repeat(64),
+      }),
+    ),
+    false,
+  );
+  for (const signature of ["not-base58", "", "1".repeat(63), "1".repeat(65)]) {
+    t.equal(
+      isValidationError(
+        chargeCredentialPayload({
+          type: "signature",
+          signature,
+        }),
+      ),
+      true,
+      signature,
+    );
+  }
+  t.end();
+});
+
+await t.test("chargeCredentialPayload validates transactions", async (t) => {
+  t.equal(
+    isValidationError(
+      chargeCredentialPayload({
+        type: "transaction",
+        transaction: Buffer.alloc(SOLANA_CHARGE_TRANSACTION_MAX_BYTES).toString(
+          "base64",
+        ),
+      }),
+    ),
+    false,
+  );
+  for (const transaction of [
+    "",
+    "not-base64",
+    Buffer.alloc(SOLANA_CHARGE_TRANSACTION_MAX_BYTES + 1).toString("base64"),
+  ]) {
+    t.equal(
+      isValidationError(
+        chargeCredentialPayload({
+          type: "transaction",
+          transaction,
+        }),
+      ),
+      true,
+      transaction.length.toString(),
+    );
+  }
+  t.end();
+});

--- a/packages/payment-solana/src/charge/common.ts
+++ b/packages/payment-solana/src/charge/common.ts
@@ -1,4 +1,73 @@
 import { type } from "arktype";
+import { address, getBase58Encoder, getBase64Encoder } from "@solana/kit";
+import { TOKEN_PROGRAM_ADDRESS } from "@solana-program/token";
+
+import { TOKEN_2022_PROGRAM_ADDRESS } from "../splToken";
+
+export const SOLANA_CHARGE_MAX_SPLITS = 8;
+export const SOLANA_MEMO_MAX_BYTES = 566;
+export const SOLANA_CHARGE_CURRENCY_MAX_LENGTH = 128;
+export const SOLANA_CHARGE_DESCRIPTION_MAX_LENGTH = 256;
+export const SOLANA_CHARGE_TRANSACTION_MAX_BYTES = 1232;
+
+const SOLANA_U64_MAX = "18446744073709551615";
+const SOLANA_NATIVE_CURRENCY = "sol";
+const SOLANA_CHARGE_DECIMALS_MIN = 0;
+const SOLANA_CHARGE_DECIMALS_MAX = 9;
+const SOLANA_TOKEN_PROGRAMS = new Set<string>([
+  TOKEN_PROGRAM_ADDRESS,
+  TOKEN_2022_PROGRAM_ADDRESS,
+]);
+
+const memoEncoder = new TextEncoder();
+const base58Encoder = getBase58Encoder();
+const base64Encoder = getBase64Encoder();
+
+const solanaAtomicAmount = type(/^[1-9][0-9]*$/).pipe.try((amount) => {
+  if (!isUint64Amount(amount)) {
+    throw new Error("amount must fit in uint64");
+  }
+  return amount;
+});
+const solanaChargeSplit = type({
+  recipient: "string",
+  amount: solanaAtomicAmount,
+  "ataCreationRequired?": "boolean",
+  "memo?": "string",
+});
+
+const solanaSignature = type("string").pipe.try((signature) => {
+  let bytes;
+  try {
+    bytes = base58Encoder.encode(signature);
+  } catch {
+    throw new Error("signature must be base58 encoded");
+  }
+
+  if (bytes.byteLength !== 64) {
+    throw new Error("signature must decode to 64 bytes");
+  }
+  return signature;
+});
+
+const solanaWireTransaction = type("string").pipe.try((transaction) => {
+  let bytes;
+  try {
+    bytes = base64Encoder.encode(transaction);
+  } catch {
+    throw new Error("transaction must be base64 encoded");
+  }
+
+  if (bytes.byteLength === 0) {
+    throw new Error("transaction must not be empty");
+  }
+  if (bytes.byteLength > SOLANA_CHARGE_TRANSACTION_MAX_BYTES) {
+    throw new Error(
+      `transaction exceeds ${SOLANA_CHARGE_TRANSACTION_MAX_BYTES} bytes`,
+    );
+  }
+  return transaction;
+});
 
 export const solanaChargeMethodDetails = type({
   "network?": "string",
@@ -7,17 +76,13 @@ export const solanaChargeMethodDetails = type({
   "feePayer?": "boolean",
   "feePayerKey?": "string",
   "recentBlockhash?": "string",
-  "splits?": type({
-    recipient: "string",
-    amount: "string",
-    "memo?": "string",
-  }).array(),
+  "splits?": solanaChargeSplit.array().atMostLength(SOLANA_CHARGE_MAX_SPLITS),
 });
 
 export type solanaChargeMethodDetails = typeof solanaChargeMethodDetails.infer;
 
-export const mppChargeRequest = type({
-  amount: "string.numeric",
+const mppChargeRequestShape = type({
+  amount: solanaAtomicAmount,
   currency: "string",
   recipient: "string",
   "description?": "string",
@@ -25,17 +90,211 @@ export const mppChargeRequest = type({
   "methodDetails?": solanaChargeMethodDetails,
 });
 
+type MPPChargeRequestShape = typeof mppChargeRequestShape.infer;
+
+export const mppChargeRequest = mppChargeRequestShape.pipe.try((request) => {
+  const error = getChargeRequestValidationError(request);
+  if (error) throw new Error(error);
+  return request;
+});
+
 export type mppChargeRequest = typeof mppChargeRequest.infer;
+
+export function getChargeSplits(request: mppChargeRequest) {
+  return request.methodDetails?.splits ?? [];
+}
+
+export function chargeHasATACreationSplits(request: mppChargeRequest): boolean {
+  return getChargeSplits(request).some(
+    (split) => split.ataCreationRequired === true,
+  );
+}
+
+export function getChargePrimaryAmount(request: mppChargeRequest): bigint {
+  const amount = BigInt(request.amount);
+  const splitsTotal = getChargeSplits(request).reduce(
+    (sum, split) => sum + BigInt(split.amount),
+    0n,
+  );
+  const primaryAmount = amount - splitsTotal;
+  if (primaryAmount <= 0n) {
+    throw new Error("splits consume the entire amount");
+  }
+  return primaryAmount;
+}
+
+export function getChargeChallengeMemo(
+  request: mppChargeRequest,
+): string | undefined {
+  return request.externalId;
+}
+
+export function getChargeMemoValidationError(memo: string): string | null {
+  if (memoEncoder.encode(memo).byteLength > SOLANA_MEMO_MAX_BYTES) {
+    return `Memo exceeds ${SOLANA_MEMO_MAX_BYTES} bytes`;
+  }
+  return null;
+}
+
+export function getChargeRequestMemoValidationError(
+  request: mppChargeRequest,
+): string | null {
+  const challengeMemo = request.externalId;
+  if (challengeMemo !== undefined && challengeMemo.length > 0) {
+    const error = getChargeMemoValidationError(challengeMemo);
+    if (error) return error;
+  }
+
+  for (const split of request.methodDetails?.splits ?? []) {
+    if (split.memo !== undefined && split.memo.length > 0) {
+      const error = getChargeMemoValidationError(split.memo);
+      if (error) return error;
+    }
+  }
+
+  return null;
+}
+
+function getChargeRequestValidationError(
+  request: MPPChargeRequestShape,
+): string | null {
+  if (!isUint64Amount(request.amount)) {
+    return "amount must be a positive uint64";
+  }
+
+  if (request.currency.length > SOLANA_CHARGE_CURRENCY_MAX_LENGTH) {
+    return `currency exceeds ${SOLANA_CHARGE_CURRENCY_MAX_LENGTH} characters`;
+  }
+
+  const isNative = request.currency === SOLANA_NATIVE_CURRENCY;
+  if (!isNative && !isSolanaAddress(request.currency)) {
+    return "currency must be 'sol' or a base58 Solana address";
+  }
+
+  if (!isSolanaAddress(request.recipient)) {
+    return "recipient must be a base58 Solana address";
+  }
+
+  if (
+    request.description !== undefined &&
+    request.description.length > SOLANA_CHARGE_DESCRIPTION_MAX_LENGTH
+  ) {
+    return `description exceeds ${SOLANA_CHARGE_DESCRIPTION_MAX_LENGTH} characters`;
+  }
+
+  const memoError = getChargeRequestMemoValidationError(request);
+  if (memoError) return memoError;
+
+  const methodDetails = request.methodDetails;
+  const decimalsError = getDecimalsValidationError(methodDetails?.decimals);
+  if (decimalsError) return decimalsError;
+
+  if (isNative) {
+    const nativeError = getNativeChargeValidationError(methodDetails);
+    if (nativeError) return nativeError;
+  } else {
+    const tokenError = getTokenChargeValidationError(methodDetails);
+    if (tokenError) return tokenError;
+  }
+
+  if (methodDetails?.feePayer === true) {
+    if (methodDetails.feePayerKey === undefined) {
+      return "feePayerKey is required when feePayer is true";
+    }
+    if (!isSolanaAddress(methodDetails.feePayerKey)) {
+      return "feePayerKey must be a base58 Solana address";
+    }
+  } else if (methodDetails?.feePayerKey !== undefined) {
+    return "feePayerKey must be absent unless feePayer is true";
+  }
+
+  let splitsTotal = 0n;
+  for (const split of methodDetails?.splits ?? []) {
+    if (!isSolanaAddress(split.recipient)) {
+      return "split recipient must be a base58 Solana address";
+    }
+    splitsTotal += BigInt(split.amount);
+  }
+
+  if (splitsTotal >= BigInt(request.amount)) {
+    return "splits consume the entire amount";
+  }
+
+  return null;
+}
+
+function getDecimalsValidationError(decimals: number | undefined) {
+  if (decimals === undefined) return null;
+  if (
+    !Number.isInteger(decimals) ||
+    decimals < SOLANA_CHARGE_DECIMALS_MIN ||
+    decimals > SOLANA_CHARGE_DECIMALS_MAX
+  ) {
+    return `decimals must be an integer from ${SOLANA_CHARGE_DECIMALS_MIN} to ${SOLANA_CHARGE_DECIMALS_MAX}`;
+  }
+  return null;
+}
+
+function getNativeChargeValidationError(
+  methodDetails: MPPChargeRequestShape["methodDetails"],
+) {
+  if (methodDetails?.decimals !== undefined) {
+    return "decimals must be absent for SOL charges";
+  }
+  if (methodDetails?.tokenProgram !== undefined) {
+    return "tokenProgram must be absent for SOL charges";
+  }
+  if (
+    (methodDetails?.splits ?? []).some(
+      (split) => split.ataCreationRequired === true,
+    )
+  ) {
+    return "ataCreationRequired requires an SPL token charge";
+  }
+  return null;
+}
+
+function getTokenChargeValidationError(
+  methodDetails: MPPChargeRequestShape["methodDetails"],
+) {
+  if (methodDetails?.decimals === undefined) {
+    return "decimals is required for SPL token charges";
+  }
+  if (methodDetails.tokenProgram === undefined) return null;
+  if (!isSolanaAddress(methodDetails.tokenProgram)) {
+    return "tokenProgram must be a base58 Solana address";
+  }
+  if (!SOLANA_TOKEN_PROGRAMS.has(methodDetails.tokenProgram)) {
+    return "tokenProgram must be the SPL Token or Token-2022 program";
+  }
+  return null;
+}
+
+function isSolanaAddress(value: string): boolean {
+  try {
+    address(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isUint64Amount(amount: string): boolean {
+  return (
+    amount.length < SOLANA_U64_MAX.length ||
+    (amount.length === SOLANA_U64_MAX.length && amount <= SOLANA_U64_MAX)
+  );
+}
 
 export const chargeCredentialPayload = type(
   {
     type: "'transaction'",
-    transaction: "string",
+    transaction: solanaWireTransaction,
   },
   "|",
   {
     type: "'signature'",
-    signature: "string",
+    signature: solanaSignature,
   },
 );
 

--- a/packages/payment-solana/src/charge/replay.test.ts
+++ b/packages/payment-solana/src/charge/replay.test.ts
@@ -1,0 +1,45 @@
+#!/usr/bin/env pnpm tsx
+
+import t from "tap";
+
+import { createInMemoryReplayStore } from "./replay";
+import type { ReplayStore } from "./replay";
+
+async function claim(store: ReplayStore, id: string, expiresAt?: number) {
+  return store.claim(id, expiresAt);
+}
+
+await t.test("in-memory replay store claims IDs once", async (t) => {
+  const store = createInMemoryReplayStore();
+
+  t.equal(await claim(store, "signature-a"), true);
+  t.equal(await claim(store, "signature-a"), false);
+  t.end();
+});
+
+await t.test("in-memory replay store expires claimed IDs", async (t) => {
+  const store = createInMemoryReplayStore();
+
+  t.equal(await claim(store, "signature-a", Date.now() - 1), true);
+  t.equal(await claim(store, "signature-a"), true);
+  t.end();
+});
+
+await t.test("in-memory replay store releases claimed IDs", async (t) => {
+  const store = createInMemoryReplayStore();
+
+  t.equal(await claim(store, "signature-a"), true);
+  t.equal(await claim(store, "signature-a"), false);
+  await store.release("signature-a");
+  t.equal(await claim(store, "signature-a"), true);
+  t.end();
+});
+
+await t.test("in-memory replay store consumes pre-added IDs", async (t) => {
+  const store = createInMemoryReplayStore();
+
+  await store.add("challenge-a");
+  t.equal(await store.consume("challenge-a"), true);
+  t.equal(await store.consume("challenge-a"), false);
+  t.end();
+});

--- a/packages/payment-solana/src/charge/replay.ts
+++ b/packages/payment-solana/src/charge/replay.ts
@@ -1,12 +1,17 @@
 /**
- * Replay protection store for MPP challenge IDs.
+ * Replay protection store for MPP challenge IDs and consumed signatures.
  *
  * `consume` atomically checks whether an ID is valid and marks it as
  * used, preventing TOCTOU races in concurrent settlement attempts.
+ * `claim` atomically records an ID only when it has not been seen before.
+ * `release` removes a claimed ID when the operation that claimed it did not
+ * commit.
  */
 export interface ReplayStore {
   consume(id: string): Promise<boolean>;
   add(id: string, expiresAt?: number): Promise<void>;
+  claim(id: string, expiresAt?: number): Promise<boolean>;
+  release(id: string): Promise<void>;
 }
 
 export function createInMemoryReplayStore(): ReplayStore {
@@ -25,6 +30,16 @@ export function createInMemoryReplayStore(): ReplayStore {
     async add(id, expiresAt) {
       prune();
       store.set(id, expiresAt ?? 0);
+    },
+    async claim(id, expiresAt) {
+      prune();
+      if (store.has(id)) return false;
+      store.set(id, expiresAt ?? 0);
+      return true;
+    },
+    async release(id) {
+      prune();
+      store.delete(id);
     },
     async consume(id) {
       prune();

--- a/packages/payment-solana/src/charge/server.test.ts
+++ b/packages/payment-solana/src/charge/server.test.ts
@@ -1,0 +1,1115 @@
+#!/usr/bin/env pnpm tsx
+
+import t from "tap";
+import { isValidationError } from "@faremeter/types";
+import {
+  canonicalizeSortedJSON,
+  decodeBase64URL,
+  encodeBase64URL,
+  type mppChallengeParams,
+} from "@faremeter/types/mpp";
+import {
+  getBase64Encoder,
+  generateKeyPairSigner,
+  type Rpc,
+  type SolanaRpcApi,
+} from "@solana/kit";
+import { TOKEN_PROGRAM_ADDRESS } from "@solana-program/token";
+import {
+  getSignatureFromTransaction,
+  getTransactionDecoder,
+  partiallySignTransaction,
+} from "@solana/transactions";
+
+import {
+  createMPPSolanaChargeClient,
+  createMPPSolanaNativeChargeClient,
+} from "./client";
+import { chargeCredentialPayload, mppChargeRequest } from "./common";
+import { createInMemoryReplayStore } from "./replay";
+import type { ReplayStore } from "./replay";
+import {
+  createMPPSolanaChargeHandler,
+  createMPPSolanaNativeChargeHandler,
+} from "./server";
+import type { Wallet } from "../exact/client";
+
+const FAKE_BLOCKHASH = "EETubP46DHLkT9hAFKy4x2BoFUqUFvKjiiNVY3CaYRi3";
+const SIGNATURE =
+  "1111111111111111111111111111111111111111111111111111111111111111";
+const SETTLEMENT_SIGNATURE =
+  "2AXDGYSE4f2sz7tvMMzyHvUfcoJmxudvdhBcmiUSo6ijwfYmfZYsKRxboQMPh3R4kUhXRVdtSXFXMheka4Rc4P2";
+const TOKEN_SIGNATURE =
+  "3L3RY5sT8K4kyEnqhizwaqxLEbcYvpGrGPNEYRwtbCSUtL6YL86jdrvCbohnP5q8VxQ3qzGmt3W3iQJW97rD7m3";
+const SECRET_KEY = new Uint8Array(32).fill(1);
+const RECEIPT_TIMESTAMP_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/;
+
+async function createWallet(): Promise<Wallet> {
+  const signer = await generateKeyPairSigner();
+  return {
+    network: "devnet",
+    publicKey: signer.address,
+    partiallySignTransaction: (tx) =>
+      partiallySignTransaction([signer.keyPair], tx),
+  };
+}
+
+function getTransactionPayload(payload: unknown) {
+  const validatedPayload = chargeCredentialPayload(payload);
+  if (isValidationError(validatedPayload)) {
+    throw new Error(validatedPayload.summary);
+  }
+  if (validatedPayload.type !== "transaction") {
+    throw new Error("expected transaction payload");
+  }
+  return validatedPayload.transaction;
+}
+
+function getPayloadTransactionSignature(transaction: string) {
+  const txBytes = getBase64Encoder().encode(transaction);
+  const decodedTx = getTransactionDecoder().decode(txBytes);
+  return getSignatureFromTransaction(decodedTx);
+}
+
+type CreateFakeRpcOpts = {
+  onSendTransaction?: (transaction: string) => void;
+  signatureStatus?: {
+    confirmationStatus?: "confirmed" | "finalized" | "processed" | null;
+    err?: unknown;
+  } | null;
+  simulationError?: unknown;
+};
+
+function createFakeRpc(
+  getTransactionBase64?: () => string,
+  opts: CreateFakeRpcOpts = {},
+): Rpc<SolanaRpcApi> {
+  let sentTransactionBase64 = "";
+  const signatureStatus =
+    opts.signatureStatus === undefined
+      ? { confirmationStatus: "confirmed", err: null }
+      : opts.signatureStatus;
+
+  return {
+    getAccountInfo: () => ({
+      send: async () => ({
+        value: {
+          data: [createMintAccountBase64(6), "base64"],
+          executable: false,
+          lamports: 1_000_000n,
+          owner: TOKEN_PROGRAM_ADDRESS,
+          space: 82n,
+        },
+      }),
+    }),
+    getLatestBlockhash: () => ({
+      send: async () => ({
+        value: {
+          blockhash: FAKE_BLOCKHASH,
+          lastValidBlockHeight: 1000n,
+        },
+      }),
+    }),
+    getSignatureStatuses: () => ({
+      send: async () => ({
+        value: [signatureStatus],
+      }),
+    }),
+    getTransaction: () => ({
+      send: async () => ({
+        meta: { err: null },
+        transaction: [
+          getTransactionBase64?.() ?? sentTransactionBase64,
+          "base64",
+        ],
+      }),
+    }),
+    sendTransaction: (transaction: string) => ({
+      send: async () => {
+        sentTransactionBase64 = transaction;
+        opts.onSendTransaction?.(transaction);
+        return SETTLEMENT_SIGNATURE;
+      },
+    }),
+    simulateTransaction: () => ({
+      send: async () => ({
+        value: { err: opts.simulationError ?? null },
+      }),
+    }),
+  } as unknown as Rpc<SolanaRpcApi>;
+}
+
+function createMintAccountBase64(decimals: number) {
+  const data = new Uint8Array(82);
+  data[44] = decimals;
+  data[45] = 1;
+  return Buffer.from(data).toString("base64");
+}
+
+async function claim(store: ReplayStore, id: string) {
+  return store.claim(id);
+}
+
+async function generateChallengeID(
+  secret: Uint8Array,
+  params: Omit<mppChallengeParams, "id">,
+): Promise<string> {
+  const slots = [
+    params.realm,
+    params.method,
+    params.intent,
+    params.request,
+    params.expires ?? "",
+    params.digest ?? "",
+    params.opaque ?? "",
+  ];
+  const message = new TextEncoder().encode(slots.join("|"));
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new Uint8Array(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const sig = await crypto.subtle.sign("HMAC", key, message);
+  return encodeBase64URL(String.fromCharCode(...new Uint8Array(sig)));
+}
+
+async function replaceChallengeRequest(
+  challenge: mppChallengeParams,
+  request: unknown,
+  secretKey: Uint8Array,
+): Promise<mppChallengeParams> {
+  const requestEncoded = encodeBase64URL(canonicalizeSortedJSON(request));
+  const nextParams: Omit<mppChallengeParams, "id"> = {
+    realm: challenge.realm,
+    method: challenge.method,
+    intent: challenge.intent,
+    request: requestEncoded,
+    ...(challenge.expires !== undefined ? { expires: challenge.expires } : {}),
+    ...(challenge.description !== undefined
+      ? { description: challenge.description }
+      : {}),
+    ...(challenge.opaque !== undefined ? { opaque: challenge.opaque } : {}),
+    ...(challenge.digest !== undefined ? { digest: challenge.digest } : {}),
+  };
+  const id = await generateChallengeID(secretKey, nextParams);
+  return { id, ...nextParams };
+}
+
+async function replaceChallengeExpires(
+  challenge: mppChallengeParams,
+  expires: string,
+  secretKey: Uint8Array,
+): Promise<mppChallengeParams> {
+  const nextParams: Omit<mppChallengeParams, "id"> = {
+    realm: challenge.realm,
+    method: challenge.method,
+    intent: challenge.intent,
+    request: challenge.request,
+    expires,
+    ...(challenge.description !== undefined
+      ? { description: challenge.description }
+      : {}),
+    ...(challenge.opaque !== undefined ? { opaque: challenge.opaque } : {}),
+    ...(challenge.digest !== undefined ? { digest: challenge.digest } : {}),
+  };
+  const id = await generateChallengeID(secretKey, nextParams);
+  return { id, ...nextParams };
+}
+
+await t.test("charge request rejects malformed split amounts", async (t) => {
+  const receiver = await generateKeyPairSigner();
+  const splitReceiver = await generateKeyPairSigner();
+  for (const amount of ["not-a-number", "1.5", "-1", "0"]) {
+    const request = mppChargeRequest({
+      amount: "1000000",
+      currency: "sol",
+      externalId: "challenge-a",
+      recipient: receiver.address,
+      methodDetails: {
+        splits: [
+          {
+            amount,
+            recipient: splitReceiver.address,
+          },
+        ],
+      },
+    });
+
+    t.equal(isValidationError(request), true, amount);
+  }
+  t.end();
+});
+
+await t.test("charge request rejects too many splits", async (t) => {
+  const receiver = await generateKeyPairSigner();
+  const splitReceiver = await generateKeyPairSigner();
+  const request = mppChargeRequest({
+    amount: "1000000",
+    currency: "sol",
+    externalId: "challenge-a",
+    recipient: receiver.address,
+    methodDetails: {
+      splits: Array.from({ length: 9 }, () => ({
+        amount: "1",
+        recipient: splitReceiver.address,
+      })),
+    },
+  });
+
+  t.equal(isValidationError(request), true);
+  t.end();
+});
+
+await t.test(
+  "native charge challenges bind externalId memo and claim push signatures",
+  async (t) => {
+    let transactionBase64 = "";
+    const rpc = createFakeRpc(() => transactionBase64);
+    const replayStore = createInMemoryReplayStore();
+    const handler = await createMPPSolanaNativeChargeHandler({
+      network: "devnet",
+      rpc,
+      replayStore,
+      realm: "test",
+      secretKey: new Uint8Array(32).fill(1),
+    });
+
+    const receiver = await generateKeyPairSigner();
+    const challenge = await handler.getChallenge(
+      "charge",
+      {
+        amount: "1000000",
+        asset: "sol",
+        recipient: receiver.address,
+        network: "solana:devnet",
+      },
+      "https://example.test/resource",
+    );
+
+    const request = mppChargeRequest(
+      JSON.parse(decodeBase64URL(challenge.request)),
+    );
+    if (isValidationError(request)) {
+      throw new Error(request.summary);
+    }
+    t.match(challenge.expires, RECEIPT_TIMESTAMP_RE);
+    t.ok(request.externalId);
+    t.notOk(Object.hasOwn(request.methodDetails ?? {}, "memo"));
+    t.notOk(Object.hasOwn(request.methodDetails ?? {}, "decimals"));
+
+    const client = createMPPSolanaNativeChargeClient({
+      wallet: await createWallet(),
+      rpc,
+    });
+    const execer = await client(challenge);
+    if (!execer) {
+      throw new Error("expected client to handle native charge challenge");
+    }
+    const credential = await execer.exec();
+    transactionBase64 = getTransactionPayload(credential.payload);
+
+    const receipt = await handler.handleSettle({
+      challenge,
+      payload: { type: "signature", signature: SIGNATURE },
+    });
+
+    t.match(receipt, {
+      status: "success",
+      method: "solana",
+      challengeId: challenge.id,
+      timestamp: RECEIPT_TIMESTAMP_RE,
+      reference: SIGNATURE,
+    });
+    t.equal(
+      await claim(replayStore, `solana-charge:consumed:${SIGNATURE}`),
+      false,
+    );
+    t.end();
+  },
+);
+
+await t.test("native charge settles without externalId", async (t) => {
+  const rpc = createFakeRpc();
+  const replayStore = createInMemoryReplayStore();
+  const handler = await createMPPSolanaNativeChargeHandler({
+    network: "devnet",
+    rpc,
+    replayStore,
+    realm: "test",
+    secretKey: SECRET_KEY,
+  });
+
+  const receiver = await generateKeyPairSigner();
+  const challenge = await handler.getChallenge(
+    "charge",
+    {
+      amount: "1000000",
+      asset: "sol",
+      recipient: receiver.address,
+      network: "solana:devnet",
+    },
+    "https://example.test/resource",
+  );
+
+  const request = mppChargeRequest(
+    JSON.parse(decodeBase64URL(challenge.request)),
+  );
+  if (isValidationError(request)) {
+    throw new Error(request.summary);
+  }
+  const requestWithoutExternalId = { ...request, externalId: undefined };
+  const challengeWithoutExternalId = await replaceChallengeRequest(
+    challenge,
+    requestWithoutExternalId,
+    SECRET_KEY,
+  );
+  await replayStore.add(challengeWithoutExternalId.id, Date.now() + 60_000);
+
+  const client = createMPPSolanaNativeChargeClient({
+    wallet: await createWallet(),
+    rpc,
+  });
+  const execer = await client(challengeWithoutExternalId);
+  if (!execer) {
+    throw new Error("expected client to handle native charge challenge");
+  }
+
+  const receipt = await handler.handleSettle(await execer.exec());
+
+  t.match(receipt, {
+    status: "success",
+    method: "solana",
+    challengeId: challengeWithoutExternalId.id,
+    timestamp: RECEIPT_TIMESTAMP_RE,
+    reference: SETTLEMENT_SIGNATURE,
+  });
+  t.end();
+});
+
+await t.test(
+  "native charge settles with legacy unix-second expiry",
+  async (t) => {
+    const rpc = createFakeRpc();
+    const replayStore = createInMemoryReplayStore();
+    const handler = await createMPPSolanaNativeChargeHandler({
+      network: "devnet",
+      rpc,
+      replayStore,
+      realm: "test",
+      secretKey: SECRET_KEY,
+    });
+
+    const receiver = await generateKeyPairSigner();
+    const challenge = await handler.getChallenge(
+      "charge",
+      {
+        amount: "1000000",
+        asset: "sol",
+        recipient: receiver.address,
+        network: "solana:devnet",
+      },
+      "https://example.test/resource",
+    );
+    const legacyChallenge = await replaceChallengeExpires(
+      challenge,
+      String(Math.floor(Date.now() / 1000) + 60),
+      SECRET_KEY,
+    );
+    await replayStore.add(legacyChallenge.id, Date.now() + 60_000);
+
+    const client = createMPPSolanaNativeChargeClient({
+      wallet: await createWallet(),
+      rpc,
+    });
+    const execer = await client(legacyChallenge);
+    if (!execer) {
+      throw new Error("expected client to handle native charge challenge");
+    }
+
+    const receipt = await handler.handleSettle(await execer.exec());
+
+    t.match(receipt, {
+      status: "success",
+      method: "solana",
+      challengeId: legacyChallenge.id,
+      timestamp: RECEIPT_TIMESTAMP_RE,
+      reference: SETTLEMENT_SIGNATURE,
+    });
+    t.end();
+  },
+);
+
+await t.test(
+  "native charge settles client-paid pull transactions without fee payer",
+  async (t) => {
+    const rpc = createFakeRpc();
+    const replayStore = createInMemoryReplayStore();
+    const handler = await createMPPSolanaNativeChargeHandler({
+      network: "devnet",
+      rpc,
+      replayStore,
+      realm: "test",
+      secretKey: new Uint8Array(32).fill(1),
+    });
+
+    const receiver = await generateKeyPairSigner();
+    const challenge = await handler.getChallenge(
+      "charge",
+      {
+        amount: "1000000",
+        asset: "sol",
+        recipient: receiver.address,
+        network: "solana:devnet",
+      },
+      "https://example.test/resource",
+    );
+
+    const client = createMPPSolanaNativeChargeClient({
+      wallet: await createWallet(),
+      rpc,
+    });
+    const execer = await client(challenge);
+    if (!execer) {
+      throw new Error("expected client to handle native charge challenge");
+    }
+    const credential = await execer.exec();
+    const transactionSignature = getPayloadTransactionSignature(
+      getTransactionPayload(credential.payload),
+    );
+
+    const receipt = await handler.handleSettle(credential);
+
+    t.match(receipt, {
+      status: "success",
+      method: "solana",
+      challengeId: challenge.id,
+      timestamp: RECEIPT_TIMESTAMP_RE,
+      reference: SETTLEMENT_SIGNATURE,
+    });
+    t.equal(
+      await claim(
+        replayStore,
+        `solana-charge:consumed:${transactionSignature}`,
+      ),
+      false,
+    );
+    t.end();
+  },
+);
+
+await t.test(
+  "native charge rejects pull when the confirmed transaction differs",
+  async (t) => {
+    let confirmedTransactionBase64 = "";
+    const rpc = createFakeRpc(() => confirmedTransactionBase64);
+    const replayStore = createInMemoryReplayStore();
+    const handler = await createMPPSolanaNativeChargeHandler({
+      network: "devnet",
+      rpc,
+      replayStore,
+      realm: "test",
+      secretKey: SECRET_KEY,
+    });
+
+    const receiver = await generateKeyPairSigner();
+    const challenge = await handler.getChallenge(
+      "charge",
+      {
+        amount: "1000000",
+        asset: "sol",
+        recipient: receiver.address,
+        network: "solana:devnet",
+      },
+      "https://example.test/resource",
+    );
+    const request = mppChargeRequest(
+      JSON.parse(decodeBase64URL(challenge.request)),
+    );
+    if (isValidationError(request)) {
+      throw new Error(request.summary);
+    }
+
+    const client = createMPPSolanaNativeChargeClient({
+      wallet: await createWallet(),
+      rpc,
+    });
+    const execer = await client(challenge);
+    if (!execer) {
+      throw new Error("expected client to handle native charge challenge");
+    }
+    const credential = await execer.exec();
+
+    const wrongReceiver = await generateKeyPairSigner();
+    const wrongChallenge = await replaceChallengeRequest(
+      challenge,
+      { ...request, recipient: wrongReceiver.address },
+      SECRET_KEY,
+    );
+    const wrongExecer = await client(wrongChallenge);
+    if (!wrongExecer) {
+      throw new Error("expected client to handle modified native challenge");
+    }
+    const wrongCredential = await wrongExecer.exec();
+    confirmedTransactionBase64 = getTransactionPayload(wrongCredential.payload);
+
+    await t.rejects(handler.handleSettle(credential), {
+      message:
+        /confirmed transaction verification failed: no matching transferSol instruction found/,
+    });
+    t.end();
+  },
+);
+
+await t.test(
+  "native charge rejects consumed pull signatures before sending",
+  async (t) => {
+    let sendCount = 0;
+    const rpc = createFakeRpc(undefined, {
+      onSendTransaction: () => {
+        sendCount += 1;
+      },
+    });
+    const replayStore = createInMemoryReplayStore();
+    const handler = await createMPPSolanaNativeChargeHandler({
+      network: "devnet",
+      rpc,
+      replayStore,
+      realm: "test",
+      secretKey: new Uint8Array(32).fill(1),
+    });
+
+    const receiver = await generateKeyPairSigner();
+    const challenge = await handler.getChallenge(
+      "charge",
+      {
+        amount: "1000000",
+        asset: "sol",
+        recipient: receiver.address,
+        network: "solana:devnet",
+      },
+      "https://example.test/resource",
+    );
+
+    const client = createMPPSolanaNativeChargeClient({
+      wallet: await createWallet(),
+      rpc,
+    });
+    const execer = await client(challenge);
+    if (!execer) {
+      throw new Error("expected client to handle native charge challenge");
+    }
+    const credential = await execer.exec();
+    const transactionSignature = getPayloadTransactionSignature(
+      getTransactionPayload(credential.payload),
+    );
+
+    t.equal(
+      await claim(
+        replayStore,
+        `solana-charge:consumed:${transactionSignature}`,
+      ),
+      true,
+    );
+    await t.rejects(handler.handleSettle(credential), {
+      message: "transaction signature already consumed",
+    });
+    t.equal(sendCount, 0);
+    t.end();
+  },
+);
+
+await t.test(
+  "native charge releases pull signatures when simulation fails",
+  async (t) => {
+    let sendCount = 0;
+    const rpc = createFakeRpc(undefined, {
+      onSendTransaction: () => {
+        sendCount += 1;
+      },
+      simulationError: { InstructionError: [0, "Custom"] },
+    });
+    const replayStore = createInMemoryReplayStore();
+    const handler = await createMPPSolanaNativeChargeHandler({
+      network: "devnet",
+      rpc,
+      replayStore,
+      realm: "test",
+      secretKey: SECRET_KEY,
+    });
+
+    const receiver = await generateKeyPairSigner();
+    const challenge = await handler.getChallenge(
+      "charge",
+      {
+        amount: "1000000",
+        asset: "sol",
+        recipient: receiver.address,
+        network: "solana:devnet",
+      },
+      "https://example.test/resource",
+    );
+
+    const client = createMPPSolanaNativeChargeClient({
+      wallet: await createWallet(),
+      rpc,
+    });
+    const execer = await client(challenge);
+    if (!execer) {
+      throw new Error("expected client to handle native charge challenge");
+    }
+    const credential = await execer.exec();
+    const transactionSignature = getPayloadTransactionSignature(
+      getTransactionPayload(credential.payload),
+    );
+
+    await t.rejects(
+      handler.handleSettle(credential, createChargeContext(challenge)),
+      { message: "settlement failed: Transaction simulation failed" },
+    );
+
+    t.equal(sendCount, 0);
+    t.equal(
+      await claim(
+        replayStore,
+        `solana-charge:consumed:${transactionSignature}`,
+      ),
+      true,
+    );
+    t.end();
+  },
+);
+
+await t.test(
+  "native charge keeps pull signatures claimed after submit timeout",
+  async (t) => {
+    let sendCount = 0;
+    const rpc = createFakeRpc(undefined, {
+      onSendTransaction: () => {
+        sendCount += 1;
+      },
+      signatureStatus: null,
+    });
+    const replayStore = createInMemoryReplayStore();
+    const handler = await createMPPSolanaNativeChargeHandler({
+      network: "devnet",
+      rpc,
+      replayStore,
+      realm: "test",
+      secretKey: SECRET_KEY,
+      maxRetries: 1,
+      retryDelayMs: 0,
+    });
+
+    const receiver = await generateKeyPairSigner();
+    const challenge = await handler.getChallenge(
+      "charge",
+      {
+        amount: "1000000",
+        asset: "sol",
+        recipient: receiver.address,
+        network: "solana:devnet",
+      },
+      "https://example.test/resource",
+    );
+
+    const client = createMPPSolanaNativeChargeClient({
+      wallet: await createWallet(),
+      rpc,
+    });
+    const execer = await client(challenge);
+    if (!execer) {
+      throw new Error("expected client to handle native charge challenge");
+    }
+    const credential = await execer.exec();
+    const transactionSignature = getPayloadTransactionSignature(
+      getTransactionPayload(credential.payload),
+    );
+
+    await t.rejects(
+      handler.handleSettle(credential, createChargeContext(challenge)),
+      { message: "settlement failed: Transaction confirmation timeout" },
+    );
+
+    t.equal(sendCount, 1);
+    t.equal(
+      await claim(
+        replayStore,
+        `solana-charge:consumed:${transactionSignature}`,
+      ),
+      false,
+    );
+    t.end();
+  },
+);
+
+await t.test("native charge rejects consumed push signatures", async (t) => {
+  let transactionBase64 = "";
+  const rpc = createFakeRpc(() => transactionBase64);
+  const replayStore = createInMemoryReplayStore();
+  const handler = await createMPPSolanaNativeChargeHandler({
+    network: "devnet",
+    rpc,
+    replayStore,
+    realm: "test",
+    secretKey: new Uint8Array(32).fill(1),
+  });
+
+  const receiver = await generateKeyPairSigner();
+  const challenge = await handler.getChallenge(
+    "charge",
+    {
+      amount: "1000000",
+      asset: "sol",
+      recipient: receiver.address,
+      network: "solana:devnet",
+    },
+    "https://example.test/resource",
+  );
+
+  const client = createMPPSolanaNativeChargeClient({
+    wallet: await createWallet(),
+    rpc,
+  });
+  const execer = await client(challenge);
+  if (!execer) {
+    throw new Error("expected client to handle native charge challenge");
+  }
+  const credential = await execer.exec();
+  transactionBase64 = getTransactionPayload(credential.payload);
+
+  t.equal(
+    await claim(replayStore, `solana-charge:consumed:${SIGNATURE}`),
+    true,
+  );
+  await t.rejects(
+    handler.handleSettle({
+      challenge,
+      payload: { type: "signature", signature: SIGNATURE },
+    }),
+    { message: "transaction signature already consumed" },
+  );
+  t.end();
+});
+
+await t.test(
+  "SPL charge settles client-paid pull transactions without fee payer",
+  async (t) => {
+    const rpc = createFakeRpc();
+    const replayStore = createInMemoryReplayStore();
+    const mint = await generateKeyPairSigner();
+    const handler = await createMPPSolanaChargeHandler({
+      network: "devnet",
+      rpc,
+      mint: mint.address,
+      replayStore,
+      realm: "test",
+      secretKey: new Uint8Array(32).fill(1),
+    });
+
+    const receiver = await generateKeyPairSigner();
+    const challenge = await handler.getChallenge(
+      "charge",
+      {
+        amount: "1000000",
+        asset: mint.address,
+        recipient: receiver.address,
+        network: "solana:devnet",
+      },
+      "https://example.test/resource",
+    );
+
+    const client = createMPPSolanaChargeClient({
+      wallet: await createWallet(),
+      mint: mint.address,
+      rpc,
+    });
+    const execer = await client(challenge);
+    if (!execer) {
+      throw new Error("expected client to handle SPL charge challenge");
+    }
+    const credential = await execer.exec();
+    const transactionSignature = getPayloadTransactionSignature(
+      getTransactionPayload(credential.payload),
+    );
+
+    const receipt = await handler.handleSettle(credential);
+
+    t.match(receipt, {
+      status: "success",
+      method: "solana",
+      challengeId: challenge.id,
+      timestamp: RECEIPT_TIMESTAMP_RE,
+      reference: SETTLEMENT_SIGNATURE,
+    });
+    t.equal(
+      await claim(
+        replayStore,
+        `solana-charge:consumed:${transactionSignature}`,
+      ),
+      false,
+    );
+    t.end();
+  },
+);
+
+await t.test(
+  "SPL charge releases pull signatures when simulation fails",
+  async (t) => {
+    let sendCount = 0;
+    const rpc = createFakeRpc(undefined, {
+      onSendTransaction: () => {
+        sendCount += 1;
+      },
+      simulationError: { InstructionError: [0, "Custom"] },
+    });
+    const replayStore = createInMemoryReplayStore();
+    const mint = await generateKeyPairSigner();
+    const handler = await createMPPSolanaChargeHandler({
+      network: "devnet",
+      rpc,
+      mint: mint.address,
+      replayStore,
+      realm: "test",
+      secretKey: SECRET_KEY,
+    });
+
+    const receiver = await generateKeyPairSigner();
+    const challenge = await handler.getChallenge(
+      "charge",
+      {
+        amount: "1000000",
+        asset: mint.address,
+        recipient: receiver.address,
+        network: "solana:devnet",
+      },
+      "https://example.test/resource",
+    );
+
+    const client = createMPPSolanaChargeClient({
+      wallet: await createWallet(),
+      mint: mint.address,
+      rpc,
+    });
+    const execer = await client(challenge);
+    if (!execer) {
+      throw new Error("expected client to handle SPL charge challenge");
+    }
+    const credential = await execer.exec();
+    const transactionSignature = getPayloadTransactionSignature(
+      getTransactionPayload(credential.payload),
+    );
+
+    await t.rejects(
+      handler.handleSettle(credential, createChargeContext(challenge)),
+      { message: "settlement failed: Transaction simulation failed" },
+    );
+
+    t.equal(sendCount, 0);
+    t.equal(
+      await claim(
+        replayStore,
+        `solana-charge:consumed:${transactionSignature}`,
+      ),
+      true,
+    );
+    t.end();
+  },
+);
+
+await t.test(
+  "SPL charge rejects pull transactions with address lookup tables",
+  async (t) => {
+    let sendCount = 0;
+    const rpc = createFakeRpc(undefined, {
+      onSendTransaction: () => {
+        sendCount += 1;
+      },
+    });
+    const replayStore = createInMemoryReplayStore();
+    const mint = await generateKeyPairSigner();
+    const handler = await createMPPSolanaChargeHandler({
+      network: "devnet",
+      rpc,
+      mint: mint.address,
+      replayStore,
+      realm: "test",
+      secretKey: SECRET_KEY,
+    });
+
+    const sender = await generateKeyPairSigner();
+    const receiver = await generateKeyPairSigner();
+    const challenge = await handler.getChallenge(
+      "charge",
+      {
+        amount: "1000000",
+        asset: mint.address,
+        recipient: receiver.address,
+        network: "solana:devnet",
+      },
+      "https://example.test/resource",
+    );
+    const [senderATA] = await findAssociatedTokenPda({
+      mint: mint.address,
+      owner: sender.address,
+      tokenProgram: TOKEN_PROGRAM_ADDRESS,
+    });
+    const [receiverATA] = await findAssociatedTokenPda({
+      mint: mint.address,
+      owner: receiver.address,
+      tokenProgram: TOKEN_PROGRAM_ADDRESS,
+    });
+    const transaction = await encodeTransactionWithLookupTable(
+      buildTransactionMessage(
+        [
+          getTransferCheckedInstruction(
+            {
+              source: senderATA,
+              mint: mint.address,
+              destination: receiverATA,
+              authority: sender.address,
+              amount: 1_000_000n,
+              decimals: 6,
+            },
+            { programAddress: TOKEN_PROGRAM_ADDRESS },
+          ),
+        ],
+        sender,
+      ),
+      sender,
+      [receiverATA],
+    );
+
+    await t.rejects(
+      handler.handleSettle(
+        {
+          challenge,
+          payload: { type: "transaction", transaction },
+        },
+        createChargeContext(challenge),
+      ),
+      { message: "address lookup tables are not supported" },
+    );
+    t.equal(sendCount, 0);
+    t.end();
+  },
+);
+
+await t.test(
+  "SPL charge rejects pull when the confirmed transaction differs",
+  async (t) => {
+    let confirmedTransactionBase64 = "";
+    const rpc = createFakeRpc(() => confirmedTransactionBase64);
+    const replayStore = createInMemoryReplayStore();
+    const mint = await generateKeyPairSigner();
+    const handler = await createMPPSolanaChargeHandler({
+      network: "devnet",
+      rpc,
+      mint: mint.address,
+      replayStore,
+      realm: "test",
+      secretKey: SECRET_KEY,
+    });
+
+    const receiver = await generateKeyPairSigner();
+    const challenge = await handler.getChallenge(
+      "charge",
+      {
+        amount: "1000000",
+        asset: mint.address,
+        recipient: receiver.address,
+        network: "solana:devnet",
+      },
+      "https://example.test/resource",
+    );
+    const request = mppChargeRequest(
+      JSON.parse(decodeBase64URL(challenge.request)),
+    );
+    if (isValidationError(request)) {
+      throw new Error(request.summary);
+    }
+
+    const client = createMPPSolanaChargeClient({
+      wallet: await createWallet(),
+      mint: mint.address,
+      rpc,
+    });
+    const execer = await client(challenge);
+    if (!execer) {
+      throw new Error("expected client to handle SPL charge challenge");
+    }
+    const credential = await execer.exec();
+
+    const wrongReceiver = await generateKeyPairSigner();
+    const wrongChallenge = await replaceChallengeRequest(
+      challenge,
+      { ...request, recipient: wrongReceiver.address },
+      SECRET_KEY,
+    );
+    const wrongExecer = await client(wrongChallenge);
+    if (!wrongExecer) {
+      throw new Error("expected client to handle modified SPL challenge");
+    }
+    const wrongCredential = await wrongExecer.exec();
+    confirmedTransactionBase64 = getTransactionPayload(wrongCredential.payload);
+
+    await t.rejects(handler.handleSettle(credential), {
+      message:
+        /confirmed transaction verification failed: no matching transferChecked instruction found/,
+    });
+    t.end();
+  },
+);
+
+await t.test("SPL charge rejects consumed push signatures", async (t) => {
+  let transactionBase64 = "";
+  const rpc = createFakeRpc(() => transactionBase64);
+  const replayStore = createInMemoryReplayStore();
+  const mint = await generateKeyPairSigner();
+  const handler = await createMPPSolanaChargeHandler({
+    network: "devnet",
+    rpc,
+    mint: mint.address,
+    replayStore,
+    realm: "test",
+    secretKey: new Uint8Array(32).fill(1),
+  });
+
+  const receiver = await generateKeyPairSigner();
+  const challenge = await handler.getChallenge(
+    "charge",
+    {
+      amount: "1000000",
+      asset: mint.address,
+      recipient: receiver.address,
+      network: "solana:devnet",
+    },
+    "https://example.test/resource",
+  );
+
+  const client = createMPPSolanaChargeClient({
+    wallet: await createWallet(),
+    mint: mint.address,
+    rpc,
+  });
+  const execer = await client(challenge);
+  if (!execer) {
+    throw new Error("expected client to handle SPL charge challenge");
+  }
+  const credential = await execer.exec();
+  transactionBase64 = getTransactionPayload(credential.payload);
+
+  t.equal(
+    await claim(replayStore, `solana-charge:consumed:${TOKEN_SIGNATURE}`),
+    true,
+  );
+  await t.rejects(
+    handler.handleSettle({
+      challenge,
+      payload: { type: "signature", signature: TOKEN_SIGNATURE },
+    }),
+    { message: "transaction signature already consumed" },
+  );
+  t.end();
+});

--- a/packages/payment-solana/src/charge/server.test.ts
+++ b/packages/payment-solana/src/charge/server.test.ts
@@ -43,6 +43,7 @@ const TOKEN_SIGNATURE =
   "3L3RY5sT8K4kyEnqhizwaqxLEbcYvpGrGPNEYRwtbCSUtL6YL86jdrvCbohnP5q8VxQ3qzGmt3W3iQJW97rD7m3";
 const SECRET_KEY = new Uint8Array(32).fill(1);
 const RECEIPT_TIMESTAMP_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/;
+const RESOURCE_URL = "https://example.test/resource";
 
 async function createWallet(): Promise<Wallet> {
   const signer = await generateKeyPairSigner();
@@ -51,6 +52,27 @@ async function createWallet(): Promise<Wallet> {
     publicKey: signer.address,
     partiallySignTransaction: (tx) =>
       partiallySignTransaction([signer.keyPair], tx),
+  };
+}
+
+function createChargeContext(
+  challenge: mppChallengeParams,
+  network = "devnet",
+) {
+  const request = mppChargeRequest(
+    JSON.parse(decodeBase64URL(challenge.request)),
+  );
+  if (isValidationError(request)) {
+    throw new Error(request.summary);
+  }
+  return {
+    pricing: {
+      amount: request.amount,
+      asset: request.currency,
+      recipient: request.recipient,
+      network,
+    },
+    resourceURL: RESOURCE_URL,
   };
 }
 
@@ -310,10 +332,13 @@ await t.test(
     const credential = await execer.exec();
     transactionBase64 = getTransactionPayload(credential.payload);
 
-    const receipt = await handler.handleSettle({
-      challenge,
-      payload: { type: "signature", signature: SIGNATURE },
-    });
+    const receipt = await handler.handleSettle(
+      {
+        challenge,
+        payload: { type: "signature", signature: SIGNATURE },
+      },
+      createChargeContext(challenge),
+    );
 
     t.match(receipt, {
       status: "success",
@@ -376,7 +401,10 @@ await t.test("native charge settles without externalId", async (t) => {
     throw new Error("expected client to handle native charge challenge");
   }
 
-  const receipt = await handler.handleSettle(await execer.exec());
+  const receipt = await handler.handleSettle(
+    await execer.exec(),
+    createChargeContext(challengeWithoutExternalId),
+  );
 
   t.match(receipt, {
     status: "success",
@@ -428,7 +456,10 @@ await t.test(
       throw new Error("expected client to handle native charge challenge");
     }
 
-    const receipt = await handler.handleSettle(await execer.exec());
+    const receipt = await handler.handleSettle(
+      await execer.exec(),
+      createChargeContext(legacyChallenge),
+    );
 
     t.match(receipt, {
       status: "success",
@@ -479,7 +510,10 @@ await t.test(
       getTransactionPayload(credential.payload),
     );
 
-    const receipt = await handler.handleSettle(credential);
+    const receipt = await handler.handleSettle(
+      credential,
+      createChargeContext(challenge),
+    );
 
     t.match(receipt, {
       status: "success",
@@ -554,10 +588,13 @@ await t.test(
     const wrongCredential = await wrongExecer.exec();
     confirmedTransactionBase64 = getTransactionPayload(wrongCredential.payload);
 
-    await t.rejects(handler.handleSettle(credential), {
-      message:
-        /confirmed transaction verification failed: no matching transferSol instruction found/,
-    });
+    await t.rejects(
+      handler.handleSettle(credential, createChargeContext(challenge)),
+      {
+        message:
+          /confirmed transaction verification failed: no matching transferSol instruction found/,
+      },
+    );
     t.end();
   },
 );
@@ -612,9 +649,12 @@ await t.test(
       ),
       true,
     );
-    await t.rejects(handler.handleSettle(credential), {
-      message: "transaction signature already consumed",
-    });
+    await t.rejects(
+      handler.handleSettle(credential, createChargeContext(challenge)),
+      {
+        message: "transaction signature already consumed",
+      },
+    );
     t.equal(sendCount, 0);
     t.end();
   },
@@ -784,10 +824,13 @@ await t.test("native charge rejects consumed push signatures", async (t) => {
     true,
   );
   await t.rejects(
-    handler.handleSettle({
-      challenge,
-      payload: { type: "signature", signature: SIGNATURE },
-    }),
+    handler.handleSettle(
+      {
+        challenge,
+        payload: { type: "signature", signature: SIGNATURE },
+      },
+      createChargeContext(challenge),
+    ),
     { message: "transaction signature already consumed" },
   );
   t.end();
@@ -834,7 +877,10 @@ await t.test(
       getTransactionPayload(credential.payload),
     );
 
-    const receipt = await handler.handleSettle(credential);
+    const receipt = await handler.handleSettle(
+      credential,
+      createChargeContext(challenge),
+    );
 
     t.match(receipt, {
       status: "success",
@@ -1054,10 +1100,13 @@ await t.test(
     const wrongCredential = await wrongExecer.exec();
     confirmedTransactionBase64 = getTransactionPayload(wrongCredential.payload);
 
-    await t.rejects(handler.handleSettle(credential), {
-      message:
-        /confirmed transaction verification failed: no matching transferChecked instruction found/,
-    });
+    await t.rejects(
+      handler.handleSettle(credential, createChargeContext(challenge)),
+      {
+        message:
+          /confirmed transaction verification failed: no matching transferChecked instruction found/,
+      },
+    );
     t.end();
   },
 );
@@ -1105,10 +1154,13 @@ await t.test("SPL charge rejects consumed push signatures", async (t) => {
     true,
   );
   await t.rejects(
-    handler.handleSettle({
-      challenge,
-      payload: { type: "signature", signature: TOKEN_SIGNATURE },
-    }),
+    handler.handleSettle(
+      {
+        challenge,
+        payload: { type: "signature", signature: TOKEN_SIGNATURE },
+      },
+      createChargeContext(challenge),
+    ),
     { message: "transaction signature already consumed" },
   );
   t.end();

--- a/packages/payment-solana/src/charge/server.test.ts
+++ b/packages/payment-solana/src/charge/server.test.ts
@@ -10,13 +10,34 @@ import {
   type mppChallengeParams,
 } from "@faremeter/types/mpp";
 import {
-  getBase64Encoder,
+  appendTransactionMessageInstructions,
+  compileTransaction,
+  compressTransactionMessageUsingAddressLookupTables,
+  createNoopSigner,
+  createTransactionMessage,
   generateKeyPairSigner,
+  getBase64Encoder,
+  pipe,
+  setTransactionMessageFeePayer,
+  setTransactionMessageLifetimeUsingBlockhash,
+  type Address,
+  type Instruction,
+  type KeyPairSigner,
   type Rpc,
   type SolanaRpcApi,
+  type TransactionMessage,
+  type TransactionMessageWithBlockhashLifetime,
+  type TransactionMessageWithFeePayer,
 } from "@solana/kit";
-import { TOKEN_PROGRAM_ADDRESS } from "@solana-program/token";
+import type { Blockhash } from "@solana/rpc-types";
 import {
+  findAssociatedTokenPda,
+  getTransferCheckedInstruction,
+  TOKEN_PROGRAM_ADDRESS,
+} from "@solana-program/token";
+import { getTransferSolInstruction } from "@solana-program/system";
+import {
+  getBase64EncodedWireTransaction,
   getSignatureFromTransaction,
   getTransactionDecoder,
   partiallySignTransaction,
@@ -35,7 +56,8 @@ import {
 } from "./server";
 import type { Wallet } from "../exact/client";
 
-const FAKE_BLOCKHASH = "EETubP46DHLkT9hAFKy4x2BoFUqUFvKjiiNVY3CaYRi3";
+const FAKE_BLOCKHASH =
+  "EETubP46DHLkT9hAFKy4x2BoFUqUFvKjiiNVY3CaYRi3" as Blockhash;
 const SIGNATURE =
   "1111111111111111111111111111111111111111111111111111111111111111";
 const SETTLEMENT_SIGNATURE =
@@ -45,6 +67,13 @@ const TOKEN_SIGNATURE =
 const SECRET_KEY = new Uint8Array(32).fill(1);
 const RECEIPT_TIMESTAMP_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/;
 const RESOURCE_URL = "https://example.test/resource";
+
+type V0CompilableTransactionMessage = Extract<
+  TransactionMessage,
+  { version: 0 }
+> &
+  TransactionMessageWithFeePayer &
+  TransactionMessageWithBlockhashLifetime;
 
 async function createWallet(): Promise<Wallet> {
   const signer = await generateKeyPairSigner();
@@ -92,6 +121,40 @@ function getPayloadTransactionSignature(transaction: string) {
   const txBytes = getBase64Encoder().encode(transaction);
   const decodedTx = getTransactionDecoder().decode(txBytes);
   return getSignatureFromTransaction(decodedTx);
+}
+
+function buildTransactionMessage(
+  instructions: Instruction[],
+  feePayer: KeyPairSigner,
+): V0CompilableTransactionMessage {
+  return pipe(
+    createTransactionMessage({ version: 0 }),
+    (msg) => setTransactionMessageFeePayer(feePayer.address, msg),
+    (msg) =>
+      setTransactionMessageLifetimeUsingBlockhash(
+        { blockhash: FAKE_BLOCKHASH, lastValidBlockHeight: 1000n },
+        msg,
+      ),
+    (msg) => appendTransactionMessageInstructions(instructions, msg),
+  );
+}
+
+async function encodeTransactionWithLookupTable(
+  transactionMessage: V0CompilableTransactionMessage,
+  signer: KeyPairSigner,
+  lookupAddresses: Address[],
+) {
+  const lookupTable = await generateKeyPairSigner();
+  const compressedMessage = compressTransactionMessageUsingAddressLookupTables(
+    transactionMessage,
+    { [lookupTable.address]: lookupAddresses },
+  );
+  const transaction = compileTransaction(compressedMessage);
+  const signedTransaction = await partiallySignTransaction(
+    [signer.keyPair],
+    transaction,
+  );
+  return getBase64EncodedWireTransaction(signedTransaction);
 }
 
 type CreateFakeRpcOpts = {
@@ -530,6 +593,66 @@ await t.test(
       ),
       false,
     );
+    t.end();
+  },
+);
+
+await t.test(
+  "native charge rejects pull transactions with address lookup tables",
+  async (t) => {
+    let sendCount = 0;
+    const rpc = createFakeRpc(undefined, {
+      onSendTransaction: () => {
+        sendCount += 1;
+      },
+    });
+    const replayStore = createInMemoryReplayStore();
+    const handler = await createMPPSolanaNativeChargeHandler({
+      network: "devnet",
+      rpc,
+      replayStore,
+      realm: "test",
+      secretKey: SECRET_KEY,
+    });
+
+    const sender = await generateKeyPairSigner();
+    const receiver = await generateKeyPairSigner();
+    const challenge = await handler.getChallenge(
+      "charge",
+      {
+        amount: "1000000",
+        asset: "sol",
+        recipient: receiver.address,
+        network: "solana:devnet",
+      },
+      "https://example.test/resource",
+    );
+    const transaction = await encodeTransactionWithLookupTable(
+      buildTransactionMessage(
+        [
+          getTransferSolInstruction({
+            source: createNoopSigner(sender.address),
+            destination: receiver.address,
+            amount: 1_000_000n,
+          }),
+        ],
+        sender,
+      ),
+      sender,
+      [receiver.address],
+    );
+
+    await t.rejects(
+      handler.handleSettle(
+        {
+          challenge,
+          payload: { type: "transaction", transaction },
+        },
+        createChargeContext(challenge),
+      ),
+      { message: "address lookup tables are not supported" },
+    );
+    t.equal(sendCount, 0);
     t.end();
   },
 );

--- a/packages/payment-solana/src/charge/server.test.ts
+++ b/packages/payment-solana/src/charge/server.test.ts
@@ -67,6 +67,7 @@ const TOKEN_SIGNATURE =
 const SECRET_KEY = new Uint8Array(32).fill(1);
 const RECEIPT_TIMESTAMP_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/;
 const RESOURCE_URL = "https://example.test/resource";
+const STALE_BLOCK_TIME_DELTA_MS = -25 * 60 * 60 * 1000;
 
 type V0CompilableTransactionMessage = Extract<
   TransactionMessage,
@@ -123,6 +124,10 @@ function getPayloadTransactionSignature(transaction: string) {
   return getSignatureFromTransaction(decodedTx);
 }
 
+function blockTimeSecondsFromNow(deltaMs = 0) {
+  return Math.floor((Date.now() + deltaMs) / 1000);
+}
+
 function buildTransactionMessage(
   instructions: Instruction[],
   feePayer: KeyPairSigner,
@@ -163,6 +168,7 @@ type CreateFakeRpcOpts = {
     confirmationStatus?: "confirmed" | "finalized" | "processed" | null;
     err?: unknown;
   } | null;
+  blockTime?: number | bigint | null;
   simulationError?: unknown;
 };
 
@@ -203,6 +209,10 @@ function createFakeRpc(
     }),
     getTransaction: () => ({
       send: async () => ({
+        blockTime:
+          opts.blockTime === undefined
+            ? blockTimeSecondsFromNow()
+            : opts.blockTime,
         meta: { err: null },
         transaction: [
           getTransactionBase64?.() ?? sentTransactionBase64,
@@ -1070,6 +1080,112 @@ await t.test("native charge rejects consumed push signatures", async (t) => {
 });
 
 await t.test(
+  "native charge rejects stale push transaction block time",
+  async (t) => {
+    let transactionBase64 = "";
+    const rpc = createFakeRpc(() => transactionBase64, {
+      blockTime: blockTimeSecondsFromNow(STALE_BLOCK_TIME_DELTA_MS),
+    });
+    const replayStore = createInMemoryReplayStore();
+    const handler = await createMPPSolanaNativeChargeHandler({
+      network: "devnet",
+      rpc,
+      replayStore,
+      realm: "test",
+      secretKey: new Uint8Array(32).fill(1),
+    });
+
+    const receiver = await generateKeyPairSigner();
+    const challenge = await handler.getChallenge(
+      "charge",
+      {
+        amount: "1000000",
+        asset: "sol",
+        recipient: receiver.address,
+        network: "solana:devnet",
+      },
+      "https://example.test/resource",
+    );
+
+    const client = createMPPSolanaNativeChargeClient({
+      wallet: await createWallet(),
+      rpc,
+    });
+    const execer = await client(challenge);
+    if (!execer) {
+      throw new Error("expected client to handle native charge challenge");
+    }
+    const credential = await execer.exec();
+    transactionBase64 = getTransactionPayload(credential.payload);
+
+    await t.rejects(
+      handler.handleSettle(
+        {
+          challenge,
+          payload: { type: "signature", signature: SIGNATURE },
+        },
+        createChargeContext(challenge),
+      ),
+      {
+        message: "confirmed transaction block time is outside challenge window",
+      },
+    );
+    t.end();
+  },
+);
+
+await t.test(
+  "native charge rejects push transactions without block time",
+  async (t) => {
+    let transactionBase64 = "";
+    const rpc = createFakeRpc(() => transactionBase64, { blockTime: null });
+    const replayStore = createInMemoryReplayStore();
+    const handler = await createMPPSolanaNativeChargeHandler({
+      network: "devnet",
+      rpc,
+      replayStore,
+      realm: "test",
+      secretKey: new Uint8Array(32).fill(1),
+    });
+
+    const receiver = await generateKeyPairSigner();
+    const challenge = await handler.getChallenge(
+      "charge",
+      {
+        amount: "1000000",
+        asset: "sol",
+        recipient: receiver.address,
+        network: "solana:devnet",
+      },
+      "https://example.test/resource",
+    );
+
+    const client = createMPPSolanaNativeChargeClient({
+      wallet: await createWallet(),
+      rpc,
+    });
+    const execer = await client(challenge);
+    if (!execer) {
+      throw new Error("expected client to handle native charge challenge");
+    }
+    const credential = await execer.exec();
+    transactionBase64 = getTransactionPayload(credential.payload);
+
+    await t.rejects(
+      handler.handleSettle(
+        {
+          challenge,
+          payload: { type: "signature", signature: SIGNATURE },
+        },
+        createChargeContext(challenge),
+      ),
+      { message: "confirmed transaction is missing block time" },
+    );
+    t.end();
+  },
+);
+
+await t.test(
   "SPL charge settles client-paid pull transactions without fee payer",
   async (t) => {
     const rpc = createFakeRpc();
@@ -1398,3 +1514,61 @@ await t.test("SPL charge rejects consumed push signatures", async (t) => {
   );
   t.end();
 });
+
+await t.test(
+  "SPL charge rejects stale push transaction block time",
+  async (t) => {
+    let transactionBase64 = "";
+    const rpc = createFakeRpc(() => transactionBase64, {
+      blockTime: blockTimeSecondsFromNow(STALE_BLOCK_TIME_DELTA_MS),
+    });
+    const replayStore = createInMemoryReplayStore();
+    const mint = await generateKeyPairSigner();
+    const handler = await createMPPSolanaChargeHandler({
+      network: "devnet",
+      rpc,
+      mint: mint.address,
+      replayStore,
+      realm: "test",
+      secretKey: new Uint8Array(32).fill(1),
+    });
+
+    const receiver = await generateKeyPairSigner();
+    const challenge = await handler.getChallenge(
+      "charge",
+      {
+        amount: "1000000",
+        asset: mint.address,
+        recipient: receiver.address,
+        network: "solana:devnet",
+      },
+      "https://example.test/resource",
+    );
+
+    const client = createMPPSolanaChargeClient({
+      wallet: await createWallet(),
+      mint: mint.address,
+      rpc,
+    });
+    const execer = await client(challenge);
+    if (!execer) {
+      throw new Error("expected client to handle SPL charge challenge");
+    }
+    const credential = await execer.exec();
+    transactionBase64 = getTransactionPayload(credential.payload);
+
+    await t.rejects(
+      handler.handleSettle(
+        {
+          challenge,
+          payload: { type: "signature", signature: TOKEN_SIGNATURE },
+        },
+        createChargeContext(challenge),
+      ),
+      {
+        message: "confirmed transaction block time is outside challenge window",
+      },
+    );
+    t.end();
+  },
+);

--- a/packages/payment-solana/src/charge/server.test.ts
+++ b/packages/payment-solana/src/charge/server.test.ts
@@ -777,6 +777,64 @@ await t.test("native charge rejects unknown pricing networks", async (t) => {
 });
 
 await t.test(
+  "native charge malformed payload does not consume challenge",
+  async (t) => {
+    const rpc = createFakeRpc();
+    const replayStore = createInMemoryReplayStore();
+    const handler = await createMPPSolanaNativeChargeHandler({
+      network: "devnet",
+      rpc,
+      replayStore,
+      realm: "test",
+      secretKey: SECRET_KEY,
+    });
+
+    const receiver = await generateKeyPairSigner();
+    const challenge = await handler.getChallenge(
+      "charge",
+      {
+        amount: "1000000",
+        asset: "sol",
+        recipient: receiver.address,
+        network: "solana:devnet",
+      },
+      "https://example.test/resource",
+    );
+
+    const client = createMPPSolanaNativeChargeClient({
+      wallet: await createWallet(),
+      rpc,
+    });
+    const execer = await client(challenge);
+    if (!execer) {
+      throw new Error("expected client to handle native charge challenge");
+    }
+    const credential = await execer.exec();
+
+    await t.rejects(
+      handler.handleSettle(
+        { challenge, payload: { type: "transaction" } },
+        createChargeContext(challenge),
+      ),
+      { message: /^invalid credential payload:/ },
+    );
+
+    const receipt = await handler.handleSettle(
+      credential,
+      createChargeContext(challenge),
+    );
+    t.match(receipt, {
+      status: "success",
+      method: "solana",
+      challengeId: challenge.id,
+      timestamp: RECEIPT_TIMESTAMP_RE,
+      reference: SETTLEMENT_SIGNATURE,
+    });
+    t.end();
+  },
+);
+
+await t.test(
   "native charge rejects pull when the confirmed transaction differs",
   async (t) => {
     let confirmedTransactionBase64 = "";
@@ -1245,6 +1303,67 @@ await t.test(
       ),
       false,
     );
+    t.end();
+  },
+);
+
+await t.test(
+  "SPL charge malformed payload does not consume challenge",
+  async (t) => {
+    const rpc = createFakeRpc();
+    const replayStore = createInMemoryReplayStore();
+    const mint = await generateKeyPairSigner();
+    const handler = await createMPPSolanaChargeHandler({
+      network: "devnet",
+      rpc,
+      mint: mint.address,
+      replayStore,
+      realm: "test",
+      secretKey: SECRET_KEY,
+    });
+
+    const receiver = await generateKeyPairSigner();
+    const challenge = await handler.getChallenge(
+      "charge",
+      {
+        amount: "1000000",
+        asset: mint.address,
+        recipient: receiver.address,
+        network: "solana:devnet",
+      },
+      "https://example.test/resource",
+    );
+
+    const client = createMPPSolanaChargeClient({
+      wallet: await createWallet(),
+      mint: mint.address,
+      rpc,
+    });
+    const execer = await client(challenge);
+    if (!execer) {
+      throw new Error("expected client to handle SPL charge challenge");
+    }
+    const credential = await execer.exec();
+
+    await t.rejects(
+      handler.handleSettle(
+        { challenge, payload: { type: "transaction" } },
+        createChargeContext(challenge),
+      ),
+      { message: /^invalid credential payload:/ },
+    );
+
+    const receipt = await handler.handleSettle(
+      credential,
+      createChargeContext(challenge),
+    );
+    t.match(receipt, {
+      status: "success",
+      method: "solana",
+      challengeId: challenge.id,
+      timestamp: RECEIPT_TIMESTAMP_RE,
+      reference: SETTLEMENT_SIGNATURE,
+    });
     t.end();
   },
 );

--- a/packages/payment-solana/src/charge/server.test.ts
+++ b/packages/payment-solana/src/charge/server.test.ts
@@ -6,6 +6,7 @@ import {
   canonicalizeSortedJSON,
   decodeBase64URL,
   encodeBase64URL,
+  type MPPHandlerContext,
   type mppChallengeParams,
 } from "@faremeter/types/mpp";
 import {
@@ -58,7 +59,7 @@ async function createWallet(): Promise<Wallet> {
 function createChargeContext(
   challenge: mppChallengeParams,
   network = "devnet",
-) {
+): MPPHandlerContext {
   const request = mppChargeRequest(
     JSON.parse(decodeBase64URL(challenge.request)),
   );
@@ -532,6 +533,115 @@ await t.test(
     t.end();
   },
 );
+
+await t.test(
+  "native charge route mismatch does not consume the challenge",
+  async (t) => {
+    const rpc = createFakeRpc();
+    const replayStore = createInMemoryReplayStore();
+    const handler = await createMPPSolanaNativeChargeHandler({
+      network: "devnet",
+      rpc,
+      replayStore,
+      realm: "test",
+      secretKey: SECRET_KEY,
+    });
+
+    const receiver = await generateKeyPairSigner();
+    const challenge = await handler.getChallenge(
+      "charge",
+      {
+        amount: "1000000",
+        asset: "sol",
+        recipient: receiver.address,
+        network: "solana:devnet",
+      },
+      "https://example.test/resource",
+    );
+
+    const client = createMPPSolanaNativeChargeClient({
+      wallet: await createWallet(),
+      rpc,
+    });
+    const execer = await client(challenge);
+    if (!execer) {
+      throw new Error("expected client to handle native charge challenge");
+    }
+    const credential = await execer.exec();
+    const mismatchedContext = createChargeContext(challenge);
+    mismatchedContext.pricing.amount = "2000000";
+
+    t.equal(await handler.handleSettle(credential, mismatchedContext), null);
+
+    const receipt = await handler.handleSettle(
+      credential,
+      createChargeContext(challenge),
+    );
+    t.match(receipt, {
+      status: "success",
+      method: "solana",
+      challengeId: challenge.id,
+      timestamp: RECEIPT_TIMESTAMP_RE,
+      reference: SETTLEMENT_SIGNATURE,
+    });
+    t.end();
+  },
+);
+
+await t.test("native charge rejects unknown pricing networks", async (t) => {
+  const rpc = createFakeRpc();
+  const replayStore = createInMemoryReplayStore();
+  const handler = await createMPPSolanaNativeChargeHandler({
+    network: "devnet",
+    rpc,
+    replayStore,
+    realm: "test",
+    secretKey: SECRET_KEY,
+  });
+
+  const receiver = await generateKeyPairSigner();
+  const challenge = await handler.getChallenge(
+    "charge",
+    {
+      amount: "1000000",
+      asset: "sol",
+      recipient: receiver.address,
+      network: "solana:devnet",
+    },
+    "https://example.test/resource",
+  );
+
+  const client = createMPPSolanaNativeChargeClient({
+    wallet: await createWallet(),
+    rpc,
+  });
+  const execer = await client(challenge);
+  if (!execer) {
+    throw new Error("expected client to handle native charge challenge");
+  }
+  const credential = await execer.exec();
+
+  await t.rejects(
+    handler.handleSettle(
+      credential,
+      createChargeContext(challenge, "unknown-network"),
+    ),
+    { message: "Unknown Solana network: unknown-network" },
+  );
+
+  const receipt = await handler.handleSettle(
+    credential,
+    createChargeContext(challenge),
+  );
+  t.match(receipt, {
+    status: "success",
+    method: "solana",
+    challengeId: challenge.id,
+    timestamp: RECEIPT_TIMESTAMP_RE,
+    reference: SETTLEMENT_SIGNATURE,
+  });
+  t.end();
+});
 
 await t.test(
   "native charge rejects pull when the confirmed transaction differs",

--- a/packages/payment-solana/src/charge/server.ts
+++ b/packages/payment-solana/src/charge/server.ts
@@ -228,6 +228,7 @@ const fetchConfirmedTransaction = async (
       const compiledMessage = getCompiledTransactionMessageDecoder().decode(
         decodedTx.messageBytes,
       );
+      assertNoAddressLookupTables(compiledMessage);
       return decompileTransactionMessage(compiledMessage);
     }
 
@@ -273,11 +274,21 @@ const decodeWireTransaction = (base64Transaction: string) => {
   const compiledMessage = getCompiledTransactionMessageDecoder().decode(
     decodedTx.messageBytes,
   );
+  assertNoAddressLookupTables(compiledMessage);
   return {
     transactionMessage: decompileTransactionMessage(compiledMessage),
     decodedTx,
   };
 };
+
+function assertNoAddressLookupTables(compiledMessage: unknown) {
+  const addressTableLookups = (
+    compiledMessage as { readonly addressTableLookups?: readonly unknown[] }
+  ).addressTableLookups;
+  if ((addressTableLookups?.length ?? 0) > 0) {
+    throw new Error("address lookup tables are not supported");
+  }
+}
 
 async function claimConsumedSignature(
   replayStore: ReplayStore,

--- a/packages/payment-solana/src/charge/server.ts
+++ b/packages/payment-solana/src/charge/server.ts
@@ -393,6 +393,8 @@ export async function createMPPSolanaChargeHandler(
     opts?: ChallengeOpts,
   ): Promise<mppChallengeParams> => {
     const methodDetails: mppChargeRequest["methodDetails"] = {
+      // Keep Solana's "mainnet-beta" cluster spelling for
+      // interoperability with other implementations.
       network: caip2ToCluster(solanaNetwork.caip2) ?? solanaNetwork.caip2,
       decimals: mintInfo.data.decimals,
       tokenProgram: tokenProgram as string,
@@ -637,6 +639,8 @@ export async function createMPPSolanaNativeChargeHandler(
     opts?: ChallengeOpts,
   ): Promise<mppChallengeParams> => {
     const methodDetails: mppChargeRequest["methodDetails"] = {
+      // Keep Solana's "mainnet-beta" cluster spelling for
+      // interoperability with other implementations.
       network: caip2ToCluster(solanaNetwork.caip2) ?? solanaNetwork.caip2,
     };
 

--- a/packages/payment-solana/src/charge/server.ts
+++ b/packages/payment-solana/src/charge/server.ts
@@ -236,6 +236,36 @@ const fetchConfirmedTransaction = async (
   return null;
 };
 
+type ConfirmedChargeVerifier = (
+  transactionMessage: CompilableTransactionMessage,
+) => Promise<{ payer: string } | { error: string }>;
+
+const verifyConfirmedTransaction = async (args: {
+  rpc: Rpc<SolanaRpcApi>;
+  signature: string;
+  maxRetries: number;
+  retryDelayMs: number;
+  verifyTransaction: ConfirmedChargeVerifier;
+}) => {
+  const transactionMessage = await fetchConfirmedTransaction(
+    args.rpc,
+    args.signature,
+    args.maxRetries,
+    args.retryDelayMs,
+  );
+
+  if (!transactionMessage) {
+    throw new Error("could not fetch confirmed transaction");
+  }
+
+  const verifyResult = await args.verifyTransaction(transactionMessage);
+  if ("error" in verifyResult) {
+    throw new Error(
+      `confirmed transaction verification failed: ${verifyResult.error}`,
+    );
+  }
+};
+
 const decodeWireTransaction = (base64Transaction: string) => {
   const txBytes = getBase64Encoder().encode(base64Transaction);
   const decodedTx = getTransactionDecoder().decode(txBytes);
@@ -413,6 +443,7 @@ export async function createMPPSolanaChargeHandler(
         `invalid credential payload: ${validatedPayload.summary}`,
       );
     }
+
     const verifyArgs = {
       request,
       feePayerAddress: feePayerAddress ?? "",
@@ -496,6 +527,18 @@ export async function createMPPSolanaChargeHandler(
       }
       throw new Error(`settlement failed: ${txResult.error}`);
     }
+
+    await verifyConfirmedTransaction({
+      rpc,
+      signature: txResult.signature,
+      maxRetries,
+      retryDelayMs,
+      verifyTransaction: (confirmedTransactionMessage) =>
+        verifyChargeTransaction({
+          transactionMessage: confirmedTransactionMessage,
+          ...verifyArgs,
+        }),
+    });
 
     return createChargeReceipt(challenge, txResult.signature);
   };
@@ -630,6 +673,7 @@ export async function createMPPSolanaNativeChargeHandler(
         `invalid credential payload: ${validatedPayload.summary}`,
       );
     }
+
     const verifyArgs = {
       request,
       feePayerAddress: feePayerAddress ?? "",
@@ -712,6 +756,18 @@ export async function createMPPSolanaNativeChargeHandler(
       }
       throw new Error(`settlement failed: ${txResult.error}`);
     }
+
+    await verifyConfirmedTransaction({
+      rpc,
+      signature: txResult.signature,
+      maxRetries,
+      retryDelayMs,
+      verifyTransaction: (confirmedTransactionMessage) =>
+        verifyNativeChargeTransaction({
+          transactionMessage: confirmedTransactionMessage,
+          ...verifyArgs,
+        }),
+    });
 
     return createChargeReceipt(challenge, txResult.signature);
   };

--- a/packages/payment-solana/src/charge/server.ts
+++ b/packages/payment-solana/src/charge/server.ts
@@ -31,11 +31,13 @@ import {
 } from "@solana/kit";
 import {
   getBase64EncodedWireTransaction,
+  getSignatureFromTransaction,
   getTransactionDecoder,
   partiallySignTransaction,
 } from "@solana/transactions";
 
-const LAMPORTS_PER_SOL = 1_000_000_000;
+const SIGNATURE_REPLAY_PREFIX = "solana-charge:consumed:";
+const SIGNATURE_REPLAY_TTL_MS = 24 * 60 * 60 * 1000;
 
 import type { CompilableTransactionMessage } from "../common";
 import { mppChargeRequest, chargeCredentialPayload } from "./common";
@@ -104,51 +106,91 @@ export type CreateMPPSolanaChargeHandlerArgs = {
   maxPriorityFee?: number;
 };
 
+type SendTransactionResult =
+  | { success: true; signature: Signature }
+  | { success: false; error: string; submitted: boolean };
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
 const sendTransaction = async (
   rpc: Rpc<SolanaRpcApi>,
   signedTransaction: Transaction,
   maxRetries: number,
   retryDelayMs: number,
-): Promise<
-  { success: true; signature: string } | { success: false; error: string }
-> => {
+): Promise<SendTransactionResult> => {
   const base64EncodedTransaction =
     getBase64EncodedWireTransaction(signedTransaction);
 
-  const simResult = await rpc
-    .simulateTransaction(base64EncodedTransaction, {
-      encoding: "base64",
-    })
-    .send();
+  try {
+    const simResult = await rpc
+      .simulateTransaction(base64EncodedTransaction, {
+        encoding: "base64",
+      })
+      .send();
 
-  if (simResult.value.err) {
-    logger.error("transaction simulation failed", simResult.value);
-    return { success: false, error: "Transaction simulation failed" };
-  }
-
-  const signature = await rpc
-    .sendTransaction(base64EncodedTransaction, {
-      encoding: "base64",
-    })
-    .send();
-
-  for (let i = 0; i < maxRetries; i++) {
-    const status = await rpc.getSignatureStatuses([signature]).send();
-    if (status.value[0]?.err) {
+    if (simResult.value.err) {
+      logger.error("transaction simulation failed", simResult.value);
       return {
         success: false,
-        error: `Transaction failed: ${JSON.stringify(status.value[0].err)}`,
+        submitted: false,
+        error: "Transaction simulation failed",
       };
     }
-    if (
-      status.value[0]?.confirmationStatus === "confirmed" ||
-      status.value[0]?.confirmationStatus === "finalized"
-    ) {
-      return { success: true, signature };
+  } catch (error) {
+    return {
+      success: false,
+      submitted: false,
+      error: `Transaction simulation failed: ${getErrorMessage(error)}`,
+    };
+  }
+
+  let signature: Signature;
+  try {
+    signature = await rpc
+      .sendTransaction(base64EncodedTransaction, {
+        encoding: "base64",
+      })
+      .send();
+  } catch (error) {
+    return {
+      success: false,
+      submitted: false,
+      error: `Transaction send failed: ${getErrorMessage(error)}`,
+    };
+  }
+
+  for (let i = 0; i < maxRetries; i++) {
+    try {
+      const status = await rpc.getSignatureStatuses([signature]).send();
+      if (status.value[0]?.err) {
+        return {
+          success: false,
+          submitted: true,
+          error: `Transaction failed: ${JSON.stringify(status.value[0].err)}`,
+        };
+      }
+      if (
+        status.value[0]?.confirmationStatus === "confirmed" ||
+        status.value[0]?.confirmationStatus === "finalized"
+      ) {
+        return { success: true, signature };
+      }
+    } catch (error) {
+      return {
+        success: false,
+        submitted: true,
+        error: `Transaction confirmation failed: ${getErrorMessage(error)}`,
+      };
     }
     await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
   }
-  return { success: false, error: "Transaction confirmation timeout" };
+  return {
+    success: false,
+    submitted: true,
+    error: "Transaction confirmation timeout",
+  };
 };
 
 const fetchConfirmedTransaction = async (
@@ -204,6 +246,31 @@ const decodeWireTransaction = (base64Transaction: string) => {
   };
 };
 
+async function claimConsumedSignature(
+  replayStore: ReplayStore,
+  signature: string,
+) {
+  const key = `${SIGNATURE_REPLAY_PREFIX}${signature}`;
+  const claimed = await replayStore.claim(
+    key,
+    Date.now() + SIGNATURE_REPLAY_TTL_MS,
+  );
+  if (!claimed) {
+    throw new Error("transaction signature already consumed");
+  }
+  return () => replayStore.release(key);
+}
+
+async function releaseSignatureClaim(release: () => Promise<void>) {
+  try {
+    await release();
+  } catch (error) {
+    logger.error("failed to release consumed signature claim", {
+      error: getErrorMessage(error),
+    });
+  }
+}
+
 export async function createMPPSolanaChargeHandler(
   args: CreateMPPSolanaChargeHandlerArgs,
 ): Promise<MPPMethodHandler> {
@@ -253,6 +320,7 @@ export async function createMPPSolanaChargeHandler(
       amount: pricing.amount,
       currency: mintAddress,
       recipient: pricing.recipient,
+      externalId: crypto.randomUUID(),
       ...(pricing.description ? { description: pricing.description } : {}),
       methodDetails,
     };
@@ -319,7 +387,6 @@ export async function createMPPSolanaChargeHandler(
         `invalid credential payload: ${validatedPayload.summary}`,
       );
     }
-
     const verifyArgs = {
       request,
       feePayerAddress: feePayerAddress ?? "",
@@ -354,6 +421,8 @@ export async function createMPPSolanaChargeHandler(
         );
       }
 
+      await claimConsumedSignature(replayStore, validatedPayload.signature);
+
       return {
         status: "success",
         method: "solana",
@@ -375,23 +444,35 @@ export async function createMPPSolanaChargeHandler(
       throw new Error(`transaction verification failed: ${verifyResult.error}`);
     }
 
-    if (!feePayerSigner) {
-      throw new Error("pull mode requires a fee payer keypair");
+    let transactionToSend = decodedTx;
+    if (request.methodDetails?.feePayer === true) {
+      if (!feePayerSigner) {
+        throw new Error("pull mode requires a fee payer keypair");
+      }
+      transactionToSend = await partiallySignTransaction(
+        [feePayerSigner.keyPair],
+        decodedTx,
+      );
     }
 
-    const signedTransaction = await partiallySignTransaction(
-      [feePayerSigner.keyPair],
-      decodedTx,
+    // Reserve the signature before broadcasting so a replayed payment is
+    // rejected here rather than after it has already settled on-chain.
+    const releaseConsumedSignature = await claimConsumedSignature(
+      replayStore,
+      getSignatureFromTransaction(transactionToSend),
     );
 
     const txResult = await sendTransaction(
       rpc,
-      signedTransaction,
+      transactionToSend,
       maxRetries,
       retryDelayMs,
     );
 
     if (!txResult.success) {
+      if (!txResult.submitted) {
+        await releaseSignatureClaim(releaseConsumedSignature);
+      }
       throw new Error(`settlement failed: ${txResult.error}`);
     }
 
@@ -414,8 +495,6 @@ export async function createMPPSolanaChargeHandler(
     handleSettle,
   };
 }
-
-const SOL_DECIMALS = Math.log10(LAMPORTS_PER_SOL);
 
 export type CreateMPPSolanaNativeChargeHandlerArgs = {
   network: string | SolanaCAIP2Network;
@@ -460,7 +539,6 @@ export async function createMPPSolanaNativeChargeHandler(
   ): Promise<mppChallengeParams> => {
     const methodDetails: mppChargeRequest["methodDetails"] = {
       network: caip2ToCluster(solanaNetwork.caip2) ?? solanaNetwork.caip2,
-      decimals: SOL_DECIMALS,
     };
 
     if (hasFeePayer && feePayerAddress) {
@@ -474,6 +552,7 @@ export async function createMPPSolanaNativeChargeHandler(
       amount: pricing.amount,
       currency: "sol",
       recipient: pricing.recipient,
+      externalId: crypto.randomUUID(),
       ...(pricing.description ? { description: pricing.description } : {}),
       methodDetails,
     };
@@ -540,7 +619,6 @@ export async function createMPPSolanaNativeChargeHandler(
         `invalid credential payload: ${validatedPayload.summary}`,
       );
     }
-
     const verifyArgs = {
       request,
       feePayerAddress: feePayerAddress ?? "",
@@ -574,6 +652,8 @@ export async function createMPPSolanaNativeChargeHandler(
         );
       }
 
+      await claimConsumedSignature(replayStore, validatedPayload.signature);
+
       return {
         status: "success",
         method: "solana",
@@ -595,23 +675,35 @@ export async function createMPPSolanaNativeChargeHandler(
       throw new Error(`transaction verification failed: ${verifyResult.error}`);
     }
 
-    if (!feePayerSigner) {
-      throw new Error("pull mode requires a fee payer keypair");
+    let transactionToSend = decodedTx;
+    if (request.methodDetails?.feePayer === true) {
+      if (!feePayerSigner) {
+        throw new Error("pull mode requires a fee payer keypair");
+      }
+      transactionToSend = await partiallySignTransaction(
+        [feePayerSigner.keyPair],
+        decodedTx,
+      );
     }
 
-    const signedTransaction = await partiallySignTransaction(
-      [feePayerSigner.keyPair],
-      decodedTx,
+    // Reserve the signature before broadcasting so a replayed payment is
+    // rejected here rather than after it has already settled on-chain.
+    const releaseConsumedSignature = await claimConsumedSignature(
+      replayStore,
+      getSignatureFromTransaction(transactionToSend),
     );
 
     const txResult = await sendTransaction(
       rpc,
-      signedTransaction,
+      transactionToSend,
       maxRetries,
       retryDelayMs,
     );
 
     if (!txResult.success) {
+      if (!txResult.submitted) {
+        await releaseSignatureClaim(releaseConsumedSignature);
+      }
       throw new Error(`settlement failed: ${txResult.error}`);
     }
 

--- a/packages/payment-solana/src/charge/server.ts
+++ b/packages/payment-solana/src/charge/server.ts
@@ -41,6 +41,8 @@ import {
 
 const SIGNATURE_REPLAY_PREFIX = "solana-charge:consumed:";
 const SIGNATURE_REPLAY_TTL_MS = 24 * 60 * 60 * 1000;
+const CHARGE_CHALLENGE_TIMEOUT_MS = 60_000;
+const SIGNATURE_BLOCK_TIME_CLOCK_SKEW_MS = 5_000;
 
 import type { CompilableTransactionMessage } from "../common";
 import { mppChargeRequest, chargeCredentialPayload } from "./common";
@@ -112,6 +114,11 @@ export type CreateMPPSolanaChargeHandlerArgs = {
 type SendTransactionResult =
   | { success: true; signature: Signature }
   | { success: false; error: string; submitted: boolean };
+
+type ConfirmedChargeTransaction = {
+  transactionMessage: CompilableTransactionMessage;
+  blockTime: number | bigint | null;
+};
 
 function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
@@ -201,7 +208,7 @@ const fetchConfirmedTransaction = async (
   signature: string,
   maxRetries: number,
   retryDelayMs: number,
-): Promise<CompilableTransactionMessage | null> => {
+): Promise<ConfirmedChargeTransaction | null> => {
   for (let i = 0; i < maxRetries; i++) {
     const result = await rpc
       .getTransaction(signature as Signature, {
@@ -229,7 +236,10 @@ const fetchConfirmedTransaction = async (
         decodedTx.messageBytes,
       );
       assertNoAddressLookupTables(compiledMessage);
-      return decompileTransactionMessage(compiledMessage);
+      return {
+        transactionMessage: decompileTransactionMessage(compiledMessage),
+        blockTime: getRPCBlockTime(result),
+      };
     }
 
     await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
@@ -237,6 +247,69 @@ const fetchConfirmedTransaction = async (
 
   return null;
 };
+
+function getRPCBlockTime(result: unknown): number | bigint | null {
+  if (typeof result !== "object" || result === null) {
+    return null;
+  }
+  if (!("blockTime" in result)) {
+    return null;
+  }
+  const { blockTime } = result;
+  if (typeof blockTime === "number" || typeof blockTime === "bigint") {
+    return blockTime;
+  }
+  return null;
+}
+
+function getBlockTimeMs(blockTime: number | bigint | null): number | null {
+  if (blockTime === null) {
+    return null;
+  }
+  const blockTimeSeconds = Number(blockTime);
+  if (!Number.isFinite(blockTimeSeconds)) {
+    return null;
+  }
+  return blockTimeSeconds * 1000;
+}
+
+function assertPushTransactionFresh(
+  challenge: mppChallengeParams,
+  blockTime: number | bigint | null,
+) {
+  const blockTimeMs = getBlockTimeMs(blockTime);
+  if (blockTimeMs === null) {
+    throw new Error("confirmed transaction is missing block time");
+  }
+
+  const now = Date.now();
+  if (blockTimeMs > now + SIGNATURE_BLOCK_TIME_CLOCK_SKEW_MS) {
+    throw new Error("confirmed transaction block time is in the future");
+  }
+
+  if (challenge.expires === undefined) {
+    if (now - blockTimeMs > SIGNATURE_REPLAY_TTL_MS) {
+      throw new Error("confirmed transaction is too old");
+    }
+    return;
+  }
+
+  const expiresAtMs = parseMPPExpiresAtMs(challenge.expires);
+  if (expiresAtMs === null) {
+    throw new Error("invalid challenge expiration");
+  }
+
+  const earliestBlockTimeMs =
+    expiresAtMs -
+    CHARGE_CHALLENGE_TIMEOUT_MS -
+    SIGNATURE_BLOCK_TIME_CLOCK_SKEW_MS;
+  const latestBlockTimeMs = expiresAtMs + SIGNATURE_BLOCK_TIME_CLOCK_SKEW_MS;
+  if (blockTimeMs < earliestBlockTimeMs || blockTimeMs > latestBlockTimeMs) {
+    throw new Error(
+      "confirmed transaction block time is outside challenge window",
+    );
+  }
+}
 
 type ConfirmedChargeVerifier = (
   transactionMessage: CompilableTransactionMessage,
@@ -249,18 +322,20 @@ const verifyConfirmedTransaction = async (args: {
   retryDelayMs: number;
   verifyTransaction: ConfirmedChargeVerifier;
 }) => {
-  const transactionMessage = await fetchConfirmedTransaction(
+  const confirmedTransaction = await fetchConfirmedTransaction(
     args.rpc,
     args.signature,
     args.maxRetries,
     args.retryDelayMs,
   );
 
-  if (!transactionMessage) {
+  if (!confirmedTransaction) {
     throw new Error("could not fetch confirmed transaction");
   }
 
-  const verifyResult = await args.verifyTransaction(transactionMessage);
+  const verifyResult = await args.verifyTransaction(
+    confirmedTransaction.transactionMessage,
+  );
   if ("error" in verifyResult) {
     throw new Error(
       `confirmed transaction verification failed: ${verifyResult.error}`,
@@ -418,8 +493,7 @@ export async function createMPPSolanaChargeHandler(
 
     const requestEncoded = encodeBase64URL(canonicalizeSortedJSON(requestBody));
 
-    const challengeTimeoutMs = 60_000;
-    const expiresAt = Date.now() + challengeTimeoutMs;
+    const expiresAt = Date.now() + CHARGE_CHALLENGE_TIMEOUT_MS;
 
     const paramsWithoutID: Omit<mppChallengeParams, "id"> = {
       realm,
@@ -498,19 +572,20 @@ export async function createMPPSolanaChargeHandler(
         throw new Error("push mode is not allowed with fee sponsorship");
       }
 
-      const transactionMessage = await fetchConfirmedTransaction(
+      const confirmedTransaction = await fetchConfirmedTransaction(
         rpc,
         validatedPayload.signature,
         maxRetries,
         retryDelayMs,
       );
 
-      if (!transactionMessage) {
+      if (!confirmedTransaction) {
         throw new Error("could not fetch confirmed transaction");
       }
+      assertPushTransactionFresh(challenge, confirmedTransaction.blockTime);
 
       const verifyResult = await verifyChargeTransaction({
-        transactionMessage,
+        transactionMessage: confirmedTransaction.transactionMessage,
         ...verifyArgs,
       });
 
@@ -662,8 +737,7 @@ export async function createMPPSolanaNativeChargeHandler(
 
     const requestEncoded = encodeBase64URL(canonicalizeSortedJSON(requestBody));
 
-    const challengeTimeoutMs = 60_000;
-    const expiresAt = Date.now() + challengeTimeoutMs;
+    const expiresAt = Date.now() + CHARGE_CHALLENGE_TIMEOUT_MS;
 
     const paramsWithoutID: Omit<mppChallengeParams, "id"> = {
       realm,
@@ -741,19 +815,20 @@ export async function createMPPSolanaNativeChargeHandler(
         throw new Error("push mode is not allowed with fee sponsorship");
       }
 
-      const transactionMessage = await fetchConfirmedTransaction(
+      const confirmedTransaction = await fetchConfirmedTransaction(
         rpc,
         validatedPayload.signature,
         maxRetries,
         retryDelayMs,
       );
 
-      if (!transactionMessage) {
+      if (!confirmedTransaction) {
         throw new Error("could not fetch confirmed transaction");
       }
+      assertPushTransactionFresh(challenge, confirmedTransaction.blockTime);
 
       const verifyResult = await verifyNativeChargeTransaction({
-        transactionMessage,
+        transactionMessage: confirmedTransaction.transactionMessage,
         ...verifyArgs,
       });
 

--- a/packages/payment-solana/src/charge/server.ts
+++ b/packages/payment-solana/src/charge/server.ts
@@ -9,6 +9,8 @@ import {
   encodeBase64URL,
   canonicalizeSortedJSON,
   decodeBase64URL,
+  formatMPPDateTime,
+  parseMPPExpiresAtMs,
 } from "@faremeter/types/mpp";
 import type { ResourcePricing } from "@faremeter/types/pricing";
 import { isValidationError } from "@faremeter/types";
@@ -271,6 +273,35 @@ async function releaseSignatureClaim(release: () => Promise<void>) {
   }
 }
 
+function getReceiptTimestamp(now = new Date()): string {
+  return formatMPPDateTime(now);
+}
+
+function createChargeReceipt(
+  challenge: mppChallengeParams,
+  reference: string,
+): mppReceipt {
+  return {
+    status: "success",
+    method: "solana",
+    challengeId: challenge.id,
+    timestamp: getReceiptTimestamp(),
+    reference,
+  };
+}
+
+function assertChallengeNotExpired(challenge: mppChallengeParams) {
+  if (challenge.expires === undefined) return;
+
+  const expiresAtMs = parseMPPExpiresAtMs(challenge.expires);
+  if (expiresAtMs === null) {
+    throw new Error("invalid challenge expiry");
+  }
+  if (Date.now() > expiresAtMs) {
+    throw new Error("challenge expired");
+  }
+}
+
 export async function createMPPSolanaChargeHandler(
   args: CreateMPPSolanaChargeHandlerArgs,
 ): Promise<MPPMethodHandler> {
@@ -335,7 +366,7 @@ export async function createMPPSolanaChargeHandler(
       method: "solana",
       intent,
       request: requestEncoded,
-      expires: String(Math.floor(expiresAt / 1000)),
+      expires: formatMPPDateTime(new Date(expiresAt)),
       ...(opts?.digest !== undefined ? { digest: opts.digest } : {}),
     };
 
@@ -369,12 +400,7 @@ export async function createMPPSolanaChargeHandler(
       throw new Error("invalid challenge ID");
     }
 
-    if (challenge.expires !== undefined) {
-      const expiresAtMs = Number(challenge.expires) * 1000;
-      if (expiresAtMs > 0 && Date.now() > expiresAtMs) {
-        throw new Error("challenge expired");
-      }
-    }
+    assertChallengeNotExpired(challenge);
 
     const consumed = await replayStore.consume(challenge.id);
     if (!consumed) {
@@ -423,12 +449,7 @@ export async function createMPPSolanaChargeHandler(
 
       await claimConsumedSignature(replayStore, validatedPayload.signature);
 
-      return {
-        status: "success",
-        method: "solana",
-        timestamp: new Date().toISOString(),
-        reference: validatedPayload.signature,
-      };
+      return createChargeReceipt(challenge, validatedPayload.signature);
     }
 
     const { transactionMessage, decodedTx } = decodeWireTransaction(
@@ -476,12 +497,7 @@ export async function createMPPSolanaChargeHandler(
       throw new Error(`settlement failed: ${txResult.error}`);
     }
 
-    return {
-      status: "success",
-      method: "solana",
-      timestamp: new Date().toISOString(),
-      reference: txResult.signature,
-    };
+    return createChargeReceipt(challenge, txResult.signature);
   };
 
   return {
@@ -567,7 +583,7 @@ export async function createMPPSolanaNativeChargeHandler(
       method: "solana",
       intent,
       request: requestEncoded,
-      expires: String(Math.floor(expiresAt / 1000)),
+      expires: formatMPPDateTime(new Date(expiresAt)),
       ...(opts?.digest !== undefined ? { digest: opts.digest } : {}),
     };
 
@@ -601,12 +617,7 @@ export async function createMPPSolanaNativeChargeHandler(
       throw new Error("invalid challenge ID");
     }
 
-    if (challenge.expires !== undefined) {
-      const expiresAtMs = Number(challenge.expires) * 1000;
-      if (expiresAtMs > 0 && Date.now() > expiresAtMs) {
-        throw new Error("challenge expired");
-      }
-    }
+    assertChallengeNotExpired(challenge);
 
     const consumed = await replayStore.consume(challenge.id);
     if (!consumed) {
@@ -654,12 +665,7 @@ export async function createMPPSolanaNativeChargeHandler(
 
       await claimConsumedSignature(replayStore, validatedPayload.signature);
 
-      return {
-        status: "success",
-        method: "solana",
-        timestamp: new Date().toISOString(),
-        reference: validatedPayload.signature,
-      };
+      return createChargeReceipt(challenge, validatedPayload.signature);
     }
 
     const { transactionMessage, decodedTx } = decodeWireTransaction(
@@ -707,12 +713,7 @@ export async function createMPPSolanaNativeChargeHandler(
       throw new Error(`settlement failed: ${txResult.error}`);
     }
 
-    return {
-      status: "success",
-      method: "solana",
-      timestamp: new Date().toISOString(),
-      reference: txResult.signature,
-    };
+    return createChargeReceipt(challenge, txResult.signature);
   };
 
   return {

--- a/packages/payment-solana/src/charge/server.ts
+++ b/packages/payment-solana/src/charge/server.ts
@@ -519,6 +519,11 @@ export async function createMPPSolanaChargeHandler(
     if (challenge.method !== "solana") return null;
     if (challenge.intent !== "charge") return null;
 
+    const idValid = await verifyChallengeID(secretKey, challenge);
+    if (!idValid) {
+      throw new Error("invalid challenge ID");
+    }
+
     let requestBody: unknown;
     try {
       requestBody = JSON.parse(decodeBase64URL(challenge.request));
@@ -529,11 +534,6 @@ export async function createMPPSolanaChargeHandler(
     const request = mppChargeRequest(requestBody);
     if (isValidationError(request)) return null;
     if (request.currency === "sol") return null;
-
-    const idValid = await verifyChallengeID(secretKey, challenge);
-    if (!idValid) {
-      throw new Error("invalid challenge ID");
-    }
 
     assertChallengeNotExpired(challenge);
 
@@ -548,16 +548,16 @@ export async function createMPPSolanaChargeHandler(
       return null;
     }
 
-    const consumed = await replayStore.consume(challenge.id);
-    if (!consumed) {
-      throw new Error("challenge ID already consumed or expired");
-    }
-
     const validatedPayload = chargeCredentialPayload(payload);
     if (isValidationError(validatedPayload)) {
       throw new Error(
         `invalid credential payload: ${validatedPayload.summary}`,
       );
+    }
+
+    const consumed = await replayStore.consume(challenge.id);
+    if (!consumed) {
+      throw new Error("challenge ID already consumed or expired");
     }
 
     const verifyArgs = {
@@ -763,6 +763,11 @@ export async function createMPPSolanaNativeChargeHandler(
     if (challenge.method !== "solana") return null;
     if (challenge.intent !== "charge") return null;
 
+    const idValid = await verifyChallengeID(secretKey, challenge);
+    if (!idValid) {
+      throw new Error("invalid challenge ID");
+    }
+
     let requestBody: unknown;
     try {
       requestBody = JSON.parse(decodeBase64URL(challenge.request));
@@ -773,11 +778,6 @@ export async function createMPPSolanaNativeChargeHandler(
     const request = mppChargeRequest(requestBody);
     if (isValidationError(request)) return null;
     if (request.currency !== "sol") return null;
-
-    const idValid = await verifyChallengeID(secretKey, challenge);
-    if (!idValid) {
-      throw new Error("invalid challenge ID");
-    }
 
     assertChallengeNotExpired(challenge);
 
@@ -792,16 +792,16 @@ export async function createMPPSolanaNativeChargeHandler(
       return null;
     }
 
-    const consumed = await replayStore.consume(challenge.id);
-    if (!consumed) {
-      throw new Error("challenge ID already consumed or expired");
-    }
-
     const validatedPayload = chargeCredentialPayload(payload);
     if (isValidationError(validatedPayload)) {
       throw new Error(
         `invalid credential payload: ${validatedPayload.summary}`,
       );
+    }
+
+    const consumed = await replayStore.consume(challenge.id);
+    if (!consumed) {
+      throw new Error("challenge ID already consumed or expired");
     }
 
     const verifyArgs = {

--- a/packages/payment-solana/src/charge/server.ts
+++ b/packages/payment-solana/src/charge/server.ts
@@ -472,14 +472,14 @@ export async function createMPPSolanaChargeHandler(
       // interoperability with other implementations.
       network: caip2ToCluster(solanaNetwork.caip2) ?? solanaNetwork.caip2,
       decimals: mintInfo.data.decimals,
-      tokenProgram: tokenProgram as string,
+      tokenProgram,
     };
 
     if (hasFeePayer && feePayerAddress) {
       const latestBlockhash = await rpc.getLatestBlockhash().send();
       methodDetails.feePayer = true;
       methodDetails.feePayerKey = feePayerAddress;
-      methodDetails.recentBlockhash = latestBlockhash.value.blockhash as string;
+      methodDetails.recentBlockhash = latestBlockhash.value.blockhash;
     }
 
     const requestBody: mppChargeRequest = {
@@ -723,7 +723,7 @@ export async function createMPPSolanaNativeChargeHandler(
       const latestBlockhash = await rpc.getLatestBlockhash().send();
       methodDetails.feePayer = true;
       methodDetails.feePayerKey = feePayerAddress;
-      methodDetails.recentBlockhash = latestBlockhash.value.blockhash as string;
+      methodDetails.recentBlockhash = latestBlockhash.value.blockhash;
     }
 
     const requestBody: mppChargeRequest = {

--- a/packages/payment-solana/src/charge/server.ts
+++ b/packages/payment-solana/src/charge/server.ts
@@ -1,6 +1,7 @@
 import type {
   MPPMethodHandler,
   ChallengeOpts,
+  MPPHandlerContext,
   mppChallengeParams,
   mppCredential,
   mppReceipt,
@@ -332,6 +333,22 @@ function assertChallengeNotExpired(challenge: mppChallengeParams) {
   }
 }
 
+function chargeRequestMatchesPricing(args: {
+  currency: string;
+  pricing: ResourcePricing;
+  request: mppChargeRequest;
+  solanaNetwork: SolanaCAIP2Network;
+}): boolean {
+  const { currency, pricing, request, solanaNetwork } = args;
+  return (
+    lookupX402Network(pricing.network).caip2 === solanaNetwork.caip2 &&
+    request.amount === pricing.amount &&
+    request.currency === currency &&
+    pricing.asset === currency &&
+    request.recipient === pricing.recipient
+  );
+}
+
 export async function createMPPSolanaChargeHandler(
   args: CreateMPPSolanaChargeHandlerArgs,
 ): Promise<MPPMethodHandler> {
@@ -408,6 +425,7 @@ export async function createMPPSolanaChargeHandler(
 
   const handleSettle = async (
     credential: mppCredential,
+    context: MPPHandlerContext,
   ): Promise<mppReceipt | null> => {
     const { challenge, payload } = credential;
 
@@ -431,6 +449,17 @@ export async function createMPPSolanaChargeHandler(
     }
 
     assertChallengeNotExpired(challenge);
+
+    if (
+      !chargeRequestMatchesPricing({
+        currency: mintAddress,
+        pricing: context.pricing,
+        request,
+        solanaNetwork,
+      })
+    ) {
+      return null;
+    }
 
     const consumed = await replayStore.consume(challenge.id);
     if (!consumed) {
@@ -638,6 +667,7 @@ export async function createMPPSolanaNativeChargeHandler(
 
   const handleSettle = async (
     credential: mppCredential,
+    context: MPPHandlerContext,
   ): Promise<mppReceipt | null> => {
     const { challenge, payload } = credential;
 
@@ -661,6 +691,17 @@ export async function createMPPSolanaNativeChargeHandler(
     }
 
     assertChallengeNotExpired(challenge);
+
+    if (
+      !chargeRequestMatchesPricing({
+        currency: "sol",
+        pricing: context.pricing,
+        request,
+        solanaNetwork,
+      })
+    ) {
+      return null;
+    }
 
     const consumed = await replayStore.consume(challenge.id);
     if (!consumed) {

--- a/packages/payment-solana/src/charge/verify.test.ts
+++ b/packages/payment-solana/src/charge/verify.test.ts
@@ -1,0 +1,1967 @@
+#!/usr/bin/env pnpm tsx
+
+import t from "tap";
+import {
+  getSetComputeUnitLimitInstruction,
+  getSetComputeUnitPriceInstruction,
+} from "@solana-program/compute-budget";
+import { getAddMemoInstruction } from "@solana-program/memo";
+import {
+  getTransferSolInstruction,
+  TRANSFER_SOL_DISCRIMINATOR,
+} from "@solana-program/system";
+import {
+  getCreateAssociatedTokenIdempotentInstruction,
+  findAssociatedTokenPda,
+  getTransferCheckedInstruction,
+  TOKEN_PROGRAM_ADDRESS,
+  TRANSFER_CHECKED_DISCRIMINATOR,
+} from "@solana-program/token";
+import {
+  appendTransactionMessageInstructions,
+  AccountRole,
+  address,
+  createNoopSigner,
+  createTransactionMessage,
+  generateKeyPairSigner,
+  pipe,
+  setTransactionMessageFeePayer,
+  setTransactionMessageLifetimeUsingBlockhash,
+  type Instruction,
+  type KeyPairSigner,
+} from "@solana/kit";
+import type { Blockhash } from "@solana/rpc-types";
+
+import type { mppChargeRequest } from "./common";
+import {
+  verifyChargeTransaction,
+  verifyNativeChargeTransaction,
+} from "./verify";
+import type { CompilableTransactionMessage } from "../common";
+
+const FAKE_BLOCKHASH =
+  "EETubP46DHLkT9hAFKy4x2BoFUqUFvKjiiNVY3CaYRi3" as Blockhash;
+const OVERSIZED_MEMO = "x".repeat(567);
+
+function buildTxMessage(
+  instructions: Instruction[],
+  feePayer: KeyPairSigner,
+): CompilableTransactionMessage {
+  return pipe(
+    createTransactionMessage({ version: 0 }),
+    (msg) => setTransactionMessageFeePayer(feePayer.address, msg),
+    (msg) =>
+      setTransactionMessageLifetimeUsingBlockhash(
+        { blockhash: FAKE_BLOCKHASH, lastValidBlockHeight: 1000n },
+        msg,
+      ),
+    (msg) => appendTransactionMessageInstructions(instructions, msg),
+  );
+}
+
+function withNonTransferSolDiscriminator(ix: Instruction): Instruction {
+  if (!ix.data) {
+    throw new Error("expected instruction data");
+  }
+  const data = new Uint8Array(ix.data);
+  data[0] = TRANSFER_SOL_DISCRIMINATOR + 1;
+  return { ...ix, data };
+}
+
+function withNonTransferCheckedDiscriminator(ix: Instruction): Instruction {
+  if (!ix.data) {
+    throw new Error("expected instruction data");
+  }
+  const data = new Uint8Array(ix.data);
+  data[0] = TRANSFER_CHECKED_DISCRIMINATOR + 1;
+  return { ...ix, data };
+}
+
+function withLeadingBOM(ix: Instruction): Instruction {
+  if (!ix.data) {
+    throw new Error("expected instruction data");
+  }
+  const data = new Uint8Array(ix.data);
+  return { ...ix, data: Uint8Array.of(0xef, 0xbb, 0xbf, ...data) };
+}
+
+async function createTokenFixtures(memo = "challenge-a") {
+  const sender = await generateKeyPairSigner();
+  const receiver = await generateKeyPairSigner();
+  const mint = await generateKeyPairSigner();
+  const amount = 1_000_000n;
+  const decimals = 6;
+
+  const [senderATA] = await findAssociatedTokenPda({
+    mint: mint.address,
+    owner: sender.address,
+    tokenProgram: TOKEN_PROGRAM_ADDRESS,
+  });
+  const [receiverATA] = await findAssociatedTokenPda({
+    mint: mint.address,
+    owner: receiver.address,
+    tokenProgram: TOKEN_PROGRAM_ADDRESS,
+  });
+
+  const request: mppChargeRequest = {
+    amount: amount.toString(),
+    currency: mint.address,
+    recipient: receiver.address,
+    externalId: memo,
+    methodDetails: {
+      decimals,
+      tokenProgram: TOKEN_PROGRAM_ADDRESS,
+    },
+  };
+
+  const transferIx = getTransferCheckedInstruction(
+    {
+      source: senderATA,
+      mint: mint.address,
+      destination: receiverATA,
+      authority: sender.address,
+      amount,
+      decimals,
+    },
+    { programAddress: TOKEN_PROGRAM_ADDRESS },
+  );
+
+  return {
+    sender,
+    request,
+    transferIx,
+    computeLimitIx: getSetComputeUnitLimitInstruction({ units: 50_000 }),
+    computePriceIx: getSetComputeUnitPriceInstruction({ microLamports: 1n }),
+  };
+}
+
+type TokenFixtures = Awaited<ReturnType<typeof createTokenFixtures>>;
+
+async function createTokenTransferIx(
+  f: TokenFixtures,
+  recipient: string,
+  amount: bigint,
+  sender = f.sender.address,
+): Promise<Instruction> {
+  const decimals = f.request.methodDetails?.decimals;
+  if (decimals === undefined) {
+    throw new Error("expected token decimals");
+  }
+
+  const [sourceATA] = await findAssociatedTokenPda({
+    mint: address(f.request.currency),
+    owner: address(sender),
+    tokenProgram: TOKEN_PROGRAM_ADDRESS,
+  });
+  const [receiverATA] = await findAssociatedTokenPda({
+    mint: address(f.request.currency),
+    owner: address(recipient),
+    tokenProgram: TOKEN_PROGRAM_ADDRESS,
+  });
+
+  return getTransferCheckedInstruction(
+    {
+      source: sourceATA,
+      mint: address(f.request.currency),
+      destination: receiverATA,
+      authority: address(sender),
+      amount,
+      decimals,
+    },
+    { programAddress: TOKEN_PROGRAM_ADDRESS },
+  );
+}
+
+async function createNativeFixtures(memo = "challenge-a") {
+  const sender = await generateKeyPairSigner();
+  const receiver = await generateKeyPairSigner();
+  const amount = 1_000_000n;
+
+  const request: mppChargeRequest = {
+    amount: amount.toString(),
+    currency: "sol",
+    recipient: receiver.address,
+    externalId: memo,
+    methodDetails: {
+      decimals: 9,
+    },
+  };
+
+  const transferIx = getTransferSolInstruction({
+    source: createNoopSigner(sender.address),
+    destination: receiver.address,
+    amount,
+  });
+
+  return {
+    sender,
+    request,
+    transferIx,
+    computeLimitIx: getSetComputeUnitLimitInstruction({ units: 50_000 }),
+    computePriceIx: getSetComputeUnitPriceInstruction({ microLamports: 1n }),
+  };
+}
+
+await t.test("verifyChargeTransaction validates challenge memo", async (t) => {
+  await t.test("accepts matching memo", async (t) => {
+    const f = await createTokenFixtures();
+    const txMsg = buildTxMessage(
+      [
+        f.computeLimitIx,
+        f.computePriceIx,
+        f.transferIx,
+        getAddMemoInstruction({ memo: "challenge-a" }),
+      ],
+      f.sender,
+    );
+
+    const result = await verifyChargeTransaction({
+      transactionMessage: txMsg,
+      request: f.request,
+      feePayerAddress: "",
+      tokenProgram: TOKEN_PROGRAM_ADDRESS,
+    });
+
+    t.matchOnly(result, { payer: f.sender.address });
+    t.end();
+  });
+
+  await t.test("rejects missing memo", async (t) => {
+    const f = await createTokenFixtures();
+    const txMsg = buildTxMessage(
+      [f.computeLimitIx, f.computePriceIx, f.transferIx],
+      f.sender,
+    );
+
+    const result = await verifyChargeTransaction({
+      transactionMessage: txMsg,
+      request: f.request,
+      feePayerAddress: "",
+      tokenProgram: TOKEN_PROGRAM_ADDRESS,
+    });
+
+    t.matchOnly(result, { error: "expected a Memo instruction" });
+    t.end();
+  });
+
+  await t.test("rejects memo instruction accounts", async (t) => {
+    const f = await createTokenFixtures();
+    const memoIx: Instruction = {
+      ...getAddMemoInstruction({ memo: "challenge-a" }),
+      accounts: [
+        {
+          address: f.sender.address,
+          role: AccountRole.WRITABLE_SIGNER,
+        },
+      ],
+    };
+    const txMsg = buildTxMessage(
+      [f.computeLimitIx, f.computePriceIx, f.transferIx, memoIx],
+      f.sender,
+    );
+
+    const result = await verifyChargeTransaction({
+      transactionMessage: txMsg,
+      request: f.request,
+      feePayerAddress: "",
+      tokenProgram: TOKEN_PROGRAM_ADDRESS,
+    });
+
+    t.matchOnly(result, {
+      error: "Memo instruction must not include accounts",
+    });
+    t.end();
+  });
+
+  await t.test("rejects empty memo", async (t) => {
+    const f = await createTokenFixtures("");
+    const txMsg = buildTxMessage(
+      [
+        f.computeLimitIx,
+        f.computePriceIx,
+        f.transferIx,
+        getAddMemoInstruction({ memo: "" }),
+      ],
+      f.sender,
+    );
+
+    const result = await verifyChargeTransaction({
+      transactionMessage: txMsg,
+      request: f.request,
+      feePayerAddress: "",
+      tokenProgram: TOKEN_PROGRAM_ADDRESS,
+    });
+
+    t.matchOnly(result, { error: "unexpected Memo instruction" });
+    t.end();
+  });
+
+  await t.test("accepts missing challenge memo", async (t) => {
+    const f = await createTokenFixtures();
+    const request: mppChargeRequest = {
+      amount: f.request.amount,
+      currency: f.request.currency,
+      recipient: f.request.recipient,
+      ...(f.request.methodDetails
+        ? { methodDetails: f.request.methodDetails }
+        : {}),
+    };
+    const txMsg = buildTxMessage(
+      [f.computeLimitIx, f.computePriceIx, f.transferIx],
+      f.sender,
+    );
+
+    const result = await verifyChargeTransaction({
+      transactionMessage: txMsg,
+      request,
+      feePayerAddress: "",
+      tokenProgram: TOKEN_PROGRAM_ADDRESS,
+    });
+
+    t.matchOnly(result, { payer: f.sender.address });
+    t.end();
+  });
+
+  await t.test("rejects mismatched memo", async (t) => {
+    const f = await createTokenFixtures();
+    const txMsg = buildTxMessage(
+      [
+        f.computeLimitIx,
+        f.computePriceIx,
+        f.transferIx,
+        getAddMemoInstruction({ memo: "wrong-challenge" }),
+      ],
+      f.sender,
+    );
+
+    const result = await verifyChargeTransaction({
+      transactionMessage: txMsg,
+      request: f.request,
+      feePayerAddress: "",
+      tokenProgram: TOKEN_PROGRAM_ADDRESS,
+    });
+
+    t.matchOnly(result, {
+      error: "Memo instruction data does not match challenge",
+    });
+    t.end();
+  });
+
+  await t.test("rejects BOM-prefixed memo", async (t) => {
+    const f = await createTokenFixtures();
+    const txMsg = buildTxMessage(
+      [
+        f.computeLimitIx,
+        f.computePriceIx,
+        f.transferIx,
+        withLeadingBOM(getAddMemoInstruction({ memo: "challenge-a" })),
+      ],
+      f.sender,
+    );
+
+    const result = await verifyChargeTransaction({
+      transactionMessage: txMsg,
+      request: f.request,
+      feePayerAddress: "",
+      tokenProgram: TOKEN_PROGRAM_ADDRESS,
+    });
+
+    t.matchOnly(result, {
+      error: "Memo instruction data does not match challenge",
+    });
+    t.end();
+  });
+
+  await t.test("rejects oversized challenge memo", async (t) => {
+    const f = await createTokenFixtures(OVERSIZED_MEMO);
+    const txMsg = buildTxMessage(
+      [
+        f.computeLimitIx,
+        f.computePriceIx,
+        f.transferIx,
+        getAddMemoInstruction({ memo: OVERSIZED_MEMO }),
+      ],
+      f.sender,
+    );
+
+    const result = await verifyChargeTransaction({
+      transactionMessage: txMsg,
+      request: f.request,
+      feePayerAddress: "",
+      tokenProgram: TOKEN_PROGRAM_ADDRESS,
+    });
+
+    t.matchOnly(result, { error: "Memo exceeds 566 bytes" });
+    t.end();
+  });
+
+  await t.test("rejects fake token program transferChecked", async (t) => {
+    const f = await createTokenFixtures();
+    const fakeProgram = await generateKeyPairSigner();
+    const fakeIx: Instruction = {
+      ...f.transferIx,
+      programAddress: fakeProgram.address,
+    };
+    const txMsg = buildTxMessage(
+      [
+        f.computeLimitIx,
+        f.computePriceIx,
+        fakeIx,
+        getAddMemoInstruction({ memo: "challenge-a" }),
+      ],
+      f.sender,
+    );
+
+    const result = await verifyChargeTransaction({
+      transactionMessage: txMsg,
+      request: f.request,
+      feePayerAddress: "",
+      tokenProgram: TOKEN_PROGRAM_ADDRESS,
+    });
+
+    t.matchOnly(result, {
+      error: "no matching transferChecked instruction found",
+    });
+    t.end();
+  });
+
+  await t.test("rejects non-transferChecked token instruction", async (t) => {
+    const f = await createTokenFixtures();
+    const txMsg = buildTxMessage(
+      [
+        f.computeLimitIx,
+        f.computePriceIx,
+        withNonTransferCheckedDiscriminator(f.transferIx),
+        getAddMemoInstruction({ memo: "challenge-a" }),
+      ],
+      f.sender,
+    );
+
+    const result = await verifyChargeTransaction({
+      transactionMessage: txMsg,
+      request: f.request,
+      feePayerAddress: "",
+      tokenProgram: TOKEN_PROGRAM_ADDRESS,
+    });
+
+    t.matchOnly(result, {
+      error: "no matching transferChecked instruction found",
+    });
+    t.end();
+  });
+
+  await t.test("rejects additional duplicate challenge memo", async (t) => {
+    const f = await createTokenFixtures();
+    const txMsg = buildTxMessage(
+      [
+        f.computeLimitIx,
+        f.computePriceIx,
+        f.transferIx,
+        getAddMemoInstruction({ memo: "challenge-a" }),
+        getAddMemoInstruction({ memo: "challenge-a" }),
+      ],
+      f.sender,
+    );
+
+    const result = await verifyChargeTransaction({
+      transactionMessage: txMsg,
+      request: f.request,
+      feePayerAddress: "",
+      tokenProgram: TOKEN_PROGRAM_ADDRESS,
+    });
+
+    t.matchOnly(result, { error: "unexpected Memo instruction" });
+    t.end();
+  });
+
+  await t.test("rejects additional non-challenge memo", async (t) => {
+    const f = await createTokenFixtures();
+    const txMsg = buildTxMessage(
+      [
+        f.computeLimitIx,
+        f.computePriceIx,
+        f.transferIx,
+        getAddMemoInstruction({ memo: "challenge-a" }),
+        getAddMemoInstruction({ memo: "split-memo" }),
+      ],
+      f.sender,
+    );
+
+    const result = await verifyChargeTransaction({
+      transactionMessage: txMsg,
+      request: f.request,
+      feePayerAddress: "",
+      tokenProgram: TOKEN_PROGRAM_ADDRESS,
+    });
+
+    t.matchOnly(result, { error: "unexpected Memo instruction" });
+    t.end();
+  });
+
+  await t.test("accepts split memo matching externalId", async (t) => {
+    const f = await createTokenFixtures("shared-memo");
+    const splitReceiver = await generateKeyPairSigner();
+    const request: mppChargeRequest = {
+      ...f.request,
+      methodDetails: {
+        ...f.request.methodDetails,
+        splits: [
+          {
+            amount: "250000",
+            memo: "shared-memo",
+            recipient: splitReceiver.address,
+          },
+        ],
+      },
+    };
+    const txMsg = buildTxMessage(
+      [
+        f.computeLimitIx,
+        f.computePriceIx,
+        await createTokenTransferIx(f, f.request.recipient, 750000n),
+        getAddMemoInstruction({ memo: "shared-memo" }),
+        await createTokenTransferIx(f, splitReceiver.address, 250000n),
+        getAddMemoInstruction({ memo: "shared-memo" }),
+      ],
+      f.sender,
+    );
+
+    const result = await verifyChargeTransaction({
+      transactionMessage: txMsg,
+      request,
+      feePayerAddress: "",
+      tokenProgram: TOKEN_PROGRAM_ADDRESS,
+    });
+
+    t.matchOnly(result, { payer: f.sender.address });
+    t.end();
+  });
+
+  await t.test("rejects oversized split memo", async (t) => {
+    const f = await createTokenFixtures();
+    const splitReceiver = await generateKeyPairSigner();
+    const request: mppChargeRequest = {
+      ...f.request,
+      methodDetails: {
+        ...f.request.methodDetails,
+        splits: [
+          {
+            amount: "250000",
+            memo: OVERSIZED_MEMO,
+            recipient: splitReceiver.address,
+          },
+        ],
+      },
+    };
+    const txMsg = buildTxMessage(
+      [
+        f.computeLimitIx,
+        f.computePriceIx,
+        await createTokenTransferIx(f, f.request.recipient, 750000n),
+        getAddMemoInstruction({ memo: "challenge-a" }),
+        await createTokenTransferIx(f, splitReceiver.address, 250000n),
+        getAddMemoInstruction({ memo: OVERSIZED_MEMO }),
+      ],
+      f.sender,
+    );
+
+    const result = await verifyChargeTransaction({
+      transactionMessage: txMsg,
+      request,
+      feePayerAddress: "",
+      tokenProgram: TOKEN_PROGRAM_ADDRESS,
+    });
+
+    t.matchOnly(result, { error: "Memo exceeds 566 bytes" });
+    t.end();
+  });
+
+  await t.test(
+    "accepts fee payer split ATA creation instruction",
+    async (t) => {
+      const f = await createTokenFixtures();
+      const feePayer = await generateKeyPairSigner();
+      const splitReceiver = await generateKeyPairSigner();
+      const [splitATA] = await findAssociatedTokenPda({
+        mint: address(f.request.currency),
+        owner: splitReceiver.address,
+        tokenProgram: TOKEN_PROGRAM_ADDRESS,
+      });
+      const request: mppChargeRequest = {
+        ...f.request,
+        methodDetails: {
+          ...f.request.methodDetails,
+          feePayer: true,
+          feePayerKey: feePayer.address,
+          splits: [
+            {
+              amount: "250000",
+              ataCreationRequired: true,
+              memo: "split-memo",
+              recipient: splitReceiver.address,
+            },
+          ],
+        },
+      };
+      const txMsg = buildTxMessage(
+        [
+          f.computeLimitIx,
+          f.computePriceIx,
+          await createTokenTransferIx(f, f.request.recipient, 750000n),
+          getAddMemoInstruction({ memo: "challenge-a" }),
+          getCreateAssociatedTokenIdempotentInstruction({
+            ata: splitATA,
+            owner: splitReceiver.address,
+            payer: createNoopSigner(feePayer.address),
+            mint: address(f.request.currency),
+            tokenProgram: TOKEN_PROGRAM_ADDRESS,
+          }),
+          await createTokenTransferIx(f, splitReceiver.address, 250000n),
+          getAddMemoInstruction({ memo: "split-memo" }),
+        ],
+        feePayer,
+      );
+
+      const result = await verifyChargeTransaction({
+        transactionMessage: txMsg,
+        request,
+        feePayerAddress: feePayer.address,
+        tokenProgram: TOKEN_PROGRAM_ADDRESS,
+      });
+
+      t.matchOnly(result, { payer: f.sender.address });
+      t.end();
+    },
+  );
+
+  await t.test(
+    "accepts fee payer-owned split ATA creation instruction",
+    async (t) => {
+      const f = await createTokenFixtures();
+      const feePayer = await generateKeyPairSigner();
+      const [splitATA] = await findAssociatedTokenPda({
+        mint: address(f.request.currency),
+        owner: feePayer.address,
+        tokenProgram: TOKEN_PROGRAM_ADDRESS,
+      });
+      const request: mppChargeRequest = {
+        ...f.request,
+        methodDetails: {
+          ...f.request.methodDetails,
+          feePayer: true,
+          feePayerKey: feePayer.address,
+          splits: [
+            {
+              amount: "250000",
+              ataCreationRequired: true,
+              memo: "split-memo",
+              recipient: feePayer.address,
+            },
+          ],
+        },
+      };
+      const txMsg = buildTxMessage(
+        [
+          f.computeLimitIx,
+          f.computePriceIx,
+          await createTokenTransferIx(f, f.request.recipient, 750000n),
+          getAddMemoInstruction({ memo: "challenge-a" }),
+          getCreateAssociatedTokenIdempotentInstruction({
+            ata: splitATA,
+            owner: feePayer.address,
+            payer: createNoopSigner(feePayer.address),
+            mint: address(f.request.currency),
+            tokenProgram: TOKEN_PROGRAM_ADDRESS,
+          }),
+          await createTokenTransferIx(f, feePayer.address, 250000n),
+          getAddMemoInstruction({ memo: "split-memo" }),
+        ],
+        feePayer,
+      );
+
+      const result = await verifyChargeTransaction({
+        transactionMessage: txMsg,
+        request,
+        feePayerAddress: feePayer.address,
+        tokenProgram: TOKEN_PROGRAM_ADDRESS,
+      });
+
+      t.matchOnly(result, { payer: f.sender.address });
+      t.end();
+    },
+  );
+
+  await t.test("rejects fee payer as ATA system program", async (t) => {
+    const f = await createTokenFixtures();
+    const feePayer = await generateKeyPairSigner();
+    const splitReceiver = await generateKeyPairSigner();
+    const [splitATA] = await findAssociatedTokenPda({
+      mint: address(f.request.currency),
+      owner: splitReceiver.address,
+      tokenProgram: TOKEN_PROGRAM_ADDRESS,
+    });
+    const request: mppChargeRequest = {
+      ...f.request,
+      methodDetails: {
+        ...f.request.methodDetails,
+        feePayer: true,
+        feePayerKey: feePayer.address,
+        splits: [
+          {
+            amount: "250000",
+            ataCreationRequired: true,
+            memo: "split-memo",
+            recipient: splitReceiver.address,
+          },
+        ],
+      },
+    };
+    const ataIx = getCreateAssociatedTokenIdempotentInstruction({
+      ata: splitATA,
+      owner: splitReceiver.address,
+      payer: createNoopSigner(feePayer.address),
+      mint: address(f.request.currency),
+      tokenProgram: TOKEN_PROGRAM_ADDRESS,
+    });
+    if (!ataIx.accounts) {
+      throw new Error("expected ATA instruction accounts");
+    }
+    const badATAIx: Instruction = {
+      ...ataIx,
+      accounts: ataIx.accounts.map((account, index) =>
+        index === 4 ? { ...account, address: feePayer.address } : account,
+      ),
+    };
+    const txMsg = buildTxMessage(
+      [
+        f.computeLimitIx,
+        f.computePriceIx,
+        await createTokenTransferIx(f, f.request.recipient, 750000n),
+        getAddMemoInstruction({ memo: "challenge-a" }),
+        badATAIx,
+        await createTokenTransferIx(f, splitReceiver.address, 250000n),
+        getAddMemoInstruction({ memo: "split-memo" }),
+      ],
+      feePayer,
+    );
+
+    const result = await verifyChargeTransaction({
+      transactionMessage: txMsg,
+      request,
+      feePayerAddress: feePayer.address,
+      tokenProgram: TOKEN_PROGRAM_ADDRESS,
+    });
+
+    t.matchOnly(result, {
+      error: "ATA creation system program does not match charge",
+    });
+    t.end();
+  });
+
+  await t.test("rejects unmarked fee payer split ATA creation", async (t) => {
+    const f = await createTokenFixtures();
+    const feePayer = await generateKeyPairSigner();
+    const splitReceiver = await generateKeyPairSigner();
+    const [splitATA] = await findAssociatedTokenPda({
+      mint: address(f.request.currency),
+      owner: splitReceiver.address,
+      tokenProgram: TOKEN_PROGRAM_ADDRESS,
+    });
+    const request: mppChargeRequest = {
+      ...f.request,
+      methodDetails: {
+        ...f.request.methodDetails,
+        feePayer: true,
+        feePayerKey: feePayer.address,
+        splits: [
+          {
+            amount: "250000",
+            memo: "split-memo",
+            recipient: splitReceiver.address,
+          },
+        ],
+      },
+    };
+    const txMsg = buildTxMessage(
+      [
+        f.computeLimitIx,
+        f.computePriceIx,
+        await createTokenTransferIx(f, f.request.recipient, 750000n),
+        getAddMemoInstruction({ memo: "challenge-a" }),
+        getCreateAssociatedTokenIdempotentInstruction({
+          ata: splitATA,
+          owner: splitReceiver.address,
+          payer: createNoopSigner(feePayer.address),
+          mint: address(f.request.currency),
+          tokenProgram: TOKEN_PROGRAM_ADDRESS,
+        }),
+        await createTokenTransferIx(f, splitReceiver.address, 250000n),
+        getAddMemoInstruction({ memo: "split-memo" }),
+      ],
+      feePayer,
+    );
+
+    const result = await verifyChargeTransaction({
+      transactionMessage: txMsg,
+      request,
+      feePayerAddress: feePayer.address,
+      tokenProgram: TOKEN_PROGRAM_ADDRESS,
+    });
+
+    t.matchOnly(result, { error: "unexpected ATA creation instruction" });
+    t.end();
+  });
+
+  await t.test("rejects missing required split ATA creation", async (t) => {
+    const f = await createTokenFixtures();
+    const splitReceiver = await generateKeyPairSigner();
+    const request: mppChargeRequest = {
+      ...f.request,
+      methodDetails: {
+        ...f.request.methodDetails,
+        splits: [
+          {
+            amount: "250000",
+            ataCreationRequired: true,
+            memo: "split-memo",
+            recipient: splitReceiver.address,
+          },
+        ],
+      },
+    };
+    const txMsg = buildTxMessage(
+      [
+        f.computeLimitIx,
+        f.computePriceIx,
+        await createTokenTransferIx(f, f.request.recipient, 750000n),
+        getAddMemoInstruction({ memo: "challenge-a" }),
+        await createTokenTransferIx(f, splitReceiver.address, 250000n),
+        getAddMemoInstruction({ memo: "split-memo" }),
+      ],
+      f.sender,
+    );
+
+    const result = await verifyChargeTransaction({
+      transactionMessage: txMsg,
+      request,
+      feePayerAddress: "",
+      tokenProgram: TOKEN_PROGRAM_ADDRESS,
+    });
+
+    t.matchOnly(result, { error: "missing required ATA creation instruction" });
+    t.end();
+  });
+
+  await t.test("rejects top-level recipient ATA creation", async (t) => {
+    const f = await createTokenFixtures();
+    const [receiverATA] = await findAssociatedTokenPda({
+      mint: address(f.request.currency),
+      owner: address(f.request.recipient),
+      tokenProgram: TOKEN_PROGRAM_ADDRESS,
+    });
+    const txMsg = buildTxMessage(
+      [
+        f.computeLimitIx,
+        f.computePriceIx,
+        getCreateAssociatedTokenIdempotentInstruction({
+          ata: receiverATA,
+          owner: address(f.request.recipient),
+          payer: createNoopSigner(f.sender.address),
+          mint: address(f.request.currency),
+          tokenProgram: TOKEN_PROGRAM_ADDRESS,
+        }),
+        f.transferIx,
+        getAddMemoInstruction({ memo: "challenge-a" }),
+      ],
+      f.sender,
+    );
+
+    const result = await verifyChargeTransaction({
+      transactionMessage: txMsg,
+      request: f.request,
+      feePayerAddress: "",
+      tokenProgram: TOKEN_PROGRAM_ADDRESS,
+    });
+
+    t.matchOnly(result, { error: "unexpected ATA creation instruction" });
+    t.end();
+  });
+
+  await t.test(
+    "rejects required split ATA creation after transfer",
+    async (t) => {
+      const f = await createTokenFixtures();
+      const splitReceiver = await generateKeyPairSigner();
+      const [splitATA] = await findAssociatedTokenPda({
+        mint: address(f.request.currency),
+        owner: splitReceiver.address,
+        tokenProgram: TOKEN_PROGRAM_ADDRESS,
+      });
+      const request: mppChargeRequest = {
+        ...f.request,
+        methodDetails: {
+          ...f.request.methodDetails,
+          splits: [
+            {
+              amount: "250000",
+              ataCreationRequired: true,
+              memo: "split-memo",
+              recipient: splitReceiver.address,
+            },
+          ],
+        },
+      };
+      const txMsg = buildTxMessage(
+        [
+          f.computeLimitIx,
+          f.computePriceIx,
+          await createTokenTransferIx(f, f.request.recipient, 750000n),
+          getAddMemoInstruction({ memo: "challenge-a" }),
+          await createTokenTransferIx(f, splitReceiver.address, 250000n),
+          getCreateAssociatedTokenIdempotentInstruction({
+            ata: splitATA,
+            owner: splitReceiver.address,
+            payer: createNoopSigner(f.sender.address),
+            mint: address(f.request.currency),
+            tokenProgram: TOKEN_PROGRAM_ADDRESS,
+          }),
+          getAddMemoInstruction({ memo: "split-memo" }),
+        ],
+        f.sender,
+      );
+
+      const result = await verifyChargeTransaction({
+        transactionMessage: txMsg,
+        request,
+        feePayerAddress: "",
+        tokenProgram: TOKEN_PROGRAM_ADDRESS,
+      });
+
+      t.matchOnly(result, {
+        error: "required ATA creation instruction must precede split transfer",
+      });
+      t.end();
+    },
+  );
+
+  await t.test("rejects unexpected token instruction", async (t) => {
+    const f = await createTokenFixtures();
+    const txMsg = buildTxMessage(
+      [
+        f.computeLimitIx,
+        f.computePriceIx,
+        f.transferIx,
+        getAddMemoInstruction({ memo: "challenge-a" }),
+        getTransferSolInstruction({
+          source: createNoopSigner(f.sender.address),
+          destination: f.sender.address,
+          amount: 1n,
+        }),
+      ],
+      f.sender,
+    );
+
+    const result = await verifyChargeTransaction({
+      transactionMessage: txMsg,
+      request: f.request,
+      feePayerAddress: "",
+      tokenProgram: TOKEN_PROGRAM_ADDRESS,
+    });
+
+    t.matchOnly(result, {
+      error: "unexpected instruction in charge transaction",
+    });
+    t.end();
+  });
+
+  await t.test(
+    "rejects fee payer token account as transfer source",
+    async (t) => {
+      const f = await createTokenFixtures();
+      const feePayer = await generateKeyPairSigner();
+      const [feePayerATA] = await findAssociatedTokenPda({
+        mint: address(f.request.currency),
+        owner: feePayer.address,
+        tokenProgram: TOKEN_PROGRAM_ADDRESS,
+      });
+      const [receiverATA] = await findAssociatedTokenPda({
+        mint: address(f.request.currency),
+        owner: address(f.request.recipient),
+        tokenProgram: TOKEN_PROGRAM_ADDRESS,
+      });
+      const request: mppChargeRequest = {
+        ...f.request,
+        methodDetails: {
+          ...f.request.methodDetails,
+          feePayer: true,
+          feePayerKey: feePayer.address,
+        },
+      };
+      const txMsg = buildTxMessage(
+        [
+          f.computeLimitIx,
+          f.computePriceIx,
+          getTransferCheckedInstruction(
+            {
+              source: feePayerATA,
+              mint: address(f.request.currency),
+              destination: receiverATA,
+              authority: f.sender.address,
+              amount: BigInt(request.amount),
+              decimals: request.methodDetails?.decimals ?? 6,
+            },
+            { programAddress: TOKEN_PROGRAM_ADDRESS },
+          ),
+          getAddMemoInstruction({ memo: "challenge-a" }),
+        ],
+        feePayer,
+      );
+
+      const result = await verifyChargeTransaction({
+        transactionMessage: txMsg,
+        request,
+        feePayerAddress: feePayer.address,
+        tokenProgram: TOKEN_PROGRAM_ADDRESS,
+      });
+
+      t.matchOnly(result, {
+        error: "transfer source must not be the fee payer",
+      });
+      t.end();
+    },
+  );
+
+  await t.test("rejects split token payer mismatch", async (t) => {
+    const f = await createTokenFixtures();
+    const splitSender = await generateKeyPairSigner();
+    const splitReceiver = await generateKeyPairSigner();
+    const request: mppChargeRequest = {
+      ...f.request,
+      methodDetails: {
+        ...f.request.methodDetails,
+        splits: [
+          {
+            amount: "250000",
+            memo: "split-memo",
+            recipient: splitReceiver.address,
+          },
+        ],
+      },
+    };
+    const txMsg = buildTxMessage(
+      [
+        f.computeLimitIx,
+        f.computePriceIx,
+        await createTokenTransferIx(f, f.request.recipient, 750000n),
+        getAddMemoInstruction({ memo: "challenge-a" }),
+        await createTokenTransferIx(
+          f,
+          splitReceiver.address,
+          250000n,
+          splitSender.address,
+        ),
+        getAddMemoInstruction({ memo: "split-memo" }),
+      ],
+      f.sender,
+    );
+
+    const result = await verifyChargeTransaction({
+      transactionMessage: txMsg,
+      request,
+      feePayerAddress: "",
+      tokenProgram: TOKEN_PROGRAM_ADDRESS,
+    });
+
+    t.matchOnly(result, {
+      error: "split transfer payer must match primary payer",
+    });
+    t.end();
+  });
+
+  await t.test("rejects same transaction against a fresh memo", async (t) => {
+    const f = await createTokenFixtures("first-challenge");
+    const txMsg = buildTxMessage(
+      [
+        f.computeLimitIx,
+        f.computePriceIx,
+        f.transferIx,
+        getAddMemoInstruction({ memo: "first-challenge" }),
+      ],
+      f.sender,
+    );
+
+    const replayedRequest: mppChargeRequest = {
+      ...f.request,
+      externalId: "second-challenge",
+    };
+    const result = await verifyChargeTransaction({
+      transactionMessage: txMsg,
+      request: replayedRequest,
+      feePayerAddress: "",
+      tokenProgram: TOKEN_PROGRAM_ADDRESS,
+    });
+
+    t.matchOnly(result, {
+      error: "Memo instruction data does not match challenge",
+    });
+    t.end();
+  });
+
+  await t.test("rejects instruction using the fee payer", async (t) => {
+    const f = await createTokenFixtures();
+    const feePayer = await generateKeyPairSigner();
+    const request: mppChargeRequest = {
+      ...f.request,
+      methodDetails: {
+        ...f.request.methodDetails,
+        feePayer: true,
+        feePayerKey: feePayer.address,
+      },
+    };
+    const txMsg = buildTxMessage(
+      [
+        f.computeLimitIx,
+        f.computePriceIx,
+        f.transferIx,
+        getAddMemoInstruction({ memo: "challenge-a" }),
+        getTransferSolInstruction({
+          source: createNoopSigner(feePayer.address),
+          destination: f.sender.address,
+          amount: 1n,
+        }),
+      ],
+      feePayer,
+    );
+
+    const result = await verifyChargeTransaction({
+      transactionMessage: txMsg,
+      request,
+      feePayerAddress: feePayer.address,
+      tokenProgram: TOKEN_PROGRAM_ADDRESS,
+    });
+
+    t.matchOnly(result, {
+      error: "fee payer must not appear in instruction accounts",
+    });
+    t.end();
+  });
+
+  await t.test(
+    "rejects one transfer satisfying two identical splits",
+    async (t) => {
+      const f = await createTokenFixtures();
+      const splitReceiver = await generateKeyPairSigner();
+      const request: mppChargeRequest = {
+        ...f.request,
+        methodDetails: {
+          ...f.request.methodDetails,
+          splits: [
+            { amount: "100000", recipient: splitReceiver.address },
+            { amount: "100000", recipient: splitReceiver.address },
+          ],
+        },
+      };
+      const primaryTransfer = await createTokenTransferIx(
+        f,
+        f.request.recipient,
+        800000n,
+      );
+      const splitTransfer = await createTokenTransferIx(
+        f,
+        splitReceiver.address,
+        100000n,
+      );
+
+      const underpay = await verifyChargeTransaction({
+        transactionMessage: buildTxMessage(
+          [
+            f.computeLimitIx,
+            f.computePriceIx,
+            primaryTransfer,
+            splitTransfer,
+            getAddMemoInstruction({ memo: "challenge-a" }),
+          ],
+          f.sender,
+        ),
+        request,
+        feePayerAddress: "",
+        tokenProgram: TOKEN_PROGRAM_ADDRESS,
+      });
+      t.matchOnly(underpay, {
+        error: "no matching transferChecked instruction found",
+      });
+
+      const accepted = await verifyChargeTransaction({
+        transactionMessage: buildTxMessage(
+          [
+            f.computeLimitIx,
+            f.computePriceIx,
+            primaryTransfer,
+            splitTransfer,
+            await createTokenTransferIx(f, splitReceiver.address, 100000n),
+            getAddMemoInstruction({ memo: "challenge-a" }),
+          ],
+          f.sender,
+        ),
+        request,
+        feePayerAddress: "",
+        tokenProgram: TOKEN_PROGRAM_ADDRESS,
+      });
+      t.matchOnly(accepted, { payer: f.sender.address });
+      t.end();
+    },
+  );
+
+  t.end();
+});
+
+await t.test(
+  "verifyNativeChargeTransaction validates challenge memo",
+  async (t) => {
+    await t.test("accepts matching memo", async (t) => {
+      const f = await createNativeFixtures();
+      const txMsg = buildTxMessage(
+        [
+          f.computeLimitIx,
+          f.computePriceIx,
+          f.transferIx,
+          getAddMemoInstruction({ memo: "challenge-a" }),
+        ],
+        f.sender,
+      );
+
+      const result = await verifyNativeChargeTransaction({
+        transactionMessage: txMsg,
+        request: f.request,
+        feePayerAddress: "",
+      });
+
+      t.matchOnly(result, { payer: f.sender.address });
+      t.end();
+    });
+
+    await t.test("rejects missing memo", async (t) => {
+      const f = await createNativeFixtures();
+      const txMsg = buildTxMessage(
+        [f.computeLimitIx, f.computePriceIx, f.transferIx],
+        f.sender,
+      );
+
+      const result = await verifyNativeChargeTransaction({
+        transactionMessage: txMsg,
+        request: f.request,
+        feePayerAddress: "",
+      });
+
+      t.matchOnly(result, { error: "expected a Memo instruction" });
+      t.end();
+    });
+
+    await t.test("rejects memo instruction accounts", async (t) => {
+      const f = await createNativeFixtures();
+      const memoIx: Instruction = {
+        ...getAddMemoInstruction({ memo: "challenge-a" }),
+        accounts: [
+          {
+            address: f.sender.address,
+            role: AccountRole.WRITABLE_SIGNER,
+          },
+        ],
+      };
+      const txMsg = buildTxMessage(
+        [f.computeLimitIx, f.computePriceIx, f.transferIx, memoIx],
+        f.sender,
+      );
+
+      const result = await verifyNativeChargeTransaction({
+        transactionMessage: txMsg,
+        request: f.request,
+        feePayerAddress: "",
+      });
+
+      t.matchOnly(result, {
+        error: "Memo instruction must not include accounts",
+      });
+      t.end();
+    });
+
+    await t.test("rejects empty memo", async (t) => {
+      const f = await createNativeFixtures("");
+      const txMsg = buildTxMessage(
+        [
+          f.computeLimitIx,
+          f.computePriceIx,
+          f.transferIx,
+          getAddMemoInstruction({ memo: "" }),
+        ],
+        f.sender,
+      );
+
+      const result = await verifyNativeChargeTransaction({
+        transactionMessage: txMsg,
+        request: f.request,
+        feePayerAddress: "",
+      });
+
+      t.matchOnly(result, { error: "unexpected Memo instruction" });
+      t.end();
+    });
+
+    await t.test("accepts missing challenge memo", async (t) => {
+      const f = await createNativeFixtures();
+      const request: mppChargeRequest = {
+        amount: f.request.amount,
+        currency: f.request.currency,
+        recipient: f.request.recipient,
+        ...(f.request.methodDetails
+          ? { methodDetails: f.request.methodDetails }
+          : {}),
+      };
+      const txMsg = buildTxMessage(
+        [f.computeLimitIx, f.computePriceIx, f.transferIx],
+        f.sender,
+      );
+
+      const result = await verifyNativeChargeTransaction({
+        transactionMessage: txMsg,
+        request,
+        feePayerAddress: "",
+      });
+
+      t.matchOnly(result, { payer: f.sender.address });
+      t.end();
+    });
+
+    await t.test("rejects mismatched memo", async (t) => {
+      const f = await createNativeFixtures();
+      const txMsg = buildTxMessage(
+        [
+          f.computeLimitIx,
+          f.computePriceIx,
+          f.transferIx,
+          getAddMemoInstruction({ memo: "wrong-challenge" }),
+        ],
+        f.sender,
+      );
+
+      const result = await verifyNativeChargeTransaction({
+        transactionMessage: txMsg,
+        request: f.request,
+        feePayerAddress: "",
+      });
+
+      t.matchOnly(result, {
+        error: "Memo instruction data does not match challenge",
+      });
+      t.end();
+    });
+
+    await t.test("rejects non-transfer system instruction", async (t) => {
+      const f = await createNativeFixtures();
+      const txMsg = buildTxMessage(
+        [
+          f.computeLimitIx,
+          f.computePriceIx,
+          withNonTransferSolDiscriminator(f.transferIx),
+          getAddMemoInstruction({ memo: "challenge-a" }),
+        ],
+        f.sender,
+      );
+
+      const result = await verifyNativeChargeTransaction({
+        transactionMessage: txMsg,
+        request: f.request,
+        feePayerAddress: "",
+      });
+
+      t.matchOnly(result, {
+        error: "no matching transferSol instruction found",
+      });
+      t.end();
+    });
+
+    await t.test("rejects fake program native transfer", async (t) => {
+      const f = await createNativeFixtures();
+      const fakeProgram = await generateKeyPairSigner();
+      const fakeIx: Instruction = {
+        ...f.transferIx,
+        programAddress: fakeProgram.address,
+      };
+      const txMsg = buildTxMessage(
+        [
+          f.computeLimitIx,
+          f.computePriceIx,
+          fakeIx,
+          getAddMemoInstruction({ memo: "challenge-a" }),
+        ],
+        f.sender,
+      );
+
+      const result = await verifyNativeChargeTransaction({
+        transactionMessage: txMsg,
+        request: f.request,
+        feePayerAddress: "",
+      });
+
+      t.matchOnly(result, {
+        error: "no matching transferSol instruction found",
+      });
+      t.end();
+    });
+
+    await t.test("rejects additional duplicate challenge memo", async (t) => {
+      const f = await createNativeFixtures();
+      const txMsg = buildTxMessage(
+        [
+          f.computeLimitIx,
+          f.computePriceIx,
+          f.transferIx,
+          getAddMemoInstruction({ memo: "challenge-a" }),
+          getAddMemoInstruction({ memo: "challenge-a" }),
+        ],
+        f.sender,
+      );
+
+      const result = await verifyNativeChargeTransaction({
+        transactionMessage: txMsg,
+        request: f.request,
+        feePayerAddress: "",
+      });
+
+      t.matchOnly(result, { error: "unexpected Memo instruction" });
+      t.end();
+    });
+
+    await t.test("rejects additional non-challenge memo", async (t) => {
+      const f = await createNativeFixtures();
+      const txMsg = buildTxMessage(
+        [
+          f.computeLimitIx,
+          f.computePriceIx,
+          f.transferIx,
+          getAddMemoInstruction({ memo: "challenge-a" }),
+          getAddMemoInstruction({ memo: "split-memo" }),
+        ],
+        f.sender,
+      );
+
+      const result = await verifyNativeChargeTransaction({
+        transactionMessage: txMsg,
+        request: f.request,
+        feePayerAddress: "",
+      });
+
+      t.matchOnly(result, { error: "unexpected Memo instruction" });
+      t.end();
+    });
+
+    await t.test("accepts split memo matching externalId", async (t) => {
+      const f = await createNativeFixtures("shared-memo");
+      const splitReceiver = await generateKeyPairSigner();
+      const request: mppChargeRequest = {
+        ...f.request,
+        methodDetails: {
+          ...f.request.methodDetails,
+          splits: [
+            {
+              amount: "250000",
+              memo: "shared-memo",
+              recipient: splitReceiver.address,
+            },
+          ],
+        },
+      };
+      const txMsg = buildTxMessage(
+        [
+          f.computeLimitIx,
+          f.computePriceIx,
+          getTransferSolInstruction({
+            source: createNoopSigner(f.sender.address),
+            destination: address(f.request.recipient),
+            amount: 750000n,
+          }),
+          getAddMemoInstruction({ memo: "shared-memo" }),
+          getTransferSolInstruction({
+            source: createNoopSigner(f.sender.address),
+            destination: splitReceiver.address,
+            amount: 250000n,
+          }),
+          getAddMemoInstruction({ memo: "shared-memo" }),
+        ],
+        f.sender,
+      );
+
+      const result = await verifyNativeChargeTransaction({
+        transactionMessage: txMsg,
+        request,
+        feePayerAddress: "",
+      });
+
+      t.matchOnly(result, { payer: f.sender.address });
+      t.end();
+    });
+
+    await t.test("rejects ATA creation flag for native splits", async (t) => {
+      const f = await createNativeFixtures();
+      const splitReceiver = await generateKeyPairSigner();
+      const request: mppChargeRequest = {
+        ...f.request,
+        methodDetails: {
+          ...f.request.methodDetails,
+          splits: [
+            {
+              amount: "250000",
+              ataCreationRequired: true,
+              recipient: splitReceiver.address,
+            },
+          ],
+        },
+      };
+      const txMsg = buildTxMessage(
+        [
+          f.computeLimitIx,
+          f.computePriceIx,
+          getTransferSolInstruction({
+            source: createNoopSigner(f.sender.address),
+            destination: address(f.request.recipient),
+            amount: 750000n,
+          }),
+          getAddMemoInstruction({ memo: "challenge-a" }),
+          getTransferSolInstruction({
+            source: createNoopSigner(f.sender.address),
+            destination: splitReceiver.address,
+            amount: 250000n,
+          }),
+        ],
+        f.sender,
+      );
+
+      const result = await verifyNativeChargeTransaction({
+        transactionMessage: txMsg,
+        request,
+        feePayerAddress: "",
+      });
+
+      t.matchOnly(result, {
+        error: "ataCreationRequired requires an SPL token charge",
+      });
+      t.end();
+    });
+
+    await t.test("rejects unexpected native instruction", async (t) => {
+      const f = await createNativeFixtures();
+      const extraRecipient = await generateKeyPairSigner();
+      const txMsg = buildTxMessage(
+        [
+          f.computeLimitIx,
+          f.computePriceIx,
+          f.transferIx,
+          getAddMemoInstruction({ memo: "challenge-a" }),
+          getTransferSolInstruction({
+            source: createNoopSigner(f.sender.address),
+            destination: extraRecipient.address,
+            amount: 1n,
+          }),
+        ],
+        f.sender,
+      );
+
+      const result = await verifyNativeChargeTransaction({
+        transactionMessage: txMsg,
+        request: f.request,
+        feePayerAddress: "",
+      });
+
+      t.matchOnly(result, {
+        error: "unexpected instruction in charge transaction",
+      });
+      t.end();
+    });
+
+    await t.test("rejects split native payer mismatch", async (t) => {
+      const f = await createNativeFixtures();
+      const splitSender = await generateKeyPairSigner();
+      const splitReceiver = await generateKeyPairSigner();
+      const request: mppChargeRequest = {
+        ...f.request,
+        methodDetails: {
+          ...f.request.methodDetails,
+          splits: [
+            {
+              amount: "250000",
+              memo: "split-memo",
+              recipient: splitReceiver.address,
+            },
+          ],
+        },
+      };
+      const txMsg = buildTxMessage(
+        [
+          f.computeLimitIx,
+          f.computePriceIx,
+          getTransferSolInstruction({
+            source: createNoopSigner(f.sender.address),
+            destination: address(f.request.recipient),
+            amount: 750000n,
+          }),
+          getAddMemoInstruction({ memo: "challenge-a" }),
+          getTransferSolInstruction({
+            source: createNoopSigner(splitSender.address),
+            destination: splitReceiver.address,
+            amount: 250000n,
+          }),
+          getAddMemoInstruction({ memo: "split-memo" }),
+        ],
+        f.sender,
+      );
+
+      const result = await verifyNativeChargeTransaction({
+        transactionMessage: txMsg,
+        request,
+        feePayerAddress: "",
+      });
+
+      t.matchOnly(result, {
+        error: "split transfer payer must match primary payer",
+      });
+      t.end();
+    });
+
+    await t.test("rejects same transaction against a fresh memo", async (t) => {
+      const f = await createNativeFixtures("first-challenge");
+      const txMsg = buildTxMessage(
+        [
+          f.computeLimitIx,
+          f.computePriceIx,
+          f.transferIx,
+          getAddMemoInstruction({ memo: "first-challenge" }),
+        ],
+        f.sender,
+      );
+
+      const replayedRequest: mppChargeRequest = {
+        ...f.request,
+        externalId: "second-challenge",
+      };
+      const result = await verifyNativeChargeTransaction({
+        transactionMessage: txMsg,
+        request: replayedRequest,
+        feePayerAddress: "",
+      });
+
+      t.matchOnly(result, {
+        error: "Memo instruction data does not match challenge",
+      });
+      t.end();
+    });
+
+    await t.test("rejects instruction using the fee payer", async (t) => {
+      const f = await createNativeFixtures();
+      const feePayer = await generateKeyPairSigner();
+      const request: mppChargeRequest = {
+        ...f.request,
+        methodDetails: {
+          ...f.request.methodDetails,
+          feePayer: true,
+          feePayerKey: feePayer.address,
+        },
+      };
+      const txMsg = buildTxMessage(
+        [
+          f.computeLimitIx,
+          f.computePriceIx,
+          f.transferIx,
+          getAddMemoInstruction({ memo: "challenge-a" }),
+          getTransferSolInstruction({
+            source: createNoopSigner(feePayer.address),
+            destination: f.sender.address,
+            amount: 1n,
+          }),
+        ],
+        feePayer,
+      );
+
+      const result = await verifyNativeChargeTransaction({
+        transactionMessage: txMsg,
+        request,
+        feePayerAddress: feePayer.address,
+      });
+
+      t.matchOnly(result, {
+        error: "fee payer must not appear in instruction accounts",
+      });
+      t.end();
+    });
+
+    await t.test(
+      "accepts fee payer as native transfer recipient",
+      async (t) => {
+        const feePayer = await generateKeyPairSigner();
+        const f = await createNativeFixtures();
+        const request: mppChargeRequest = {
+          ...f.request,
+          recipient: feePayer.address,
+          methodDetails: {
+            ...f.request.methodDetails,
+            feePayer: true,
+            feePayerKey: feePayer.address,
+          },
+        };
+        const transferIx = getTransferSolInstruction({
+          source: createNoopSigner(f.sender.address),
+          destination: feePayer.address,
+          amount: BigInt(request.amount),
+        });
+        const txMsg = buildTxMessage(
+          [
+            f.computeLimitIx,
+            f.computePriceIx,
+            transferIx,
+            getAddMemoInstruction({ memo: "challenge-a" }),
+          ],
+          feePayer,
+        );
+
+        const result = await verifyNativeChargeTransaction({
+          transactionMessage: txMsg,
+          request,
+          feePayerAddress: feePayer.address,
+        });
+
+        t.matchOnly(result, { payer: f.sender.address });
+        t.end();
+      },
+    );
+
+    await t.test(
+      "rejects custom instruction using fee payer as native recipient",
+      async (t) => {
+        const feePayer = await generateKeyPairSigner();
+        const fakeProgram = await generateKeyPairSigner();
+        const f = await createNativeFixtures();
+        const request: mppChargeRequest = {
+          ...f.request,
+          recipient: feePayer.address,
+          methodDetails: {
+            ...f.request.methodDetails,
+            feePayer: true,
+            feePayerKey: feePayer.address,
+          },
+        };
+        const baseIx = getTransferSolInstruction(
+          {
+            source: createNoopSigner(f.sender.address),
+            destination: feePayer.address,
+            amount: BigInt(request.amount),
+          },
+          { programAddress: fakeProgram.address },
+        );
+        const fakeIx: Instruction = {
+          ...baseIx,
+          accounts: [
+            ...baseIx.accounts,
+            {
+              address: feePayer.address,
+              role: AccountRole.WRITABLE_SIGNER,
+            },
+          ],
+        };
+        const txMsg = buildTxMessage(
+          [
+            f.computeLimitIx,
+            f.computePriceIx,
+            fakeIx,
+            getAddMemoInstruction({ memo: "challenge-a" }),
+          ],
+          feePayer,
+        );
+
+        const result = await verifyNativeChargeTransaction({
+          transactionMessage: txMsg,
+          request,
+          feePayerAddress: feePayer.address,
+        });
+
+        t.matchOnly(result, {
+          error: "fee payer must not appear in instruction accounts",
+        });
+        t.end();
+      },
+    );
+
+    await t.test(
+      "rejects non-transfer system instruction using fee payer as native recipient",
+      async (t) => {
+        const feePayer = await generateKeyPairSigner();
+        const f = await createNativeFixtures();
+        const request: mppChargeRequest = {
+          ...f.request,
+          recipient: feePayer.address,
+          methodDetails: {
+            ...f.request.methodDetails,
+            feePayer: true,
+            feePayerKey: feePayer.address,
+          },
+        };
+        const baseIx = getTransferSolInstruction({
+          source: createNoopSigner(f.sender.address),
+          destination: feePayer.address,
+          amount: BigInt(request.amount),
+        });
+        const txMsg = buildTxMessage(
+          [
+            f.computeLimitIx,
+            f.computePriceIx,
+            withNonTransferSolDiscriminator(baseIx),
+            getAddMemoInstruction({ memo: "challenge-a" }),
+          ],
+          feePayer,
+        );
+
+        const result = await verifyNativeChargeTransaction({
+          transactionMessage: txMsg,
+          request,
+          feePayerAddress: feePayer.address,
+        });
+
+        t.matchOnly(result, {
+          error: "fee payer must not appear in instruction accounts",
+        });
+        t.end();
+      },
+    );
+
+    await t.test(
+      "rejects extra fee payer account on native transfer",
+      async (t) => {
+        const feePayer = await generateKeyPairSigner();
+        const f = await createNativeFixtures();
+        const request: mppChargeRequest = {
+          ...f.request,
+          recipient: feePayer.address,
+          methodDetails: {
+            ...f.request.methodDetails,
+            feePayer: true,
+            feePayerKey: feePayer.address,
+          },
+        };
+        const baseIx = getTransferSolInstruction({
+          source: createNoopSigner(f.sender.address),
+          destination: feePayer.address,
+          amount: BigInt(request.amount),
+        });
+        const transferIx: Instruction = {
+          ...baseIx,
+          accounts: [
+            ...baseIx.accounts,
+            {
+              address: feePayer.address,
+              role: AccountRole.WRITABLE_SIGNER,
+            },
+          ],
+        };
+        const txMsg = buildTxMessage(
+          [
+            f.computeLimitIx,
+            f.computePriceIx,
+            transferIx,
+            getAddMemoInstruction({ memo: "challenge-a" }),
+          ],
+          feePayer,
+        );
+
+        const result = await verifyNativeChargeTransaction({
+          transactionMessage: txMsg,
+          request,
+          feePayerAddress: feePayer.address,
+        });
+
+        t.matchOnly(result, {
+          error: "fee payer must not appear in instruction accounts",
+        });
+        t.end();
+      },
+    );
+
+    await t.test("accepts native memos in any order", async (t) => {
+      const f = await createNativeFixtures();
+      const splitReceiver = await generateKeyPairSigner();
+      const request: mppChargeRequest = {
+        ...f.request,
+        methodDetails: {
+          ...f.request.methodDetails,
+          splits: [
+            {
+              amount: "250000",
+              memo: "split-memo",
+              recipient: splitReceiver.address,
+            },
+          ],
+        },
+      };
+      const txMsg = buildTxMessage(
+        [
+          f.computeLimitIx,
+          f.computePriceIx,
+          getTransferSolInstruction({
+            source: createNoopSigner(f.sender.address),
+            destination: address(f.request.recipient),
+            amount: 750000n,
+          }),
+          getTransferSolInstruction({
+            source: createNoopSigner(f.sender.address),
+            destination: splitReceiver.address,
+            amount: 250000n,
+          }),
+          getAddMemoInstruction({ memo: "split-memo" }),
+          getAddMemoInstruction({ memo: "challenge-a" }),
+        ],
+        f.sender,
+      );
+
+      const result = await verifyNativeChargeTransaction({
+        transactionMessage: txMsg,
+        request,
+        feePayerAddress: "",
+      });
+
+      t.matchOnly(result, { payer: f.sender.address });
+      t.end();
+    });
+
+    await t.test(
+      "rejects duplicate primary transfer to recipient",
+      async (t) => {
+        const f = await createNativeFixtures();
+        const duplicate = getTransferSolInstruction({
+          source: createNoopSigner(f.sender.address),
+          destination: address(f.request.recipient),
+          amount: BigInt(f.request.amount),
+        });
+        const txMsg = buildTxMessage(
+          [
+            f.computeLimitIx,
+            f.computePriceIx,
+            f.transferIx,
+            duplicate,
+            getAddMemoInstruction({ memo: "challenge-a" }),
+          ],
+          f.sender,
+        );
+
+        const result = await verifyNativeChargeTransaction({
+          transactionMessage: txMsg,
+          request: f.request,
+          feePayerAddress: "",
+        });
+
+        t.matchOnly(result, {
+          error: "unexpected instruction in charge transaction",
+        });
+        t.end();
+      },
+    );
+
+    t.end();
+  },
+);

--- a/packages/payment-solana/src/charge/verify.ts
+++ b/packages/payment-solana/src/charge/verify.ts
@@ -1,18 +1,189 @@
 import {
+  COMPUTE_BUDGET_PROGRAM_ADDRESS,
   parseSetComputeUnitLimitInstruction,
   parseSetComputeUnitPriceInstruction,
+  SET_COMPUTE_UNIT_LIMIT_DISCRIMINATOR,
+  SET_COMPUTE_UNIT_PRICE_DISCRIMINATOR,
 } from "@solana-program/compute-budget";
-import { parseTransferSolInstruction } from "@solana-program/system";
+import { MEMO_PROGRAM_ADDRESS } from "@solana-program/memo";
 import {
+  parseTransferSolInstruction,
+  SYSTEM_PROGRAM_ADDRESS,
+  TRANSFER_SOL_DISCRIMINATOR,
+} from "@solana-program/system";
+import {
+  ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
+  CREATE_ASSOCIATED_TOKEN_IDEMPOTENT_DISCRIMINATOR,
   findAssociatedTokenPda,
+  parseCreateAssociatedTokenIdempotentInstruction,
   parseTransferCheckedInstruction,
+  TRANSFER_CHECKED_DISCRIMINATOR,
 } from "@solana-program/token";
 import { address, type Address, type Instruction } from "@solana/kit";
-import type { mppChargeRequest } from "./common";
+import {
+  chargeHasATACreationSplits,
+  getChargeChallengeMemo,
+  getChargeRequestMemoValidationError,
+  getChargePrimaryAmount,
+  getChargeSplits,
+  type mppChargeRequest,
+} from "./common";
 import type { CompilableTransactionMessage } from "../common";
 import { logger } from "./logger";
 
 const DEFAULT_COMPUTE_UNIT_LIMIT = 200_000;
+
+function isMemoInstruction(instruction: Instruction) {
+  return instruction.programAddress === MEMO_PROGRAM_ADDRESS;
+}
+
+const memoEncoder = new TextEncoder();
+
+function memoDataMatches(instruction: Instruction, memo: string): boolean {
+  if (!isMemoInstruction(instruction) || !instruction.data) {
+    return false;
+  }
+  const actual = new Uint8Array(instruction.data);
+  const expected = memoEncoder.encode(memo);
+  if (actual.byteLength !== expected.byteLength) return false;
+  return actual.every((byte, index) => byte === expected[index]);
+}
+
+function getExpectedMemoEntries(request: mppChargeRequest): string[] {
+  const entries: string[] = [];
+  const challengeMemo = getChargeChallengeMemo(request);
+  if (challengeMemo !== undefined && challengeMemo.length > 0) {
+    entries.push(challengeMemo);
+  }
+
+  for (const split of getChargeSplits(request)) {
+    if (split.memo !== undefined && split.memo.length > 0) {
+      entries.push(split.memo);
+    }
+  }
+
+  return entries;
+}
+
+function verifyExpectedMemos(
+  instructions: readonly Instruction[],
+  request: mppChargeRequest,
+): { error: string } | null {
+  const memoValidationError = getChargeRequestMemoValidationError(request);
+  if (memoValidationError) {
+    return { error: memoValidationError };
+  }
+
+  const expectedMemoEntries = getExpectedMemoEntries(request);
+  const memoInstructions = instructions.filter(isMemoInstruction);
+  if (memoInstructions.some((instruction) => instruction.accounts?.length)) {
+    return { error: "Memo instruction must not include accounts" };
+  }
+  if (expectedMemoEntries.length === 0) {
+    if (memoInstructions.length > 0) {
+      return { error: "unexpected Memo instruction" };
+    }
+    return null;
+  }
+
+  if (memoInstructions.length === 0) {
+    return { error: "expected a Memo instruction" };
+  }
+
+  const matchedMemoIndexes = new Set<number>();
+  for (const expectedMemo of expectedMemoEntries) {
+    const memoIndex = memoInstructions.findIndex((memoInstruction, index) => {
+      return (
+        !matchedMemoIndexes.has(index) &&
+        memoDataMatches(memoInstruction, expectedMemo)
+      );
+    });
+    if (memoIndex === -1) {
+      return { error: "Memo instruction data does not match challenge" };
+    }
+    matchedMemoIndexes.add(memoIndex);
+  }
+
+  if (matchedMemoIndexes.size !== memoInstructions.length) {
+    return { error: "unexpected Memo instruction" };
+  }
+
+  return null;
+}
+
+function isAllowedComputeBudgetInstruction(instruction: Instruction): boolean {
+  if (instruction.programAddress !== COMPUTE_BUDGET_PROGRAM_ADDRESS) {
+    return false;
+  }
+  if (!instruction.data || (instruction.accounts?.length ?? 0) > 0) {
+    return false;
+  }
+
+  try {
+    const limit = parseSetComputeUnitLimitInstruction({
+      programAddress: instruction.programAddress,
+      data: new Uint8Array(instruction.data),
+    });
+    if (limit.data.discriminator === SET_COMPUTE_UNIT_LIMIT_DISCRIMINATOR) {
+      return true;
+    }
+  } catch {
+    // not a setComputeUnitLimit instruction
+  }
+
+  try {
+    const price = parseSetComputeUnitPriceInstruction({
+      programAddress: instruction.programAddress,
+      data: new Uint8Array(instruction.data),
+    });
+    return price.data.discriminator === SET_COMPUTE_UNIT_PRICE_DISCRIMINATOR;
+  } catch {
+    return false;
+  }
+}
+
+function verifyNoUnexpectedInstructions(args: {
+  allowedInstructionIndexes: ReadonlySet<number>;
+  instructions: readonly Instruction[];
+}): { error: string } | null {
+  const { allowedInstructionIndexes, instructions } = args;
+
+  for (const [index, instruction] of instructions.entries()) {
+    if (allowedInstructionIndexes.has(index)) continue;
+    if (isMemoInstruction(instruction)) continue;
+    if (isAllowedComputeBudgetInstruction(instruction)) continue;
+    return { error: "unexpected instruction in charge transaction" };
+  }
+
+  return null;
+}
+
+function verifyFeePayerNotUsedByInstructions(
+  instructions: readonly Instruction[],
+  feePayerAddress: string,
+  allowAccount?: (
+    instruction: Instruction,
+    account: NonNullable<Instruction["accounts"]>[number],
+    accountIndex: number,
+    instructionIndex: number,
+  ) => boolean,
+): { error: string } | null {
+  if (feePayerAddress === "") return null;
+
+  for (const [instructionIndex, ix] of instructions.entries()) {
+    if (!ix.accounts) continue;
+    for (const [accountIndex, account] of ix.accounts.entries()) {
+      if (
+        account.address === feePayerAddress &&
+        allowAccount?.(ix, account, accountIndex, instructionIndex) !== true
+      ) {
+        return { error: "fee payer must not appear in instruction accounts" };
+      }
+    }
+  }
+
+  return null;
+}
 
 /**
  * Scans instructions for compute budget settings and calculates the
@@ -28,6 +199,7 @@ function calculatePriorityFee(instructions: readonly Instruction[]): number {
 
   for (const ix of instructions) {
     if (!ix.data) continue;
+    if (ix.programAddress !== COMPUTE_BUDGET_PROGRAM_ADDRESS) continue;
     const data = new Uint8Array(ix.data);
 
     try {
@@ -35,11 +207,13 @@ function calculatePriorityFee(instructions: readonly Instruction[]): number {
         programAddress: ix.programAddress,
         data,
       });
-      foundLimit = true;
-      if (limit.data.units > highestLimit) {
-        highestLimit = limit.data.units;
+      if (limit.data.discriminator === SET_COMPUTE_UNIT_LIMIT_DISCRIMINATOR) {
+        foundLimit = true;
+        if (limit.data.units > highestLimit) {
+          highestLimit = limit.data.units;
+        }
+        continue;
       }
-      continue;
     } catch {
       // not a setComputeUnitLimit instruction
     }
@@ -49,9 +223,11 @@ function calculatePriorityFee(instructions: readonly Instruction[]): number {
         programAddress: ix.programAddress,
         data,
       });
-      foundPrice = true;
-      if (price.data.microLamports > highestMicroLamports) {
-        highestMicroLamports = price.data.microLamports;
+      if (price.data.discriminator === SET_COMPUTE_UNIT_PRICE_DISCRIMINATOR) {
+        foundPrice = true;
+        if (price.data.microLamports > highestMicroLamports) {
+          highestMicroLamports = price.data.microLamports;
+        }
       }
     } catch {
       // not a setComputeUnitPrice instruction
@@ -62,6 +238,306 @@ function calculatePriorityFee(instructions: readonly Instruction[]): number {
 
   const units = foundLimit ? highestLimit : DEFAULT_COMPUTE_UNIT_LIMIT;
   return (units * Number(highestMicroLamports)) / 1_000_000;
+}
+
+function getPrimaryAmountResult(
+  request: mppChargeRequest,
+): { amount: bigint } | { error: string } {
+  try {
+    return { amount: getChargePrimaryAmount(request) };
+  } catch (error) {
+    return {
+      error: error instanceof Error ? error.message : "invalid charge splits",
+    };
+  }
+}
+
+async function verifySplitATAInstructions(args: {
+  feePayerAddress: string;
+  instructions: readonly Instruction[];
+  request: mppChargeRequest;
+  tokenProgram: Address;
+  transactionFeePayer: string;
+}): Promise<
+  | {
+      allowedFeePayerAccountIndexesByInstructionIndex: Map<number, Set<number>>;
+      creationIndexesByOwner: Map<string, number[]>;
+      instructionIndexes: Set<number>;
+    }
+  | { error: string }
+> {
+  const {
+    feePayerAddress,
+    instructions,
+    request,
+    tokenProgram,
+    transactionFeePayer,
+  } = args;
+  const splitRecipients = new Set<string>();
+  const requiredSplitRecipients = new Set<string>();
+  for (const split of getChargeSplits(request)) {
+    const recipient = address(split.recipient);
+    splitRecipients.add(recipient);
+    if (split.ataCreationRequired === true) {
+      requiredSplitRecipients.add(recipient);
+    }
+  }
+  // When the facilitator sponsors fees it only funds the ATAs the server
+  // marked required; a client paying its own fees may create any split
+  // recipient's ATA, since it bears the rent itself.
+  const allowedSplitATARecipients =
+    feePayerAddress !== "" && transactionFeePayer === feePayerAddress
+      ? requiredSplitRecipients
+      : splitRecipients;
+
+  const instructionIndexes = new Set<number>();
+  const allowedFeePayerAccountIndexesByInstructionIndex = new Map<
+    number,
+    Set<number>
+  >();
+  const creationIndexesByOwner = new Map<string, number[]>();
+  for (const [index, instruction] of instructions.entries()) {
+    if (instruction.programAddress !== ASSOCIATED_TOKEN_PROGRAM_ADDRESS) {
+      continue;
+    }
+    if (
+      !instruction.accounts ||
+      instruction.accounts.length !== 6 ||
+      !instruction.data
+    ) {
+      return { error: "invalid ATA creation instruction" };
+    }
+
+    let parsed;
+    try {
+      parsed = parseCreateAssociatedTokenIdempotentInstruction({
+        accounts: instruction.accounts,
+        programAddress: instruction.programAddress,
+        data: new Uint8Array(instruction.data),
+      });
+    } catch {
+      return { error: "invalid ATA creation instruction" };
+    }
+    if (
+      parsed.data.discriminator !==
+      CREATE_ASSOCIATED_TOKEN_IDEMPOTENT_DISCRIMINATOR
+    ) {
+      return { error: "invalid ATA creation instruction" };
+    }
+
+    const owner = parsed.accounts.owner.address;
+    if (!allowedSplitATARecipients.has(owner)) {
+      return { error: "unexpected ATA creation instruction" };
+    }
+    if (parsed.accounts.payer.address !== transactionFeePayer) {
+      return { error: "ATA creation payer must be transaction fee payer" };
+    }
+    if (parsed.accounts.mint.address !== request.currency) {
+      return { error: "ATA creation mint does not match charge" };
+    }
+    if (parsed.accounts.systemProgram.address !== SYSTEM_PROGRAM_ADDRESS) {
+      return { error: "ATA creation system program does not match charge" };
+    }
+    if (parsed.accounts.tokenProgram.address !== tokenProgram) {
+      return { error: "ATA creation token program does not match charge" };
+    }
+
+    const [expectedATA] = await findAssociatedTokenPda({
+      mint: address(request.currency),
+      owner: address(owner),
+      tokenProgram,
+    });
+    if (parsed.accounts.ata.address !== expectedATA) {
+      return { error: "ATA creation account does not match split recipient" };
+    }
+
+    instructionIndexes.add(index);
+    const allowedFeePayerAccountIndexes = new Set<number>();
+    if (parsed.accounts.payer.address === feePayerAddress) {
+      allowedFeePayerAccountIndexes.add(0);
+    }
+    if (parsed.accounts.owner.address === feePayerAddress) {
+      allowedFeePayerAccountIndexes.add(2);
+    }
+    if (allowedFeePayerAccountIndexes.size > 0) {
+      allowedFeePayerAccountIndexesByInstructionIndex.set(
+        index,
+        allowedFeePayerAccountIndexes,
+      );
+    }
+
+    const existingIndexes = creationIndexesByOwner.get(owner);
+    if (existingIndexes) {
+      existingIndexes.push(index);
+    } else {
+      creationIndexesByOwner.set(owner, [index]);
+    }
+  }
+
+  for (const recipient of requiredSplitRecipients) {
+    if (!creationIndexesByOwner.has(recipient)) {
+      return { error: "missing required ATA creation instruction" };
+    }
+  }
+
+  return {
+    allowedFeePayerAccountIndexesByInstructionIndex,
+    creationIndexesByOwner,
+    instructionIndexes,
+  };
+}
+
+async function findMatchingTokenTransfer(args: {
+  amount: bigint;
+  instructions: readonly Instruction[];
+  matchedInstructionIndexes: Set<number>;
+  md: mppChargeRequest["methodDetails"];
+  recipient: string;
+  request: mppChargeRequest;
+  tokenProgram: Address;
+}) {
+  const {
+    amount,
+    instructions,
+    matchedInstructionIndexes,
+    md,
+    recipient,
+    request,
+    tokenProgram,
+  } = args;
+
+  const [expectedATA] = await findAssociatedTokenPda({
+    mint: address(request.currency),
+    owner: address(recipient),
+    tokenProgram,
+  });
+
+  for (const [index, ix] of instructions.entries()) {
+    if (matchedInstructionIndexes.has(index)) continue;
+    if (!ix.data || !ix.accounts) continue;
+    if (ix.accounts.length !== 4) continue;
+    if (ix.programAddress !== tokenProgram) continue;
+
+    let transfer;
+    try {
+      transfer = parseTransferCheckedInstruction({
+        accounts: ix.accounts,
+        programAddress: ix.programAddress,
+        data: new Uint8Array(ix.data),
+      });
+    } catch {
+      continue;
+    }
+
+    if (transfer.data.discriminator !== TRANSFER_CHECKED_DISCRIMINATOR) {
+      continue;
+    }
+
+    if (transfer.data.amount !== amount) {
+      logger.debug("transfer amount mismatch", {
+        expected: amount.toString(),
+        actual: transfer.data.amount.toString(),
+      });
+      continue;
+    }
+
+    if (transfer.accounts.mint.address !== request.currency) {
+      logger.debug("transfer mint mismatch", {
+        expected: request.currency,
+        actual: transfer.accounts.mint.address,
+      });
+      continue;
+    }
+
+    if (md?.decimals !== undefined && transfer.data.decimals !== md.decimals) {
+      logger.debug("transfer decimals mismatch", {
+        expected: md.decimals,
+        actual: transfer.data.decimals,
+      });
+      continue;
+    }
+
+    if (transfer.accounts.destination.address !== expectedATA) {
+      logger.debug("transfer destination mismatch", {
+        expected: expectedATA,
+        actual: transfer.accounts.destination.address,
+      });
+      continue;
+    }
+
+    matchedInstructionIndexes.add(index);
+    return {
+      index,
+      payer: transfer.accounts.authority.address,
+      source: transfer.accounts.source.address,
+    };
+  }
+
+  return { error: "no matching transferChecked instruction found" };
+}
+
+function findMatchingNativeTransfer(args: {
+  amount: bigint;
+  feePayerAddress: string;
+  instructions: readonly Instruction[];
+  matchedInstructionIndexes: Set<number>;
+  recipient: string;
+}) {
+  const {
+    amount,
+    feePayerAddress,
+    instructions,
+    matchedInstructionIndexes,
+    recipient,
+  } = args;
+  const expectedRecipient = address(recipient);
+
+  for (const [index, ix] of instructions.entries()) {
+    if (matchedInstructionIndexes.has(index)) continue;
+    if (!ix.data || !ix.accounts) continue;
+    if (ix.accounts.length !== 2) continue;
+    if (ix.programAddress !== SYSTEM_PROGRAM_ADDRESS) continue;
+
+    let transfer;
+    try {
+      transfer = parseTransferSolInstruction({
+        accounts: ix.accounts,
+        programAddress: ix.programAddress,
+        data: new Uint8Array(ix.data),
+      });
+    } catch {
+      continue;
+    }
+
+    if (transfer.data.discriminator !== TRANSFER_SOL_DISCRIMINATOR) {
+      continue;
+    }
+
+    if (transfer.data.amount !== amount) {
+      logger.debug("native transfer amount mismatch", {
+        expected: amount.toString(),
+        actual: transfer.data.amount.toString(),
+      });
+      continue;
+    }
+
+    if (transfer.accounts.destination.address !== expectedRecipient) {
+      logger.debug("native transfer destination mismatch", {
+        expected: expectedRecipient,
+        actual: transfer.accounts.destination.address,
+      });
+      continue;
+    }
+
+    if (transfer.accounts.source.address === feePayerAddress) {
+      return { error: "transfer source must not be the fee payer" };
+    }
+
+    matchedInstructionIndexes.add(index);
+    return { index, payer: transfer.accounts.source.address };
+  }
+
+  return { error: "no matching transferSol instruction found" };
 }
 
 export type VerifyChargeTransactionArgs = {
@@ -100,66 +576,108 @@ export async function verifyChargeTransaction(
     };
   }
 
-  const [expectedATA] = await findAssociatedTokenPda({
-    mint: address(request.currency),
-    owner: address(request.recipient),
+  const memoResult = verifyExpectedMemos(instructions, request);
+  if (memoResult) return memoResult;
+
+  const splitATAResult = await verifySplitATAInstructions({
+    feePayerAddress,
+    instructions,
+    request,
+    tokenProgram,
+    transactionFeePayer: transactionMessage.feePayer.address,
+  });
+  if ("error" in splitATAResult) return splitATAResult;
+
+  const feePayerResult = verifyFeePayerNotUsedByInstructions(
+    instructions,
+    feePayerAddress,
+    (_instruction, _account, accountIndex, instructionIndex) => {
+      return (
+        splitATAResult.allowedFeePayerAccountIndexesByInstructionIndex
+          .get(instructionIndex)
+          ?.has(accountIndex) === true
+      );
+    },
+  );
+  if (feePayerResult) return feePayerResult;
+
+  const primaryAmount = getPrimaryAmountResult(request);
+  if ("error" in primaryAmount) return primaryAmount;
+
+  const feePayerTokenAccount =
+    feePayerAddress !== ""
+      ? (
+          await findAssociatedTokenPda({
+            mint: address(request.currency),
+            owner: address(feePayerAddress),
+            tokenProgram,
+          })
+        )[0]
+      : undefined;
+
+  const matchedInstructionIndexes = new Set<number>();
+  const primaryTransfer = await findMatchingTokenTransfer({
+    amount: primaryAmount.amount,
+    instructions,
+    matchedInstructionIndexes,
+    md,
+    recipient: request.recipient,
+    request,
     tokenProgram,
   });
+  if ("error" in primaryTransfer) return primaryTransfer;
 
-  for (const ix of instructions) {
-    if (!ix.data || !ix.accounts) continue;
-
-    let transfer;
-    try {
-      transfer = parseTransferCheckedInstruction({
-        accounts: ix.accounts,
-        programAddress: ix.programAddress,
-        data: new Uint8Array(ix.data),
-      });
-    } catch {
-      continue;
-    }
-
-    if (transfer.data.amount !== BigInt(request.amount)) {
-      logger.debug("transfer amount mismatch", {
-        expected: request.amount,
-        actual: transfer.data.amount.toString(),
-      });
-      continue;
-    }
-
-    if (transfer.accounts.mint.address !== request.currency) {
-      logger.debug("transfer mint mismatch", {
-        expected: request.currency,
-        actual: transfer.accounts.mint.address,
-      });
-      continue;
-    }
-
-    if (md?.decimals !== undefined && transfer.data.decimals !== md.decimals) {
-      logger.debug("transfer decimals mismatch", {
-        expected: md.decimals,
-        actual: transfer.data.decimals,
-      });
-      continue;
-    }
-
-    if (transfer.accounts.destination.address !== expectedATA) {
-      logger.debug("transfer destination mismatch", {
-        expected: expectedATA,
-        actual: transfer.accounts.destination.address,
-      });
-      continue;
-    }
-
-    if (transfer.accounts.authority.address === feePayerAddress) {
-      return { error: "transfer authority must not be the fee payer" };
-    }
-
-    return { payer: transfer.accounts.authority.address };
+  if (primaryTransfer.payer === feePayerAddress) {
+    return { error: "transfer authority must not be the fee payer" };
+  }
+  if (primaryTransfer.source === feePayerTokenAccount) {
+    return { error: "transfer source must not be the fee payer" };
   }
 
-  return { error: "no matching transferChecked instruction found" };
+  for (const split of getChargeSplits(request)) {
+    const splitTransfer = await findMatchingTokenTransfer({
+      amount: BigInt(split.amount),
+      instructions,
+      matchedInstructionIndexes,
+      md,
+      recipient: split.recipient,
+      request,
+      tokenProgram,
+    });
+    if ("error" in splitTransfer) return splitTransfer;
+    if (splitTransfer.payer === feePayerAddress) {
+      return { error: "transfer authority must not be the fee payer" };
+    }
+    if (splitTransfer.source === feePayerTokenAccount) {
+      return { error: "transfer source must not be the fee payer" };
+    }
+    if (splitTransfer.payer !== primaryTransfer.payer) {
+      return { error: "split transfer payer must match primary payer" };
+    }
+    if (split.ataCreationRequired === true) {
+      const creationIndexes = splitATAResult.creationIndexesByOwner.get(
+        address(split.recipient),
+      );
+      if (!creationIndexes?.some((index) => index < splitTransfer.index)) {
+        return {
+          error:
+            "required ATA creation instruction must precede split transfer",
+        };
+      }
+    }
+  }
+
+  const allowedInstructionIndexes = new Set<number>([
+    ...matchedInstructionIndexes,
+    ...splitATAResult.instructionIndexes,
+  ]);
+  const unexpectedInstructionResult = verifyNoUnexpectedInstructions({
+    allowedInstructionIndexes,
+    instructions,
+  });
+  if (unexpectedInstructionResult) return unexpectedInstructionResult;
+
+  return { payer: primaryTransfer.payer };
 }
 
 export type VerifyNativeChargeTransactionArgs = {
@@ -194,44 +712,92 @@ export async function verifyNativeChargeTransaction(
     };
   }
 
-  const expectedRecipient = address(request.recipient);
+  const memoResult = verifyExpectedMemos(instructions, request);
+  if (memoResult) return memoResult;
 
-  for (const ix of instructions) {
-    if (!ix.data || !ix.accounts) continue;
-
-    let transfer;
-    try {
-      transfer = parseTransferSolInstruction({
-        accounts: ix.accounts,
-        programAddress: ix.programAddress,
-        data: new Uint8Array(ix.data),
-      });
-    } catch {
-      continue;
-    }
-
-    if (transfer.data.amount !== BigInt(request.amount)) {
-      logger.debug("native transfer amount mismatch", {
-        expected: request.amount,
-        actual: transfer.data.amount.toString(),
-      });
-      continue;
-    }
-
-    if (transfer.accounts.destination.address !== expectedRecipient) {
-      logger.debug("native transfer destination mismatch", {
-        expected: expectedRecipient,
-        actual: transfer.accounts.destination.address,
-      });
-      continue;
-    }
-
-    if (transfer.accounts.source.address === feePayerAddress) {
-      return { error: "transfer source must not be the fee payer" };
-    }
-
-    return { payer: transfer.accounts.source.address };
+  if (chargeHasATACreationSplits(request)) {
+    return { error: "ataCreationRequired requires an SPL token charge" };
   }
 
-  return { error: "no matching transferSol instruction found" };
+  const primaryAmount = getPrimaryAmountResult(request);
+  if ("error" in primaryAmount) return primaryAmount;
+
+  const expectedTransfers = [
+    { amount: primaryAmount.amount, recipient: request.recipient },
+    ...getChargeSplits(request).map((split) => ({
+      amount: BigInt(split.amount),
+      recipient: split.recipient,
+    })),
+  ];
+
+  const feePayerResult = verifyFeePayerNotUsedByInstructions(
+    instructions,
+    feePayerAddress,
+    (ix, _account, index) => {
+      // account index 1 is the transferSol destination: the fee payer may
+      // receive a payout here, but must never be a transfer source.
+      if (
+        index !== 1 ||
+        !ix.data ||
+        !ix.accounts ||
+        ix.accounts.length !== 2 ||
+        ix.programAddress !== SYSTEM_PROGRAM_ADDRESS
+      ) {
+        return false;
+      }
+
+      try {
+        const transfer = parseTransferSolInstruction({
+          accounts: ix.accounts,
+          programAddress: ix.programAddress,
+          data: new Uint8Array(ix.data),
+        });
+        return (
+          transfer.data.discriminator === TRANSFER_SOL_DISCRIMINATOR &&
+          transfer.accounts.source.address !== feePayerAddress &&
+          expectedTransfers.some(
+            (expectedTransfer) =>
+              transfer.accounts.destination.address ===
+                address(expectedTransfer.recipient) &&
+              transfer.data.amount === expectedTransfer.amount,
+          )
+        );
+      } catch {
+        return false;
+      }
+    },
+  );
+  if (feePayerResult) return feePayerResult;
+
+  const matchedInstructionIndexes = new Set<number>();
+  const primaryTransfer = findMatchingNativeTransfer({
+    amount: primaryAmount.amount,
+    feePayerAddress,
+    instructions,
+    matchedInstructionIndexes,
+    recipient: request.recipient,
+  });
+  if ("error" in primaryTransfer) return primaryTransfer;
+
+  for (const split of getChargeSplits(request)) {
+    const splitTransfer = findMatchingNativeTransfer({
+      amount: BigInt(split.amount),
+      feePayerAddress,
+      instructions,
+      matchedInstructionIndexes,
+      recipient: split.recipient,
+    });
+    if ("error" in splitTransfer) return splitTransfer;
+    if (splitTransfer.payer !== primaryTransfer.payer) {
+      return { error: "split transfer payer must match primary payer" };
+    }
+  }
+
+  const unexpectedInstructionResult = verifyNoUnexpectedInstructions({
+    allowedInstructionIndexes: matchedInstructionIndexes,
+    instructions,
+  });
+  if (unexpectedInstructionResult) return unexpectedInstructionResult;
+
+  return { payer: primaryTransfer.payer };
 }

--- a/packages/test-harness/src/scheme/mpp.ts
+++ b/packages/test-harness/src/scheme/mpp.ts
@@ -115,6 +115,7 @@ export function createTestMPPHandler(
       return {
         status: "success" as const,
         method,
+        challengeId: credential.challenge.id,
         timestamp: new Date().toISOString(),
         reference: `test-tx-${Date.now()}`,
       };
@@ -134,6 +135,7 @@ export function createTestMPPHandler(
       return {
         status: "success" as const,
         method,
+        challengeId: credential.challenge.id,
         timestamp: new Date().toISOString(),
         reference: `test-verify-${Date.now()}`,
       };

--- a/packages/test-harness/src/scheme/mpp.ts
+++ b/packages/test-harness/src/scheme/mpp.ts
@@ -44,6 +44,25 @@ async function generateTestChallengeID(
   return encodeBase64URL(String.fromCharCode(...new Uint8Array(sig)));
 }
 
+function credentialMatchesPricing(
+  credential: mppCredential,
+  pricing: ResourcePricing,
+): boolean {
+  let requestBody: unknown;
+  try {
+    requestBody = JSON.parse(decodeBase64URL(credential.challenge.request));
+  } catch {
+    return false;
+  }
+
+  if (typeof requestBody !== "object" || requestBody === null) return false;
+  return (
+    Reflect.get(requestBody, "amount") === pricing.amount &&
+    Reflect.get(requestBody, "currency") === pricing.asset &&
+    Reflect.get(requestBody, "recipient") === pricing.recipient
+  );
+}
+
 export type CreateTestMPPHandlerOpts = {
   method?: string;
   realm?: string;
@@ -65,6 +84,7 @@ export function createTestMPPHandler(
   const realm = opts.realm ?? TEST_MPP_REALM;
   const intents = opts.intents ?? [TEST_MPP_INTENT];
   const challengeStore = new Map<string, boolean>();
+  const verifiedChallenges = new Set<string>();
 
   const supportsVerify = opts.supportsVerify ?? false;
 
@@ -102,7 +122,7 @@ export function createTestMPPHandler(
 
       return { id, ...paramsWithoutID };
     },
-    handleSettle: async (credential) => {
+    handleSettle: async (credential, context) => {
       opts.onSettle?.(credential);
 
       if (credential.challenge.method !== method) return null;
@@ -110,7 +130,14 @@ export function createTestMPPHandler(
       if (!challengeStore.has(credential.challenge.id)) {
         throw new Error("unknown or consumed challenge ID");
       }
+      if (
+        !credentialMatchesPricing(credential, context.pricing) &&
+        !verifiedChallenges.has(credential.challenge.id)
+      ) {
+        return null;
+      }
       challengeStore.delete(credential.challenge.id);
+      verifiedChallenges.delete(credential.challenge.id);
 
       return {
         status: "success" as const,
@@ -123,7 +150,7 @@ export function createTestMPPHandler(
   };
 
   if (supportsVerify) {
-    handler.handleVerify = async (credential) => {
+    handler.handleVerify = async (credential, context) => {
       opts.onVerify?.(credential);
 
       if (credential.challenge.method !== method) return null;
@@ -131,6 +158,8 @@ export function createTestMPPHandler(
       if (!challengeStore.has(credential.challenge.id)) {
         throw new Error("unknown challenge ID");
       }
+      if (!credentialMatchesPricing(credential, context.pricing)) return null;
+      verifiedChallenges.add(credential.challenge.id);
 
       return {
         status: "success" as const,

--- a/packages/types/src/mpp/encoding.test.ts
+++ b/packages/types/src/mpp/encoding.test.ts
@@ -1,0 +1,40 @@
+#!/usr/bin/env pnpm tsx
+
+import t from "tap";
+
+import { formatMPPDateTime, parseMPPExpiresAtMs } from "./encoding";
+
+await t.test("formatMPPDateTime emits second-precision RFC3339", (t) => {
+  t.equal(
+    formatMPPDateTime(new Date("2026-06-01T12:34:56.789Z")),
+    "2026-06-01T12:34:56Z",
+  );
+  t.end();
+});
+
+await t.test("parseMPPExpiresAtMs accepts RFC3339 timestamps", (t) => {
+  const expected = Date.UTC(2026, 5, 1, 12, 34, 56);
+
+  t.equal(parseMPPExpiresAtMs("2026-06-01T12:34:56Z"), expected);
+  t.equal(parseMPPExpiresAtMs("2026-06-01T12:34:56.789Z"), expected + 789);
+  t.equal(parseMPPExpiresAtMs("2026-06-01T14:34:56+02:00"), expected);
+  t.end();
+});
+
+await t.test("parseMPPExpiresAtMs accepts legacy unix seconds", (t) => {
+  t.equal(parseMPPExpiresAtMs("4102444800"), 4_102_444_800_000);
+  t.end();
+});
+
+await t.test("parseMPPExpiresAtMs rejects malformed timestamps", (t) => {
+  for (const expires of [
+    "",
+    "not-a-date",
+    "2026-06-01",
+    "-1",
+    "999999999999999999999999999999",
+  ]) {
+    t.equal(parseMPPExpiresAtMs(expires), null, expires);
+  }
+  t.end();
+});

--- a/packages/types/src/mpp/encoding.ts
+++ b/packages/types/src/mpp/encoding.ts
@@ -29,6 +29,37 @@ export function decodeBase64URL(encoded: string): string {
   return new TextDecoder().decode(bytes);
 }
 
+const NUMERIC_UNIX_SECONDS_RE = /^[0-9]+$/;
+const RFC3339_TIMESTAMP_RE =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/;
+
+export function formatMPPDateTime(date: Date): string {
+  return date.toISOString().replace(/\.\d{3}Z$/, "Z");
+}
+
+export function parseMPPExpiresAtMs(expires: string): number | null {
+  if (NUMERIC_UNIX_SECONDS_RE.test(expires)) {
+    const seconds = Number(expires);
+    if (
+      !Number.isSafeInteger(seconds) ||
+      seconds > Math.floor(Number.MAX_SAFE_INTEGER / 1000)
+    ) {
+      return null;
+    }
+    return seconds * 1000;
+  }
+
+  if (!RFC3339_TIMESTAMP_RE.test(expires)) {
+    return null;
+  }
+
+  const expiresAtMs = Date.parse(expires);
+  if (!Number.isFinite(expiresAtMs)) {
+    return null;
+  }
+  return expiresAtMs;
+}
+
 /**
  * Sorted-key JSON canonicalization following RFC 8785 JCS for the
  * subset of inputs used by MPP (string keys, no integer-indexed

--- a/packages/types/src/mpp/handler.test.ts
+++ b/packages/types/src/mpp/handler.test.ts
@@ -3,7 +3,17 @@
 import t from "tap";
 import type { MPPMethodHandler } from "./handler";
 import { settleMPPPayment, verifyMPPPayment } from "./handler";
+import type { ResourcePricing } from "../pricing";
 import type { mppCredential, mppReceipt } from "./types";
+
+const TEST_RESOURCE_URL = "https://example.test/resource";
+const TEST_PRICING_ENTRY: ResourcePricing = {
+  amount: "100",
+  asset: "USD",
+  recipient: "recipient-1",
+  network: "testnet",
+};
+const TEST_PRICING: ResourcePricing[] = [TEST_PRICING_ENTRY];
 
 function makeCredential(method: string): mppCredential {
   return {
@@ -59,7 +69,12 @@ await t.test("settleMPPPayment", async (t) => {
   await t.test("routes to matching handler and returns receipt", async (t) => {
     const receipt = makeReceipt("solana", "tx-1");
     const handler = makeHandler("solana", { settleResult: receipt });
-    const result = await settleMPPPayment([handler], makeCredential("solana"));
+    const result = await settleMPPPayment(
+      [handler],
+      makeCredential("solana"),
+      TEST_PRICING,
+      TEST_RESOURCE_URL,
+    );
     t.matchOnly(result, receipt);
     t.end();
   });
@@ -70,9 +85,17 @@ await t.test("settleMPPPayment", async (t) => {
       const handler = makeHandler("ethereum", {
         settleResult: makeReceipt("ethereum", "tx-1"),
       });
-      await t.rejects(settleMPPPayment([handler], makeCredential("solana")), {
-        message: 'no MPP handler accepted settlement for method "solana"',
-      });
+      await t.rejects(
+        settleMPPPayment(
+          [handler],
+          makeCredential("solana"),
+          TEST_PRICING,
+          TEST_RESOURCE_URL,
+        ),
+        {
+          message: 'no MPP handler accepted settlement for method "solana"',
+        },
+      );
       t.end();
     },
   );
@@ -80,16 +103,32 @@ await t.test("settleMPPPayment", async (t) => {
   await t.test("throws when all matching handlers return null", async (t) => {
     const h1 = makeHandler("solana", { settleResult: null });
     const h2 = makeHandler("solana", { settleResult: null });
-    await t.rejects(settleMPPPayment([h1, h2], makeCredential("solana")), {
-      message: 'no MPP handler accepted settlement for method "solana"',
-    });
+    await t.rejects(
+      settleMPPPayment(
+        [h1, h2],
+        makeCredential("solana"),
+        TEST_PRICING,
+        TEST_RESOURCE_URL,
+      ),
+      {
+        message: 'no MPP handler accepted settlement for method "solana"',
+      },
+    );
     t.end();
   });
 
   await t.test("throws when handler list is empty", async (t) => {
-    await t.rejects(settleMPPPayment([], makeCredential("solana")), {
-      message: 'no MPP handler accepted settlement for method "solana"',
-    });
+    await t.rejects(
+      settleMPPPayment(
+        [],
+        makeCredential("solana"),
+        TEST_PRICING,
+        TEST_RESOURCE_URL,
+      ),
+      {
+        message: 'no MPP handler accepted settlement for method "solana"',
+      },
+    );
     t.end();
   });
 
@@ -99,11 +138,42 @@ await t.test("settleMPPPayment", async (t) => {
       const expected = makeReceipt("solana", "tx-second");
       const h1 = makeHandler("solana", { settleResult: null });
       const h2 = makeHandler("solana", { settleResult: expected });
-      const result = await settleMPPPayment([h1, h2], makeCredential("solana"));
+      const result = await settleMPPPayment(
+        [h1, h2],
+        makeCredential("solana"),
+        TEST_PRICING,
+        TEST_RESOURCE_URL,
+      );
       t.matchOnly(result, expected);
       t.end();
     },
   );
+
+  await t.test("passes matched pricing context to handler", async (t) => {
+    const receipt = makeReceipt("solana", "tx-1");
+    let receivedPricing: ResourcePricing | undefined;
+    let receivedResourceURL: string | undefined;
+    const handler: MPPMethodHandler = {
+      ...makeHandler("solana"),
+      handleSettle: async (_credential, context) => {
+        receivedPricing = context.pricing;
+        receivedResourceURL = context.resourceURL;
+        return receipt;
+      },
+    };
+
+    const result = await settleMPPPayment(
+      [handler],
+      makeCredential("solana"),
+      TEST_PRICING,
+      TEST_RESOURCE_URL,
+    );
+
+    t.matchOnly(result, receipt);
+    t.matchOnly(receivedPricing, TEST_PRICING_ENTRY);
+    t.equal(receivedResourceURL, TEST_RESOURCE_URL);
+    t.end();
+  });
 
   t.end();
 });
@@ -112,7 +182,12 @@ await t.test("verifyMPPPayment", async (t) => {
   await t.test("routes to matching handler and returns receipt", async (t) => {
     const receipt = makeReceipt("solana", "verify-1");
     const handler = makeHandler("solana", { verifyResult: receipt });
-    const result = await verifyMPPPayment([handler], makeCredential("solana"));
+    const result = await verifyMPPPayment(
+      [handler],
+      makeCredential("solana"),
+      TEST_PRICING,
+      TEST_RESOURCE_URL,
+    );
     t.matchOnly(result, receipt);
     t.end();
   });
@@ -121,9 +196,17 @@ await t.test("verifyMPPPayment", async (t) => {
     "throws when no handler supports verification for the method",
     async (t) => {
       const handler = makeHandler("solana", { hasVerify: false });
-      await t.rejects(verifyMPPPayment([handler], makeCredential("solana")), {
-        message: 'no MPP handler supports verification for method "solana"',
-      });
+      await t.rejects(
+        verifyMPPPayment(
+          [handler],
+          makeCredential("solana"),
+          TEST_PRICING,
+          TEST_RESOURCE_URL,
+        ),
+        {
+          message: 'no MPP handler supports verification for method "solana"',
+        },
+      );
       t.end();
     },
   );
@@ -134,9 +217,17 @@ await t.test("verifyMPPPayment", async (t) => {
       const handler = makeHandler("ethereum", {
         verifyResult: makeReceipt("ethereum", "verify-1"),
       });
-      await t.rejects(verifyMPPPayment([handler], makeCredential("solana")), {
-        message: 'no MPP handler supports verification for method "solana"',
-      });
+      await t.rejects(
+        verifyMPPPayment(
+          [handler],
+          makeCredential("solana"),
+          TEST_PRICING,
+          TEST_RESOURCE_URL,
+        ),
+        {
+          message: 'no MPP handler supports verification for method "solana"',
+        },
+      );
       t.end();
     },
   );
@@ -146,17 +237,33 @@ await t.test("verifyMPPPayment", async (t) => {
     async (t) => {
       const h1 = makeHandler("solana", { verifyResult: null });
       const h2 = makeHandler("solana", { verifyResult: null });
-      await t.rejects(verifyMPPPayment([h1, h2], makeCredential("solana")), {
-        message: 'no MPP handler accepted verification for method "solana"',
-      });
+      await t.rejects(
+        verifyMPPPayment(
+          [h1, h2],
+          makeCredential("solana"),
+          TEST_PRICING,
+          TEST_RESOURCE_URL,
+        ),
+        {
+          message: 'no MPP handler accepted verification for method "solana"',
+        },
+      );
       t.end();
     },
   );
 
   await t.test("throws when handler list is empty", async (t) => {
-    await t.rejects(verifyMPPPayment([], makeCredential("solana")), {
-      message: 'no MPP handler supports verification for method "solana"',
-    });
+    await t.rejects(
+      verifyMPPPayment(
+        [],
+        makeCredential("solana"),
+        TEST_PRICING,
+        TEST_RESOURCE_URL,
+      ),
+      {
+        message: 'no MPP handler supports verification for method "solana"',
+      },
+    );
     t.end();
   });
 
@@ -170,6 +277,8 @@ await t.test("verifyMPPPayment", async (t) => {
       const result = await verifyMPPPayment(
         [noVerify, withVerify],
         makeCredential("solana"),
+        TEST_PRICING,
+        TEST_RESOURCE_URL,
       );
       t.equal(result.reference, "verify-2");
       t.end();
@@ -182,7 +291,12 @@ await t.test("verifyMPPPayment", async (t) => {
       const expected = makeReceipt("solana", "verify-second");
       const h1 = makeHandler("solana", { verifyResult: null });
       const h2 = makeHandler("solana", { verifyResult: expected });
-      const result = await verifyMPPPayment([h1, h2], makeCredential("solana"));
+      const result = await verifyMPPPayment(
+        [h1, h2],
+        makeCredential("solana"),
+        TEST_PRICING,
+        TEST_RESOURCE_URL,
+      );
       t.matchOnly(result, expected);
       t.end();
     },

--- a/packages/types/src/mpp/handler.test.ts
+++ b/packages/types/src/mpp/handler.test.ts
@@ -22,6 +22,7 @@ function makeReceipt(method: string, ref: string): mppReceipt {
   return {
     status: "success",
     method,
+    challengeId: "test-id",
     timestamp: new Date().toISOString(),
     reference: ref,
   };

--- a/packages/types/src/mpp/handler.ts
+++ b/packages/types/src/mpp/handler.ts
@@ -13,6 +13,11 @@ export type ChallengeOpts = {
   digest?: string;
 };
 
+export type MPPHandlerContext = {
+  pricing: ResourcePricing;
+  resourceURL: string;
+};
+
 export interface MPPMethodHandler {
   method: string;
   capabilities: HandlerCapabilities;
@@ -23,8 +28,14 @@ export interface MPPMethodHandler {
     resourceURL: string,
     opts?: ChallengeOpts,
   ): Promise<mppChallengeParams>;
-  handleSettle(credential: mppCredential): Promise<mppReceipt | null>;
-  handleVerify?(credential: mppCredential): Promise<mppReceipt | null>;
+  handleSettle(
+    credential: mppCredential,
+    context: MPPHandlerContext,
+  ): Promise<mppReceipt | null>;
+  handleVerify?(
+    credential: mppCredential,
+    context: MPPHandlerContext,
+  ): Promise<mppReceipt | null>;
 }
 
 /**
@@ -109,19 +120,26 @@ export async function resolveMPPChallenges(
  * Routes an MPP credential to the appropriate handler for settlement.
  *
  * Filters handlers by exact method match against the credential's
- * challenge method, then iterates handleSettle until one returns a
- * non-null result.
+ * challenge method, then iterates matching route pricing entries through
+ * handleSettle until one returns a non-null result.
  */
 export async function settleMPPPayment(
   handlers: MPPMethodHandler[],
   credential: mppCredential,
+  pricing: ResourcePricing[],
+  resourceURL: string,
 ): Promise<mppReceipt> {
   const method = credential.challenge.method;
   const candidates = handlers.filter((h) => h.method === method);
 
   for (const handler of candidates) {
-    const result = await handler.handleSettle(credential);
-    if (result) return result;
+    for (const p of matchPricingToCapabilities(handler.capabilities, pricing)) {
+      const result = await handler.handleSettle(credential, {
+        pricing: p,
+        resourceURL,
+      });
+      if (result) return result;
+    }
   }
 
   throw new Error(`no MPP handler accepted settlement for method "${method}"`);
@@ -131,11 +149,14 @@ export async function settleMPPPayment(
  * Routes an MPP credential to the appropriate handler for verification.
  *
  * Filters handlers by exact method match and presence of handleVerify,
- * then iterates until one returns a non-null result.
+ * then iterates matching route pricing entries until one returns a
+ * non-null result.
  */
 export async function verifyMPPPayment(
   handlers: MPPMethodHandler[],
   credential: mppCredential,
+  pricing: ResourcePricing[],
+  resourceURL: string,
 ): Promise<mppReceipt> {
   const method = credential.challenge.method;
   const candidates = handlers.filter(
@@ -153,8 +174,13 @@ export async function verifyMPPPayment(
   }
 
   for (const handler of candidates) {
-    const result = await handler.handleVerify(credential);
-    if (result) return result;
+    for (const p of matchPricingToCapabilities(handler.capabilities, pricing)) {
+      const result = await handler.handleVerify(credential, {
+        pricing: p,
+        resourceURL,
+      });
+      if (result) return result;
+    }
   }
 
   throw new Error(

--- a/packages/types/src/mpp/types.ts
+++ b/packages/types/src/mpp/types.ts
@@ -30,6 +30,7 @@ export type mppCredential = typeof mppCredential.infer;
 export const mppReceipt = type({
   status: "'success'|'failed'",
   method: "string",
+  challengeId: "string",
   timestamp: "string",
   reference: "string",
 });

--- a/tests/mpp/basic-flow.test.ts
+++ b/tests/mpp/basic-flow.test.ts
@@ -214,6 +214,89 @@ await t.test("MPP basic payment flow", async (t) => {
   );
 
   await t.test(
+    "credential for cheaper route is rejected without being consumed",
+    async (t) => {
+      const cheapPricing: ResourcePricing[] = [
+        {
+          amount: "100",
+          asset: TEST_ASSET,
+          recipient: "test-receiver",
+          network: TEST_NETWORK,
+        },
+      ];
+      const expensivePricing: ResourcePricing[] = [
+        {
+          amount: "10000",
+          asset: TEST_ASSET,
+          recipient: "test-receiver",
+          network: TEST_NETWORK,
+        },
+      ];
+      const methodHandler = createTestMPPHandler();
+
+      const cheapHarness = new TestHarness({
+        mppMethodHandlers: [methodHandler],
+        mppClientHandlers: [],
+        pricing: cheapPricing,
+        clientHandlers: [],
+        settleMode: "settle-only",
+      });
+      const expensiveHarness = new TestHarness({
+        mppMethodHandlers: [methodHandler],
+        mppClientHandlers: [],
+        pricing: expensivePricing,
+        clientHandlers: [],
+        settleMode: "settle-only",
+      });
+
+      const cheapClientFetch = cheapHarness.createClientFetch();
+      const challengeResponse = await cheapClientFetch("/cheap-resource");
+      t.equal(challengeResponse.status, 402);
+
+      const wwwAuth = challengeResponse.headers.get("WWW-Authenticate") ?? "";
+      const challenges = parseWWWAuthenticate(wwwAuth);
+      const challenge = challenges[0];
+      if (!challenge) {
+        t.fail("no challenge parsed");
+        t.end();
+        return;
+      }
+
+      const clientHandler = createTestMPPPaymentHandler();
+      const execer = await clientHandler(challenge);
+      if (!execer) {
+        t.fail("client handler should match the challenge");
+        t.end();
+        return;
+      }
+
+      const credential = await execer.exec();
+      const authHeader = `Payment ${serializeCredential(credential)}`;
+
+      const expensiveResponse = await expensiveHarness.createClientFetch()(
+        "/expensive-resource",
+        { headers: { Authorization: authHeader } },
+      );
+      t.equal(
+        expensiveResponse.status,
+        402,
+        "cheap credential should not settle expensive route",
+      );
+
+      const cheapResponse = await cheapClientFetch("/cheap-resource", {
+        headers: { Authorization: authHeader },
+      });
+      t.equal(
+        cheapResponse.status,
+        200,
+        "route mismatch must not consume the cheap credential",
+      );
+
+      t.end();
+    },
+  );
+
+  await t.test(
     "dual protocol: x402 and MPP coexist on same harness",
     async (t) => {
       const harness = new TestHarness({


### PR DESCRIPTION
## Summary

- Align MPP challenge handling with the payment auth flow, including RFC3339 expiry parsing, canonical request encoding, receipt serialization, and route-aware settlement context.
- Harden Solana charge settlement by validating charge requests and credential payloads, binding settlement to route pricing, rejecting replayed challenges/signatures, and re-verifying pulled transactions after confirmation.
- Expand Solana charge transaction support for split transfers, idempotent split ATA creation, memos, native SOL charges, fee-payer mode, Token-2022, and strict instruction allowlisting.
- Reject unsupported transaction shapes such as address lookup tables and tighten transaction verification around amounts, recipients, token program, decimals, memos, split totals, and fee-payer misuse.
- Add broad unit and integration coverage for MPP encoding, expiry behavior, middleware settlement, charge client construction, replay storage, server settlement, and transaction verification.