### PR TITLE
Make API reference cross-links root-absolute

### DIFF
--- a/bin/strip-link-extensions
+++ b/bin/strip-link-extensions
@@ -1,9 +1,11 @@
 #!/usr/bin/env node
 
 /**
- * Post-processes TypeDoc markdown output to strip .md extensions from
- * internal links. Mintlify expects extensionless paths for cross-page
- * references.
+ * Post-processes TypeDoc markdown output for Mintlify cross-page links:
+ * strips the .md extension and rewrites the path to be root-absolute
+ * under /api/. Mintlify resolves cross-page references from the site
+ * root, where the generated API reference is mounted at /api/; bare
+ * relative targets (TypeDoc's default) do not resolve.
  *
  * Only rewrites links whose target matches a generated file in the
  * output directory, so external URLs (e.g. GitHub source links) are
@@ -21,6 +23,9 @@ if (!docsDir) {
   process.exit(1);
 }
 
+// The generated API reference is mounted at /api/ on the docs site.
+const SITE_BASE = "/api";
+
 const mdFiles = readdirSync(docsDir).filter((f) => f.endsWith(".md"));
 const knownBases = new Set(mdFiles.map((f) => f.replace(/\.md$/, "")));
 
@@ -36,7 +41,7 @@ for (const file of mdFiles) {
   const updated = original.replace(linkRe, (match, target, anchor) => {
     if (!knownBases.has(target)) return match;
     totalRewrites++;
-    return `](${target}${anchor ?? ""})`;
+    return `](${SITE_BASE}/${target}${anchor ?? ""})`;
   });
 
   if (updated !== original) {
@@ -45,5 +50,5 @@ for (const file of mdFiles) {
 }
 
 console.log(
-  `Stripped .md from ${totalRewrites} internal links across ${mdFiles.length} files`,
+  `Rewrote ${totalRewrites} internal links to ${SITE_BASE}/ across ${mdFiles.length} files`,
 );


### PR DESCRIPTION
## Summary

- `bin/strip-link-extensions` rewrites generated API-reference cross-links to
  root-absolute `/api/` paths, on top of stripping the `.md` extension. Only
  links whose target is a generated page are rewritten, so external URLs
  (GitHub source links) stay untouched.

## Verification

- `make` builds the full tree clean (exit 0); `make doc` regenerates `docs/`
  with internal cross-links now `/api/`-prefixed (86 links across 46 files) and
  the per-page GitHub source links untouched.
- A synthetic TypeDoc-style fixture confirms page links, anchor links, and
  empty anchors are rewritten while external and non-generated `.md` links are
  left alone.

Refs FMTR-467