### PR TITLE
feat(info): add XDC Network (50) and XDC Apothem testnet (51)

### DIFF
--- a/packages/info/src/evm.ts
+++ b/packages/info/src/evm.ts
@@ -14,6 +14,8 @@ const knownX402Networks = {
   "eip155:10143": { legacyName: "monad-testnet", chainId: 10143 },
   "eip155:324705682": { legacyName: "skale-base-sepolia", chainId: 324705682 },
   "eip155:1187947933": { legacyName: "skale-base", chainId: 1187947933 },
+  "eip155:50": { legacyName: "xdc", chainId: 50 },
+  "eip155:51": { legacyName: "xdc-testnet", chainId: 51 },
 } as const;
 
 type KnownX402Networks = typeof knownX402Networks;


### PR DESCRIPTION
Adds `eip155:50` (xdc) and `eip155:51` (xdc-testnet) to `knownX402Networks` in `@faremeter/info`. The legacy-name and chain-ID maps derive automatically.

XDC is an EVM-compatible L1 (XDPoS) with native Circle USDC supporting EIP-3009 — works with the x402 exact scheme.